### PR TITLE
Adding initator to chrome har for use of associating a request with it's caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Browsertime changelog
 UNRELEASED
 -------------------------
+### Added
+* Added initiator of each request entry to chrome HAR
+
 ### Fixed 
 * Entry timings in HAR files from Chrome were strings instead of numbers.
 * New TSProxy that is less complex

--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -227,6 +227,7 @@ module.exports = {
             _wallTime: params.wallTime,
             _requestId: params.requestId,
             _frameId: params.frameId,
+            initiator: params.initiator,
             pageref: currentPageId,
             request: req,
             time: 0

--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -227,7 +227,7 @@ module.exports = {
             _wallTime: params.wallTime,
             _requestId: params.requestId,
             _frameId: params.frameId,
-            initiator: params.initiator,
+            _initiator: params.initiator,
             pageref: currentPageId,
             request: req,
             time: 0


### PR DESCRIPTION
@tobli  / @soulgalore this will surface a small object in the chrom HAR on each entry that shows where the request originated from. Possible could be used for something like https://github.com/sitespeedio/pagexray/issues/22

```
...
                _frameId": "27207.1",
                "initiator": {
                    "lineNumber": 0,
                    "type": "parser",
                    "url": "https://www.sitespeed.io/"
                },
                "pageref": "page_1",
                "request": {
                    "method": "GET",
                    "url": "https://www.sitespeed.io/img/sitespeed-logo-2c.png",
...
```

Not 100% sure if this can be done via the Firefox HAR exporter but I know it's available in their devtools in the browser.