### PR TITLE
Pickup changed prio for requests

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -218,6 +218,7 @@ module.exports = {
             headersSize: -1,
             bodySize: -1, // FIXME calculate based on postData
             _initialPriority: request.initialPriority,
+            _newPriority: request.newPriority,
             cookies: parseRequestCookies(cookieHeader),
             headers: parseHeaders(request.headers)
           };
@@ -465,8 +466,10 @@ module.exports = {
         case 'Network.eventSourceMessageReceived':
           // ignore
           break;
-        case 'Network.resourceChangedPriority':
-          // skip those for now, maybe we can do something cool with this in the future
+        case 'Network.resourceChangedPriority': {
+            let entry = entries.find((entry) => entry._requestId === params.requestId);
+            entry.newPriority = message.params.newPriority;
+          }
           break;
 
         default:


### PR DESCRIPTION
We catched Network.resourceChangedPriority but didn't do anything with it. Lets add it to the HAR and make PerfCascade pick it up so we easily can see if the prio changed.