### PR TITLE
Selenium 3 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '4'
 - '6'
+- '7'
 env:
   - CXX=g++-4.8
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ UNRELEASED
 ### Fixed 
 * Entry timings in HAR files from Chrome were strings instead of numbers.
 * New TSProxy that is less complex
+* Upgraded Selenium to 3.0.0 (no beta!)
+* Upgraded Geckodriver to 0.11.1
+* Updated minimum NodeJS to 6.9.0 (same as Selenium).
 
 version 1.0-beta.9 2016-10-16
 -------------------------

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -43,5 +43,5 @@ module.exports.createWebDriver = function(options) {
       return Promise.reject(new Error('Unsupported browser: ' + browser));
   }
 
-  return Promise.try(() => builder.buildAsync());
+  return Promise.try(() => builder.build());
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "lodash.set": "4.3.2",
     "mkdirp": "0.5.1",
     "moment": "2.15.2",
-    "selenium-webdriver": "v3.0.0-beta-3",
+    "selenium-webdriver": "3.0.0",
     "sltc": "0.5.0",
-    "soprano-saxophone": "0.10.0",
+    "soprano-saxophone": "0.11.1",
     "tough-cookie": "2.3.2",
     "valid-url": "1.0.9",
     "yargs": "5.0.0"
@@ -34,7 +34,7 @@
     "sequencediagrams": "0.0.8"
   },
   "engines": {
-    "node": ">=4.3.0"
+    "node": ">=6.9.0"
   },
   "publishConfig": {
     "tag": "canary"


### PR DESCRIPTION
Updates Selenium to 3.0.0, Geckodriver to 0.11.1 and node dependencies to 6.9.0. 

Note: When we do this update, Browsertime will fail on NodeJS 4.x (becasue of changes in Selenium).