### PR TITLE
Add chrome-esque summary line to stdout.  Disable with double -q.

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -27,6 +27,11 @@ function parseUserScripts(scripts) {
     {});
 }
 
+// 1200 -> 1.2
+function fmt(msec, d=2) {
+  return (msec/1000).toFixed(d).replace(/.0+$/,'');
+}
+
 function run(url, options) {
   let dir = 'browsertime-results';
   if (!fs.existsSync(dir)) {
@@ -72,8 +77,32 @@ function run(url, options) {
         saveOperations.push(storageManager.writeData(`screenshot-${index}.png`, value)));
 
       return Promise.all(saveOperations)
-        .then(() => log.info('Wrote data to %s',
-          path.relative(process.cwd(), storageManager.directory)));
+        .then(() => {
+          log.info('Wrote data to %s', path.relative(process.cwd(), storageManager.directory));
+          return result;
+        });
+    })
+    .tap((result) => {
+      // don't bother if no statistics or silent x2
+      if (!result.statistics || options.silent > 1) return result;
+
+      var run = result.browserScripts[0].timings,
+        nRuns = result.browserScripts.length,
+        st = result.statistics.timings,
+        nav = st.navigationTiming,
+        domContentLoadedTime = nav.domContentLoadedEventStart.mean - nav.navigationStart.mean,
+        m = nRuns > 1,
+        lines = [
+          `${run.resourceTimings.length} requests`,
+          `DOMContentLoaded: ${fmt(domContentLoadedTime)}s` + (m ? ` (±${fmt(nav.domContentLoadedEventStart.mdev)})` : ''),
+          `Load: ${fmt(st.fullyLoaded.mean)}s` + (m ? ` (±${fmt(st.fullyLoaded.mdev)})` : ''),
+          `rumSpeedIndex: ${st.rumSpeedIndex.mean}` + (m ? ` (±${st.rumSpeedIndex.mdev})` : '')
+        ],
+        note = m ? ` (${nRuns} runs)` : '';
+
+      lines = lines.join(', ');
+      console.log(`${lines}${note}`);  // eslint-disable-line no-console
+      return result;
     })
     .catch(function(e) {
       log.error('Error running browsertime', e);

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -212,8 +212,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('silent', {
       alias: 'q',
-      type: 'boolean',
-      describe: 'Only output info in the logs, not to the console'
+      type: 'count',
+      describe: 'Only output info in the logs, not to the console. Enter twice to suppress summary line.'
     })
     .option('output', {
       alias: 'o',

--- a/lib/support/statistics.js
+++ b/lib/support/statistics.js
@@ -118,7 +118,8 @@ class Statistics {
       let stats = this.data[key];
       results[key] = {
         median: Number(stats.median().toFixed(decimals)),
-        mean: Number(stats.amean().toFixed(decimals))
+        mean: Number(stats.amean().toFixed(decimals)),
+        mdev : Number(stats.stddev() / Math.sqrt(stats.length)).toFixed(decimals) // "standard deviation of the mean"
       };
       percentiles.forEach(function(p) {
         let name = percentileName(p);
@@ -136,7 +137,8 @@ class Statistics {
     function summarize(stats) {
       const results = {
         median: Number(stats.median().toFixed(decimals)),
-        mean: Number(stats.amean().toFixed(decimals))
+        mean: Number(stats.amean().toFixed(decimals)),
+        mdev : Number(stats.stddev() / Math.sqrt(stats.length)).toFixed(decimals) // "standard deviation of the mean"
       };
       percentiles.forEach((p) => {
         let name = percentileName(p);


### PR DESCRIPTION
```shell
$ bin/browsertime.js http://sitespeed.io 
[2016-09-25 00:06:41] Running chrome for url: http://sitespeed.io
[2016-09-25 00:06:41] Testing url http://sitespeed.io run 1
[2016-09-25 00:06:47] Testing url http://sitespeed.io run 2
[2016-09-25 00:06:52] Testing url http://sitespeed.io run 3
[2016-09-25 00:06:57] Wrote data to browsertime-results/sitespeed.io/2016-09-25T000640-0700
12 requests, DOMContentLoaded: 0.82s (±0.15), Load: 1.16s (±0.16), rumSpeedIndex: 960 (±109) (3 runs)
```
where ± are the std-dev of the mean.  With `-q`:
```shell
$ bin/browsertime.js http://sitespeed.io  -q
12 requests, DOMContentLoaded: 0.76s (±0.16), Load: 1.06s (±0.18), rumSpeedIndex: 828 (±164) (3 runs)
```
To silence completely, use `-qq`.  Chrome's summary line from network tab:

<img width="478" alt="screen shot 2016-09-25 at 12 08 25 am" src="https://cloud.githubusercontent.com/assets/233047/18813602/63d08bbc-82b4-11e6-8256-46aae6e42c3f.png">