### PR TITLE
Expose cli module and added getOptions() method to get cli options

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@ const Engine = require('./lib/core/engine'),
   SeleniumRunner = require('./lib/core/seleniumRunner'),
   errors = require('./lib/support/errors'),
   browserScripts = require('./lib/support/browserScript'),
-  logging = require('./lib/support/logging');
+  logging = require('./lib/support/logging'),
+  cli = require('./lib/support/cli');
 
 module.exports = {
-  Engine, SeleniumRunner, errors, logging, browserScripts
+  Engine, SeleniumRunner, errors, logging, browserScripts, cli
 };

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -48,194 +48,212 @@ function validateInput(argv) {
   return true;
 }
 
-module.exports.parseCommandLine = function parseCommandLine() {
+function getOptions(opt) {
+  var options = {
+    'timeouts.browserStart': {
+      default: 60000,
+      type: 'number',
+      describe: 'Timeout when waiting for browser to start, in milliseconds',
+      group: 'timeouts'
+    },
+    'timeouts.pageLoad': {
+      default: 300000,
+      type: 'number',
+      describe: 'Timeout when waiting for url to load, in milliseconds',
+      group: 'timeouts'
+    },
+    'timeouts.script': {
+      default: 80000,
+      type: 'number',
+      describe: 'Timeout when running browser scripts, in milliseconds',
+      group: 'timeouts'
+    },
+    'timeouts.pageCompleteCheck': {
+      default: 300000,
+      type: 'number',
+      describe: 'Timeout when waiting for page to complete loading, in milliseconds',
+      group: 'timeouts'
+    },
+    'chrome.args': {
+      describe: 'Extra command line args to pass to the chrome process (e.g. ––no-sandbox)', // note ndash '–' to prevent prefix
+      group: 'chrome'
+    },
+    'chrome.binaryPath': {
+      describe: 'Path to custom Chrome binary (e.g. Chrome Canary). ' +
+      'On OS X, the path should be to the binary inside the app bundle, ' +
+      'e.g. /Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary',
+      group: 'chrome'
+    },
+    'chrome.mobileEmulation.deviceName': {
+      describe: 'Name of device to emulate. Works only standalone (see list in Chrome DevTools, but add company like \'Apple iPhone 6\')',
+      group: 'chrome'
+    },
+    'chrome.mobileEmulation.width': {
+      type: 'number',
+      describe: 'Width in pixels of emulated mobile screen (e.g. 360)',
+      group: 'chrome'
+    },
+    'chrome.mobileEmulation.height': {
+      type: 'number',
+      describe: 'Height in pixels of emulated mobile screen (e.g. 640)',
+      group: 'chrome'
+    },
+    'chrome.mobileEmulation.pixelRatio': {
+      describe: 'Pixel ratio of emulated mobile screen (e.g. 2.0)',
+      group: 'chrome'
+    },
+    'chrome.android.package': {
+      describe: 'Run Chrome on your Android device. Set to com.android.chrome for default Chrome version.',
+      group: 'chrome'
+    },
+    'chrome.android.deviceSerial': {
+      describe: 'Choose which device to use. If you do not set it, random device will be used.',
+      group: 'chrome'
+    },
+    'firefox.binaryPath': {
+      describe: 'Path to custom Firefox binary (e.g. Firefox Nightly). ' +
+      'On OS X, the path should be to the binary inside the app bundle, ' +
+      'e.g. /Applications/Firefox.app/Contents/MacOS/firefox-bin',
+      group: 'firefox'
+    },
+    'selenium.url': {
+      describe: 'URL to a running Selenium server (e.g. to run a browser on another machine).',
+      group: 'selenium'
+    },
+    'experimental.dumpChromePerflog': {
+      describe: 'Dump Chromes performance log with Network.* events to disk.',
+      group: 'experimental'
+    },
+    'experimental.video': {
+      describe: 'Record a video and collect SpeedIndex. Needs FFMPEG & Python dependencies for VisualMetrics',
+      group: 'experimental'
+    },
+    'browser': {
+      alias: 'b',
+      default: 'chrome',
+      choices: ['chrome', 'firefox'],
+      describe: 'Specify browser'
+    },
+    'screenshot': {
+      type: 'boolean',
+      describe: 'Save one screen shot per iteration.'
+    },
+    'pageCompleteCheck': {
+      describe: 'Javascript snippet is repeatedly queried to see if page has completed loading ' +
+      '(indicated by the script returning true).'
+    },
+    'iterations': {
+      alias: 'n',
+      type: 'number',
+      default: 3,
+      describe: 'Number of times to test the url (restarting the browser between each test)'
+    },
+    'statistics': {
+      type: 'boolean',
+      default: true,
+      describe: 'Include statistics in JSON output'
+    },
+    'prettyPrint': {
+      type: 'boolean',
+      default: false,
+      describe: 'Enable to print json/har with spaces and indentation. Larger files, but easier on the eye.'
+    },
+    'delay': {
+      type: 'number',
+      default: 0,
+      describe: 'Delay between runs, in milliseconds'
+    },
+    'connectivity.profile': {
+      alias: 'c',
+      default: 'native',
+      choices: ['3g', '3gfast', '3gslow', '2g', 'cable', 'native', 'custom'],
+      describe: 'The connectivity profile. Default connectivity engine is tsproxy',
+      group: 'connectivity'
+    },
+    'connectivity.config': {
+      default: undefined,
+      describe: 'This option requires --connectivity.profile be set to "custom". Takes a JSON object with the keys downstreamKbps, upstreamKbps and latency. \"{\\\"downstreamKbps\\\":6000, \\\"upstreamKbps\\\": 6000, \\\"latency\\\": 200}\"',
+      group: 'connectivity'
+    },
+    'connectivity.tsproxy.port': {
+      default: 1080,
+      describe: 'The port used for ts proxy',
+      group: 'connectivity'
+    },
+    'connectivity.tc.device': {
+      default: 'eth0',
+      describe: 'The connectivity device. Used for engine tc.',
+      group: 'connectivity'
+    },
+    'connectivity.engine': {
+      default: 'tsproxy',
+      choices: ['tc', 'tsproxy'],
+      describe: 'The engine for connectivity. Tsproxy needs Python 2.7. TC needs tc, modprobe and ip installed to work. Running tc inside Docker needs modprobe to run outside the container.',
+      group: 'connectivity'
+    },
+    'preScript': {
+      describe: 'Task(s) to run before you test your URL (use it for login etc). Note that --preScript can be passed multiple times.'
+    },
+    'postScript': {
+      describe: 'Task(s) to run after you test your URL (use it for logout etc). Note that --postScript can be passed multiple times.'
+    },
+    'script': {
+      describe: 'Add custom Javascript to run on page. If a single js file is specified, ' +
+      'it will be included in the category named "custom" in the output json. Pass a folder to include all .js scripts ' +
+      'in the folder, and have the folder name be the category. Note that --script can be passed multiple times.'
+    },
+    'userAgent': {
+      describe: 'Override user agent'
+    },
+    'silent': {
+      alias: 'q',
+      type: 'count',
+      describe: 'Only output info in the logs, not to the console. Enter twice to suppress summary line.'
+    },
+    'output': {
+      alias: 'o',
+      describe: 'Specify file name for Browsertime data (ex: \'browsertime\'). Unless specified, file will be named browsertime.json'
+    },
+    'har': {
+      describe: 'Specify file name for .har file (ex: \'browsertime\'). Unless specified, file will be named browsertime.har'
+    },
+    'skipHar': {
+      type: 'boolean',
+      describe: 'Pass --skipHar to not collect a HAR file.'
+    },
+    'config': {
+      describe: 'Path to JSON config file',
+      config: 'config'
+    },
+    'viewPort': {
+      describe: 'Size of browser window WIDTHxHEIGHT'
+    },
+    'resultDir': {
+      describe: 'Set result directory for the files produced by Browsertime'
+    }
+  };
+
+  if (opt && opt.prefix) {
+    Object.keys(options).forEach(key => {
+      let val = options[key];
+      let describe = val.describe || val.description || val.desc;
+      if (describe) val.describe = describe.replace(/--(?=\w+)/g, t => t + opt.prefix);
+      if (opt.group && (val.group || opt.forceGroup)) val.group = opt.group;
+      options[opt.prefix + key] = val;
+      delete options[key];
+    });
+  }
+  return options;
+}
+
+function parseCommandLine() {
   let argv = yargs
     .usage('$0 [options] <url>')
     .require(1, 'url')
     .version(function() {
       return packageInfo.version;
     })
-    .option('timeouts.browserStart', {
-      default: 60000,
-      type: 'number',
-      describe: 'Timeout when waiting for browser to start, in milliseconds',
-      group: 'timeouts'
-    })
-    .option('timeouts.pageLoad', {
-      default: 300000,
-      type: 'number',
-      describe: 'Timeout when waiting for url to load, in milliseconds',
-      group: 'timeouts'
-    })
-    .option('timeouts.script', {
-      default: 80000,
-      type: 'number',
-      describe: 'Timeout when running browser scripts, in milliseconds',
-      group: 'timeouts'
-    })
-    .option('timeouts.pageCompleteCheck', {
-      default: 300000,
-      type: 'number',
-      describe: 'Timeout when waiting for page to complete loading, in milliseconds',
-      group: 'timeouts'
-    })
-    .option('chrome.args', {
-      describe: 'Extra command line args to pass to the chrome process (e.g. --no-sandbox)',
-      group: 'chrome'
-    })
-    .option('chrome.binaryPath', {
-      describe: 'Path to custom Chrome binary (e.g. Chrome Canary). ' +
-        'On OS X, the path should be to the binary inside the app bundle, ' +
-        'e.g. /Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary',
-      group: 'chrome'
-    })
-    .option('chrome.mobileEmulation.deviceName', {
-      describe: 'Name of device to emulate. Works only standalone (see list in Chrome DevTools, but add company like \'Apple iPhone 6\')',
-      group: 'chrome'
-    })
-    .option('chrome.mobileEmulation.width', {
-      type: 'number',
-      describe: 'Width in pixels of emulated mobile screen (e.g. 360)',
-      group: 'chrome'
-    })
-    .option('chrome.mobileEmulation.height', {
-      type: 'number',
-      describe: 'Height in pixels of emulated mobile screen (e.g. 640)',
-      group: 'chrome'
-    })
-    .option('chrome.mobileEmulation.pixelRatio', {
-      describe: 'Pixel ratio of emulated mobile screen (e.g. 2.0)',
-      group: 'chrome'
-    })
-    .option('chrome.android.package', {
-      describe: 'Run Chrome on your Android device. Set to com.android.chrome for default Chrome version.',
-      group: 'chrome'
-    })
-    .option('chrome.android.deviceSerial', {
-      describe: 'Choose which device to use. If you do not set it, random device will be used.',
-      group: 'chrome'
-    })
-    .option('firefox.binaryPath', {
-      describe: 'Path to custom Firefox binary (e.g. Firefox Nightly). ' +
-        'On OS X, the path should be to the binary inside the app bundle, ' +
-        'e.g. /Applications/Firefox.app/Contents/MacOS/firefox-bin',
-      group: 'firefox'
-    })
-    .option('selenium.url', {
-      describe: 'URL to a running Selenium server (e.g. to run a browser on another machine).',
-      group: 'selenium'
-    })
-    .option('experimental.dumpChromePerflog', {
-      describe: 'Dump Chromes performance log with Network.* events to disk.',
-      group: 'experimental'
-    })
-    .option('experimental.video', {
-      describe: 'Record a video and collect SpeedIndex. Needs FFMPEG & Python dependencies for VisualMetrics',
-      group: 'experimental'
-    })
-    .option('browser', {
-      alias: 'b',
-      default: 'chrome',
-      choices: ['chrome', 'firefox'],
-      describe: 'Specify browser'
-    })
-    .option('screenshot', {
-      type: 'boolean',
-      describe: 'Save one screen shot per iteration.'
-    })
-    .option('pageCompleteCheck', {
-      describe: 'Javascript snippet is repeatedly queried to see if page has completed loading ' +
-        '(indicated by the script returning true).'
-    })
-    .option('iterations', {
-      alias: 'n',
-      type: 'number',
-      default: 3,
-      describe: 'Number of times to test the url (restarting the browser between each test)'
-    })
-    .option('statistics', {
-      type: 'boolean',
-      default: true,
-      describe: 'Include statistics in JSON output'
-    })
-    .option('prettyPrint', {
-      type: 'boolean',
-      default: false,
-      describe: 'Enable to print json/har with spaces and indentation. Larger files, but easier on the eye.'
-    })
-    .option('delay', {
-      type: 'number',
-      default: 0,
-      describe: 'Delay between runs, in milliseconds'
-    })
-    .option('connectivity.profile', {
-      alias: 'c',
-      default: 'native',
-      choices: ['3g', '3gfast', '3gslow', '2g', 'cable', 'native', 'custom'],
-      describe: 'The connectivity profile. Default connectivity engine is tsproxy',
-      group: 'connectivity'
-    })
-    .option('connectivity.config', {
-      default: undefined,
-      describe: 'This option requires --connectivity.profile be set to "custom". Takes a JSON object with the keys downstreamKbps, upstreamKbps and latency. \"{\\\"downstreamKbps\\\":6000, \\\"upstreamKbps\\\": 6000, \\\"latency\\\": 200}\"',
-      group: 'connectivity'
-    })
-    .option('connectivity.tsproxy.port', {
-      default: 1080,
-      describe: 'The port used for ts proxy',
-      group: 'connectivity'
-    })
-    .option('connectivity.tc.device', {
-      default: 'eth0',
-      describe: 'The connectivity device. Used for engine tc.',
-      group: 'connectivity'
-    })
-    .option('connectivity.engine', {
-      default: 'tsproxy',
-      choices: ['tc','tsproxy'],
-      describe: 'The engine for connectivity. Tsproxy needs Python 2.7. TC needs tc, modprobe and ip installed to work. Running tc inside Docker needs modprobe to run outside the container.',
-      group: 'connectivity'
-    })
-    .option('preScript', {
-      describe: 'Task(s) to run before you test your URL (use it for login etc). Note that --preScript can be passed multiple times.'
-    })
-    .option('postScript', {
-      describe: 'Task(s) to run after you test your URL (use it for logout etc). Note that --postScript can be passed multiple times.'
-    })
-    .option('script', {
-      describe: 'Add custom Javascript to run on page. If a single js file is specified, ' +
-        'it will be included in the category named "custom" in the output json. Pass a folder to include all .js scripts ' +
-        'in the folder, and have the folder name be the category. Note that --script can be passed multiple times.'
-    })
-    .option('userAgent', {
-      describe: 'Override user agent'
-    })
-    .option('silent', {
-      alias: 'q',
-      type: 'count',
-      describe: 'Only output info in the logs, not to the console. Enter twice to suppress summary line.'
-    })
-    .option('output', {
-      alias: 'o',
-      describe: 'Specify file name for Browsertime data (ex: \'browsertime\'). Unless specified, file will be named browsertime.json'
-    })
-    .option('har', {
-      describe: 'Specify file name for .har file (ex: \'browsertime\'). Unless specified, file will be named browsertime.har'
-    })
-    .option('skipHar', {
-      type: 'boolean',
-      describe: 'Pass --skipHar to not collect a HAR file.'
-    })
-    .option('config', {
-      describe: 'Path to JSON config file',
-      config: 'config'
-    })
-    .option('viewPort', {
-      describe: 'Size of browser window WIDTHxHEIGHT'
-    })
-    .option('resultDir', {
-      describe: 'Set result directory for the files produced by Browsertime'
-    })
+    .options(getOptions())
     .count('verbose')
     .string('_')
     .help('h')
@@ -250,4 +268,9 @@ module.exports.parseCommandLine = function parseCommandLine() {
     'url': argv._[0],
     'options': argv
   };
+}
+
+module.exports = {
+  parseCommandLine: parseCommandLine,
+  getOptions: getOptions
 };

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -25,13 +25,13 @@ function validateInput(argv) {
      }
    }
 
