### PR TITLE
Avoid crash if originating request for redirect is missing from perflog.

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -235,8 +235,12 @@ module.exports = {
 
           if (params.redirectResponse) {
             let previousEntry = entries.find((entry) => entry._requestId === params.requestId);
-            previousEntry._requestId += 'r';
-            populateEntryFromResponse(previousEntry, params.redirectResponse);
+            if (previousEntry) {
+              previousEntry._requestId += 'r';
+              populateEntryFromResponse(previousEntry, params.redirectResponse);
+            } else {
+              log.warn('Couldn\'t find original request for redirect response: ' + params.requestId);
+            }
           }
 
           entries.push(entry);


### PR DESCRIPTION
See #209.