### PR TITLE
Set your own alias for connectivity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
     - python-sympy
     - python-nose
     - xz-utils
-  firefox: "latest"
+  firefox: "49"
 before_install:
 - pip install --user --upgrade pip
 - pip --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
     - python-sympy
     - python-nose
     - xz-utils
-  firefox: "49"
+  firefox: "49.0"
 before_install:
 - pip install --user --upgrade pip
 - pip --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 UNRELEASED
 -------------------------
+### Added
+* Add a alias/custom name to your connectivity profile. Thank you @jpvincent for the idea! https://github.com/sitespeedio/sitespeed.io/issues/1329
 
 version 1.0-beta.11 2016-11-13
 -------------------------

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -197,6 +197,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'This option requires --connectivity.profile be set to "custom".',
       group: 'connectivity'
     })
+    .option('connectivity.alias', {
+      default: undefined,
+      describe: 'Give your connectivity profile a custom name',
+      group: 'connectivity'
+    })
     .option('connectivity.tsproxy.port', {
       default: 1080,
       describe: 'The port used for ts proxy',


### PR DESCRIPTION
We gonna use this in sitespeed.io when we export the data to Graphite, but lets keep it in BT so we can use it here also in the future.