### PR TITLE
Fixed the key for setting up proxy for HTTPS connections

### DIFF
--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -26,7 +26,7 @@ module.exports.createWebDriver = function(options) {
     let proxyUrl = proxyHost + ':' + options.proxyPort;
     proxyConfig = proxy.manual({
       http: proxyUrl,
-      https: proxyUrl
+      ssl: proxyUrl
     });
   }
 


### PR DESCRIPTION
I am not sure why the key was set to https. And, since there are no tests for this, I can't verify whether this worked previously. This is quite a simple fix.