### PR TITLE
Add user timing measures to stats

### DIFF
--- a/lib/statistics.js
+++ b/lib/statistics.js
@@ -25,14 +25,25 @@ exports.setupTimingsStatistics = function(timings, metric) {
 };
 
 exports.setupUserTimingsStatistics = function(timings, metric) {
-    if (metric.userTimings && metric.userTimings.marks) {
-        metric.userTimings.marks.forEach(function(mark) {
-            if (timings[mark.name]) {
-                timings[mark.name].push(mark.startTime);
-            } else {
-                timings[mark.name] = new Stats().push(mark.startTime);
-            }
-        });
+    if (metric.userTimings) {
+      if (metric.userTimings.marks) {
+          metric.userTimings.marks.forEach(function(mark) {
+              if (timings[mark.name]) {
+                  timings[mark.name].push(mark.startTime);
+              } else {
+                  timings[mark.name] = new Stats().push(mark.startTime);
+              }
+          });
+      }
+      if (metric.userTimings.measures) {
+          metric.userTimings.measures.forEach(function(measure) {
+              if (timings[measure.name]) {
+                  timings[measure.name].push(measure.duration);
+              } else {
+                  timings[measure.name] = new Stats().push(measure.duration);
+              }
+          });
+      }
     }
 };
 


### PR DESCRIPTION
This adds user timing measures to the stats, using the duration
property as the primary metric number (which differs from the marks.

The measure ability is useful over mark because you can do certain
calculations on multiple marks before creating a measure as well as
being able to measure how long specific parts of the process take.
I can't think of a reason why measures wouldn't be used.
