### PR TITLE
Fix for callback error.

### DIFF
--- a/lib/browsertime.js
+++ b/lib/browsertime.js
@@ -91,7 +91,7 @@ Browsertime.prototype._collectFromTheBrowser = function(options, iteration, tota
 
   return function(callback) {
     webdriver.promise.controlFlow().on('uncaughtException', function(e) {
-      callback(e);
+      log.error('Exception operating control flow: %s', util.inspect(e));
     });
 
     async.series([

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "fast-stats": "0.0.3",
     "getport": "0.1.0",
     "minimist": "1.2.0",
-    "selenium-webdriver": "^2.47.0",
+    "selenium-webdriver": "2.47.0",
     "valid-url": "1.0.9",
     "whereis": "0.4.0",
     "winston": "^1.0.2"


### PR DESCRIPTION
I did this while troubleshooting an issue (I commented here: https://github.com/sitespeedio/sitespeed.io/issues/745.)  (The issue ended up being browsermob proxy getting hung and not responding. That was due to the paltry resources I had used on an EC2 node.) 

With this change, I was able to get the underlying exception and continue my troubleshooting at the time.

Interested in feedback. Thanks for the look.
