### PR TITLE
Configure http and https proxies separately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ UNRELEASED
  size for mdev fixing many numbers for SpeedIndex. 
 
 ### Changed
+* Configure proxies with --proxy.http and --proxy.https
 * New TSProxy that is less complex
 * Upgraded Selenium to 3.0.1 (no beta!)
 * Upgraded Geckodriver to 0.11.1

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 let Promise = require('bluebird'),
+  pick = require('lodash.pick'),
+  isEmpty = require('lodash.isempty'),
   webdriver = require('selenium-webdriver'),
   chrome = require('./chrome'),
   firefox = require('./firefox'),
@@ -20,14 +22,10 @@ module.exports.createWebDriver = function(options) {
     .usingServer(seleniumUrl);
 
   let proxyConfig = undefined;
+  const proxySettings = pick(options.proxy, ['http', 'https']);
 
-  if (options.proxyPort) {
-    let proxyHost = options.proxyHost || 'localhost';
-    let proxyUrl = proxyHost + ':' + options.proxyPort;
-    proxyConfig = proxy.manual({
-      http: proxyUrl,
-      https: proxyUrl
-    });
+  if (!isEmpty(proxySettings)) {
+    proxyConfig = proxy.manual(proxySettings);
   }
 
   switch (browser) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -164,6 +164,16 @@ module.exports.parseCommandLine = function parseCommandLine() {
       default: 0,
       describe: 'Delay between runs, in milliseconds'
     })
+    .option('proxy.http', {
+      type: 'string',
+      describe: 'Http proxy (host:port)',
+      group: 'proxy'
+    })
+    .option('proxy.https', {
+      type: 'string',
+      describe: 'Https proxy (host:port)',
+      group: 'proxy'
+    })
     .option('connectivity.profile', {
       alias: 'c',
       default: 'native',


### PR DESCRIPTION
E.g. --proxy.http=example.com:1234 and  --proxy.https=example.net:2345.