### PR TITLE
Clarify cli help text for —chrome.args.

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -81,7 +81,9 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'timeouts'
     })
     .option('chrome.args', {
-      describe: 'Extra command line args to pass to the chrome process (e.g. --no-sandbox)',
+      describe: 'Extra command line arguments to pass to the Chrome process (e.g. --no-sandbox). ' +
+      'To add multiple arguments to Chrome, repeat --chrome.args once per argument.',
+      type: 'array',
       group: 'chrome'
     })
     .option('chrome.binaryPath', {


### PR DESCRIPTION
Make it more explicit that —chrome.args can be repeated.