-    if (argv.connectivity.profile !== 'custom' && argv.connectivity.config) {
-      return 'You must pass --connectivity.profile "custom" for custom connectivity configs to take effect.'
-    }
+   if (argv.connectivity.profile !== 'custom' && (argv.connectivity.upstreamKbps || argv.connectivity.downstreamKbps || argv.connectivity.latency)) {
+     return 'You must pass --connectivity.profile "custom" for custom connectivity configs to take effect.'
+   }
 
-    if (argv.connectivity.profile === 'custom' && !argv.connectivity.config) {
-      return 'You must pass a JSON config to --connectivity.config when using --connectivity.profile "custom".'
-    }
+   if (argv.connectivity.profile === 'custom' && (!argv.connectivity.upstreamKbps || !argv.connectivity.downstreamKbps || !argv.connectivity.latency)) {
+     return 'You must set downstreamKbps, upstreamKbps and latency when using --connectivity.profile "custom".'
+   }
 
    if (argv.connectivity.profile !== 'native' && argv.connectivity.engine === 'tc') {
      if (!hasbin.all.sync(['tc', 'modprobe', 'ip'])) {
@@ -153,11 +153,6 @@ function getOptions(opt) {
       default: true,
       describe: 'Include statistics in JSON output'
     },
-    'prettyPrint': {
-      type: 'boolean',
-      default: false,
-      describe: 'Enable to print json/har with spaces and indentation. Larger files, but easier on the eye.'
-    },
     'delay': {
       type: 'number',
       default: 0,
@@ -170,9 +165,19 @@ function getOptions(opt) {
       describe: 'The connectivity profile. Default connectivity engine is tsproxy',
       group: 'connectivity'
     },
-    'connectivity.config': {
+    'connectivity.downstreamKbps': {
       default: undefined,
-      describe: 'This option requires --connectivity.profile be set to "custom". Takes a JSON object with the keys downstreamKbps, upstreamKbps and latency. \"{\\\"downstreamKbps\\\":6000, \\\"upstreamKbps\\\": 6000, \\\"latency\\\": 200}\"',
+      describe: 'This option requires --connectivity.profile be set to "custom".',
+      group: 'connectivity'
+    },
+    'connectivity.upstreamKbps': {
+      default: undefined,
+      describe: 'This option requires --connectivity.profile be set to "custom".',
+      group: 'connectivity'
+    },
+    'connectivity.latency': {
+      default: undefined,
+      describe: 'This option requires --connectivity.profile be set to "custom".',
       group: 'connectivity'
     },
     'connectivity.tsproxy.port': {
@@ -205,6 +210,31 @@ function getOptions(opt) {
     'userAgent': {
       describe: 'Override user agent'
     },
+    'viewPort': {
+      describe: 'Size of browser window WIDTHxHEIGHT'
+    }
+  };
+
+  if (opt && opt.prefix) {
+    Object.keys(options).forEach(key => {
+      let val = options[key];
+      let describe = val.describe || val.description || val.desc;
+      if (describe) val.describe = describe.replace(/--(?=\w+)/g, t => t + opt.prefix);
+      if (opt.group && (val.group || opt.forceGroup)) val.group = opt.group;
+      options[opt.prefix + key] = val;
+      delete options[key];
+    });
+  }
+  return options;
+}
+
+function getCliOptions() {
+  return {
+    'prettyPrint': {
+      type: 'boolean',
+      default: false,
+      describe: 'Enable to print json/har with spaces and indentation. Larger files, but easier on the eye.'
+    },
     'silent': {
       alias: 'q',
       type: 'count',
@@ -225,25 +255,10 @@ function getOptions(opt) {
       describe: 'Path to JSON config file',
       config: 'config'
     },
-    'viewPort': {
-      describe: 'Size of browser window WIDTHxHEIGHT'
-    },
     'resultDir': {
       describe: 'Set result directory for the files produced by Browsertime'
     }
   };
-
-  if (opt && opt.prefix) {
-    Object.keys(options).forEach(key => {
-      let val = options[key];
-      let describe = val.describe || val.description || val.desc;
-      if (describe) val.describe = describe.replace(/--(?=\w+)/g, t => t + opt.prefix);
-      if (opt.group && (val.group || opt.forceGroup)) val.group = opt.group;
-      options[opt.prefix + key] = val;
-      delete options[key];
-    });
-  }
-  return options;
 }
 
 function parseCommandLine() {
@@ -254,6 +269,7 @@ function parseCommandLine() {
       return packageInfo.version;
     })
     .options(getOptions())
+    .options(getCliOptions())
     .count('verbose')
     .string('_')
     .help('h')


### PR DESCRIPTION
Allows parent components to easily reuse browsertime yargs cli options:

``` js
var browsertimeCli = require('browsertime').cli;
let browsertimeOptions = browsertimeCli.getOptions({
  group: 'Browser',
  prefix: 'browsertime.',
  forceGroup: true
});

yargs().options(browsertimeOptions ).option(...)
```

Parent component's help:

``` shell
Browser
  --browsertime.timeouts.browserStart                     Timeout when waiting for browser to start, in milliseconds
                                                                                                                 [number] [default: 60000]

  --browsertime.timeouts.pageLoad                         Timeout when waiting for url to load, in milliseconds [number] [default: 300000]
...
```
