### PR TITLE
Output @moos command line metrics from the engine so we automatically…

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -27,23 +27,6 @@ function parseUserScripts(scripts) {
     {});
 }
 
-// 1200 -> 1.2
-function fmt(msec, d) {
-  d=d||2;
-  return (msec/1000).toFixed(d).replace(/.0+$/,'');
-}
-
-function formatMetric(name, metric, multiple) {
-    if (metric === undefined)
-        return null;
-
-    let formatted = `${name}: ${fmt(metric.mean)}s`;
-    if (multiple) {
-        formatted += ` (±${fmt(metric.mdev)})`;
-    }
-    return formatted;
-}
-
 function run(url, options) {
   let dir = 'browsertime-results';
   if (!fs.existsSync(dir)) {
@@ -93,28 +76,6 @@ function run(url, options) {
           log.info('Wrote data to %s', path.relative(process.cwd(), storageManager.directory));
           return result;
         });
-    })
-    .tap((result) => {
-      // don't bother if no statistics or silent x2
-      if (!result.statistics || !result.statistics.timings || !result.statistics.timings.pageTimings || options.silent > 1) return result;
-
-      let run = result.browserScripts[0].timings,
-        nRuns = result.browserScripts.length,
-        pt = result.statistics.timings.pageTimings,
-        t = result.statistics.timings,
-        m = nRuns > 1,
-        lines = [
-          `${run.resourceTimings.length} requests`,
-          formatMetric('firstPaint', t.firstPaint, m),
-          formatMetric('DOMContentLoaded', pt.domContentLoadedTime, m),
-          formatMetric('Load', pt.pageLoadTime, m),
-          formatMetric('rumSpeedIndex', t.rumSpeedIndex, m),
-        ],
-        note = m ? ` (${nRuns} runs)` : '';
-
-      lines = lines.filter(Boolean).join(', ');
-      log.info(`${lines}${note}`);
-      return result;
     })
     .catch(function(e) {
       log.error('Error running browsertime', e);

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -276,6 +276,27 @@ class Engine {
             statistics.addDeep({visualMetrics: data}));
           result.statistics = statistics.summarizeDeep(options);
         }
+      }).tap((result) => {
+        // don't bother if no statistics or silent x2
+        if (!result.statistics || !result.statistics.timings || !result.statistics.timings.pageTimings || options.silent > 1) return result;
+
+        let run = result.browserScripts[0].timings,
+          nRuns = result.browserScripts.length,
+          pt = result.statistics.timings.pageTimings,
+          t = result.statistics.timings,
+          m = nRuns > 1,
+          lines = [
+            `${run.resourceTimings.length} requests`,
+            util.formatMetric('firstPaint', t.firstPaint, m),
+            util.formatMetric('DOMContentLoaded', pt.domContentLoadedTime, m),
+            util.formatMetric('Load', pt.pageLoadTime, m),
+            util.formatMetric('rumSpeedIndex', t.rumSpeedIndex, m),
+          ],
+          note = m ? ` (${nRuns} runs)` : '';
+
+        lines = lines.filter(Boolean).join(', ');
+        log.info(`${lines}${note}`);
+        return result;
       })
       .catch(Promise.TimeoutError, (e) => {
         throw new UrlLoadError('Failed to load ' + url + ', cause: ' + e.message, url, {

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -21,5 +21,19 @@ module.exports = {
       return o.length === 0;
 
     return false;
+  },
+  formatMetric(name, metric, multiple) {
+      if (metric === undefined)
+          return null;
+      // 1200 -> 1.2
+      function fmt(msec) {
+          return (msec / 1000).toFixed(2).replace(/.0+$/, '');
+      }
+
+      let formatted = `${name}: ${fmt(metric.mean)}s`;
+      if (multiple) {
+          formatted += ` (±${fmt(metric.mdev)})`;
+      }
+      return formatted;
   }
 };


### PR DESCRIPTION
… will have it in sitespeed.io. Only drawback I see is that now when you run the CLI, you will get the metrics as second last log line:

<pre>
[2016-09-27 20:23:41] 12 requests, firstPaint: 0.18s (±0.04), DOMContentLoaded: 0.13s (±0.04), Load: 0.24s (±0.03), rumSpeedIndex: 0.18s (±0.04) (2 runs)
[2016-09-27 20:23:41] Wrote data to browsertime-results/www.sitespeed.io/2016-09-27T202335+0200
</pre>