### PR TITLE
Add conditional assignment to handle entries.find returning no value

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -235,6 +235,7 @@ module.exports = {
 
           if (params.redirectResponse) {
             let previousEntry = entries.find((entry) => entry._requestId === params.requestId);
+            previousEntry = (typeof previousEntry === 'undefined') ? entry : previousEntry;
             previousEntry._requestId += 'r';
             populateEntryFromResponse(previousEntry, params.redirectResponse);
           }


### PR DESCRIPTION
If entries.find method call does not find a match, previousEntry will
be undefined causing browsertime to crash.

Added conditional assignment to assign the current entry to
previousEntry if previousEntry === undefined.

#209 