### PR TITLE
Remove outdated Firefox workaround for window position.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -63,12 +63,7 @@ class SeleniumRunner {
           viewPort = viewPort.split('x');
 
           const window = this.driver.manage().window();
-          // Do not set position until this is fixed in Geckodriver
-          // https://github.com/mozilla/geckodriver/issues/113
-          if (this.options.browser === 'firefox') {
-            return window.setSize(Number(viewPort[0]), Number(viewPort[1]));
-          }
-          else return window.setPosition(0, 0)
+          return window.setPosition(0, 0)
             .then(() => window.setSize(Number(viewPort[0]), Number(viewPort[1])));
         }
       })


### PR DESCRIPTION
This doesn’t crash anymore, so remove the hack. Unfortunately it
doesn’t seem to work correctly in Firefox. Setting the window position
doesn’t take effect in my testing.