### PR TITLE
Replaced continue inside switch case statements with break

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -169,7 +169,7 @@ module.exports = {
 
           if (rootFrameMappings.has(frameId) || previousFrameId) {
             // This is a sub frame, there's already a page for the root frame
-            continue;
+            break;
           }
 
           currentPageId = 'page_' + (pages.length + 1);
@@ -187,18 +187,18 @@ module.exports = {
         case 'Network.requestWillBeSent': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue
+            break
           }
           const request = params.request;
           if (!isSupportedProtocol(request.url)) {
             ignoredRequests.add(params.requestId);
-            continue;
+            break;
           }
           let frameId = rootFrameMappings.get(params.frameId) || params.frameId;
           let page = pages.find((page) => page._frameId === frameId);
           if (!page) {
             log.warn('Request will be sent with requestId ' + params.requestId + ' that can\'t be mapped to any page.');
-            continue;
+            break;
           }
 
           const cookieHeader = getHeaderValue(request.headers, 'Cookie');
@@ -255,17 +255,17 @@ module.exports = {
         case 'Network.requestServedFromCache': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue
+            break
           }
 
           if (ignoredRequests.has(params.requestId)) {
-            continue;
+            break;
           }
 
           let entry = entries.find((entry) => entry._requestId === params.requestId);
           if (!entry) {
             log.warn('Recieved requestServedFromCache for requestId ' + params.requestId + ' with no matching request.');
-            continue;
+            break;
           }
 
           entry._servedFromCache = true;
@@ -280,16 +280,16 @@ module.exports = {
         case 'Network.responseReceived': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue
+            break
           }
           if (ignoredRequests.has(params.requestId)) {
-            continue;
+            break;
           }
 
           let entry = entries.find((entry) => entry._requestId === params.requestId);
           if (!entry) {
             log.warn('Recieved network response for requestId ' + params.requestId + ' with no matching request.');
-            continue;
+            break;
           }
           entry._responseReceivedTime = params.timestamp;
           entry._totalRequestTime = (params.timestamp - entry._requestWillBeSentTime) * 1000;
@@ -306,16 +306,16 @@ module.exports = {
         case 'Network.dataReceived': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue
+            break
           }
           if (ignoredRequests.has(params.requestId)) {
-            continue;
+            break;
           }
 
           let entry = entries.find((entry) => entry._requestId === params.requestId);
           if (!entry) {
             log.warn('Recieved network data for requestId ' + params.requestId + ' with no matching request.');
-            continue;
+            break;
           }
 
           entry._dataReceivedTime = entry._responseReceivedTime;
@@ -326,17 +326,17 @@ module.exports = {
         case 'Network.loadingFinished': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue
+            break
           }
           if (ignoredRequests.has(params.requestId)) {
             ignoredRequests.delete(params.requestId);
-            continue;
+            break;
           }
 
           let entry = entries.find((entry) => entry._requestId === params.requestId);
           if (!entry) {
             log.warn('Network loading finished for requestId ' + params.requestId + ' with no matching request.');
-            continue;
+            break;
           }
 
           const timings = entry.timings;
@@ -368,7 +368,7 @@ module.exports = {
         case 'Page.loadEventFired': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue;
+            break;
           }
 
           let page = pages[pages.length - 1];
@@ -382,7 +382,7 @@ module.exports = {
         case 'Page.domContentEventFired': {
           if (pages.length < 1) {
             //we havent loaded any pages yet.
-            continue;
+            break;
           }
 
           let page = pages[pages.length - 1];
@@ -429,13 +429,13 @@ module.exports = {
         case 'Network.loadingFailed': {
           if (ignoredRequests.has(params.requestId)) {
             ignoredRequests.delete(params.requestId);
-            continue;
+            break;
           }
 
           let entry = entries.find((entry) => entry._requestId === params.requestId);
           if (!entry) {
             log.warn('Network loading failed for requestId ' + params.requestId + ' with no matching request.');
-            continue;
+            break;
           }
 
           // This could be due to incorrect domain name etc. Sad, but unfortunately not something that a HAR file can


### PR DESCRIPTION
acorn fails with unsyntactic continue otherwise. This is the relevant discussion related to this - https://github.com/ternjs/acorn/issues/58

In this PR, replacing continue with break statements has no possible regression, because there is no code in the body of the loop following the switch expression.
