### PR TITLE
Fix for issue #272 - checking if entry is not undefined and request exists

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -470,7 +470,12 @@ module.exports = {
           break;
         case 'Network.resourceChangedPriority': {
             let entry = entries.find((entry) => entry._requestId === params.requestId);
-            entry.request._priority = message.params.newPriority;
+
+            if(!entry) {
+              entry.request._priority = message.params.newPriority;
+              log.debug('Recieved resourceChangedPriority for requestId ' + params.requestId + ' with no matching request.');
+            }
+
           }
           break;
 

--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -472,9 +472,11 @@ module.exports = {
             let entry = entries.find((entry) => entry._requestId === params.requestId);
 
             if(!entry) {
-              entry.request._priority = message.params.newPriority;
               log.debug('Recieved resourceChangedPriority for requestId ' + params.requestId + ' with no matching request.');
+              continue;
             }
+
+            entry.request._priority = message.params.newPriority;
 
           }
           break;


### PR DESCRIPTION
There was a take over ad that loaded in an iframe that caused this issue if browsertime finished before the ad completed.

<img width="848" alt="takeoverad" src="https://cloud.githubusercontent.com/assets/723985/22961952/c8270f0e-f317-11e6-9d9b-7c88cbc9f6be.png">


```
[2017-02-15 00:18:39] Testing url http://www.techrepublic.com/pictures/photos-10-hot-devices-to-boost-your-productivity-in-2016/ run 1
[2017-02-15 00:18:56] Error running browsertime TypeError: Cannot read property 'request' of undefined
    at Object.harFromEvents (/Users/jclee2/github/browsertime/lib/support/chromePerflogParser.js:473:18)
    at runner.getLogs.timeout.map.tap.then (/Users/jclee2/github/browsertime/lib/core/engineDelegate/chromeDelegate.js:59:39)
From previous event:
    at ChromeDelegate.onStopIteration (/Users/jclee2/github/browsertime/lib/core/engineDelegate/chromeDelegate.js:59:8)
    at runner.start.tap.tap.tap.then.then.tap.tap (/Users/jclee2/github/browsertime/lib/core/engine.js:241:39)
From previous event:
    at runIteration (/Users/jclee2/github/browsertime/lib/core/engine.js:241:10)
    at Promise.reduce (/Users/jclee2/github/browsertime/lib/core/engine.js:279:25)
From previous event:
    at Promise.resolve.tap.tap.tap (/Users/jclee2/github/browsertime/lib/core/engine.js:278:17)
From previous event:
    at Engine.run (/Users/jclee2/github/browsertime/lib/core/engine.js:277:8)
    at /Users/jclee2/github/browsertime/bin/browsertime.js:54:21
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)
From previous event:
    at run (/Users/jclee2/github/browsertime/bin/browsertime.js:53:6)
    at Object.<anonymous> (/Users/jclee2/github/browsertime/bin/browsertime.js:110:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3

```