### PR TITLE
Eliminate the risk to get a too early first visual change

### DIFF
--- a/lib/support/video/scripts/runVisualMetrics.js
+++ b/lib/support/video/scripts/runVisualMetrics.js
@@ -11,6 +11,7 @@ module.exports = {
     return storageManager.createSubDataDir('video', 'images', '' + context.index)
       .then((imageDir) => visualMetrics.run(taskData.videoPaths['' + context.index], imageDir))
       .then((metrics) => {
+        console.log(metrics.FirstVisualChange);
         log.debug('Collected metrics ' + JSON.stringify(metrics));
         context.results.visualMetrics = metrics;
       });

--- a/lib/support/video/scripts/runVisualMetrics.js
+++ b/lib/support/video/scripts/runVisualMetrics.js
@@ -11,7 +11,6 @@ module.exports = {
     return storageManager.createSubDataDir('video', 'images', '' + context.index)
       .then((imageDir) => visualMetrics.run(taskData.videoPaths['' + context.index], imageDir))
       .then((metrics) => {
-        console.log(metrics.FirstVisualChange);
         log.debug('Collected metrics ' + JSON.stringify(metrics));
         context.results.visualMetrics = metrics;
       });

--- a/lib/support/video/scripts/startVideo.js
+++ b/lib/support/video/scripts/startVideo.js
@@ -20,6 +20,7 @@ module.exports = {
         .then(() => driver.executeScript('window.performance.setResourceTimingBufferSize(600);'))
         // add a delay to make time for the browser to start and navigate
         .then(() => Promise.delay(1000))
+        .then(() => driver.executeScript('document.body.style.background = \"#DE640D\"'))
         .then(() => storageManager.createSubDataDir('video'))
         .then((videoDir) => {
           const fileName = context.index + '.mp4',
@@ -49,7 +50,6 @@ module.exports = {
         })
         // The extra delay removes connections errors we sometimes get simulating 3g
         // using tc (you could see that in the diff between firstPaint and FirstVisualChange and in the video)
-        .then(() => driver.executeScript('document.body.style.background = \"#DE640D\"'))
         .then(() => Promise.delay(100))
         .then(() => {
           // we are ready! Make the background white and let Browsertime do the

--- a/lib/support/video/scripts/startVideo.js
+++ b/lib/support/video/scripts/startVideo.js
@@ -18,9 +18,8 @@ module.exports = {
         // increase the default resource timing buffer size, in the future we
         // we should have a separate setup step.
         .then(() => driver.executeScript('window.performance.setResourceTimingBufferSize(600);'))
-        .then(() => driver.executeScript('document.body.style.background = \"#DE640D\"'))
         // add a delay to make time for the browser to start and navigate
-        .then(() => Promise.delay(1500))
+        .then(() => Promise.delay(1000))
         .then(() => storageManager.createSubDataDir('video'))
         .then((videoDir) => {
           const fileName = context.index + '.mp4',
@@ -50,7 +49,8 @@ module.exports = {
         })
         // The extra delay removes connections errors we sometimes get simulating 3g
         // using tc (you could see that in the diff between firstPaint and FirstVisualChange and in the video)
-        .then(() => Promise.delay(1000))
+        .then(() => driver.executeScript('document.body.style.background = \"#DE640D\"'))
+        .then(() => Promise.delay(100))
         .then(() => {
           // we are ready! Make the background white and let Browsertime do the
           // work

--- a/lib/support/video/visualMetrics.js
+++ b/lib/support/video/visualMetrics.js
@@ -19,8 +19,6 @@ module.exports = {
       '--force',
       '--renderignore',
       5,
-      '--orangelimitdiff',
-      35000,
       '--json'];
 
     if (imageDirPath) {

--- a/lib/support/video/visualMetrics.js
+++ b/lib/support/video/visualMetrics.js
@@ -17,10 +17,10 @@ module.exports = {
       '-q', 75,
       '--perceptual',
       '--force',
-      '--white',
-      '--viewport',
       '--renderignore',
       5,
+      '--orangelimitdiff',
+      35000,
       '--json'];
 
     if (imageDirPath) {

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -211,7 +211,7 @@ def remove_orange_frames(directory, orange_file):
       if is_orange_frame(frame, orange_file):
         logging.debug("Removing Orange frame: " + frame)
         os.remove(frame)
-      if frame_count > 120:
+      if frame_count > 20:
         break
     for frame in reversed(frames):
       if is_orange_frame(frame, orange_file):
@@ -643,7 +643,7 @@ def is_orange_frame(file, orange_file):
     out, err = compare.communicate()
     if re.match('^[0-9]+$', err):
       different_pixels = int(err)
-      if different_pixels < 100:
+      if different_pixels < options.orangelimitdiff:
         orange = True
 
   return orange
@@ -1280,6 +1280,8 @@ def main():
                       help="Calculate perceptual Speed Index")
   parser.add_argument('-j', '--json', action='store_true', default=False,
                       help="Set output format to JSON")
+  parser.add_argument('--orangelimitdiff', type=int, default=100,
+                    help="The limit when to the decice if the difference between frames makes a frame orange")
 
   options = parser.parse_args()
 

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -211,7 +211,7 @@ def remove_orange_frames(directory, orange_file):
       if is_orange_frame(frame, orange_file):
         logging.debug("Removing Orange frame: " + frame)
         os.remove(frame)
-      if frame_count > 20:
+      if frame_count > 120:
         break
     for frame in reversed(frames):
       if is_orange_frame(frame, orange_file):

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -637,7 +637,7 @@ def clean_directory(directory):
 def is_orange_frame(file, orange_file):
   orange = False
   if os.path.isfile(orange_file):
-    command = ('convert "{0}" "(" "{1}" -gravity Center -crop 50%x33%+0+0 -resize 200x200! ")" miff:- | '
+    command = ('convert "{0}" "(" "{1}" -resize 200x200! ")" miff:- | '
                'compare -metric AE - -fuzz 10% null:').format(orange_file, file)
     compare = subprocess.Popen(command, stderr=subprocess.PIPE, shell=True)
     out, err = compare.communicate()
@@ -653,7 +653,7 @@ def is_white_frame(file, white_file):
   global client_viewport
   white = False
   if os.path.isfile(white_file):
-    command = ('convert "{0}" "(" "{1}" -gravity Center -crop 50%x33%+0+0 -resize 200x200! ")" miff:- | '
+    command = ('convert "{0}" "(" "{1}" -resize 200x200! ")" miff:- | '
                'compare -metric AE - -fuzz 10% null:').format(white_file, file)
     if client_viewport is not None:
       crop = '{0:d}x{1:d}+{2:d}+{3:d}'.format(client_viewport['width'], client_viewport['height'], client_viewport['x'], client_viewport['y'])
@@ -1280,7 +1280,7 @@ def main():
                       help="Calculate perceptual Speed Index")
   parser.add_argument('-j', '--json', action='store_true', default=False,
                       help="Set output format to JSON")
-  parser.add_argument('--orangelimitdiff', type=int, default=100,
+  parser.add_argument('--orangelimitdiff', type=int, default=30000,
                     help="The limit when to the decice if the difference between frames makes a frame orange")
 
   options = parser.parse_args()


### PR DESCRIPTION
After no end of bother it seems I finally fixed the too early first visual change that I've been trying to fix since the kids of Hedenhös:

* I've removed the center cropping of images when visual metrics checks if an image is orange/white. The cropping made us miss the small orange lines that sometimes appear only in Chrome.

* I also fine tuned (and made configurable) the number when the diff of two images (orange and white) is ... orange.

* Re-arranged how we record the screen to record as little extra video as possible.

This means that we cannot easily upgrade visualmetrics.py anymore, lets check with Pat if it would be ok to PR the removal of cropping.
