### PR TITLE
fix permissions of browsertime-results in docker

### DIFF
--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -26,3 +26,8 @@ PID=$!
 
 trap shutdown SIGTERM SIGINT
 wait $PID
+
+RESULTDIR="/browsertime-results"
+if [ -d $RESULTDIR ]; then 
+  chown -R `stat -c "%u:%g" ${RESULTDIR}` ${RESULTDIR}
+fi


### PR DESCRIPTION
Executing the docker image as advertised on the Readme

```
$ docker build -t sitespeedio/browsertime .
$ docker run --privileged --shm-size=1g --rm -v "$(pwd)":/browsertime-results sitespeedio/browsertime -n 1 -c cable --video --speedIndex https://www.sitespeed.io/
```

will create a directory in the current pwd called www.sitespeed.io.
However, the permissions are the permissions of docker root. Hence, if one tries to delete it without sudo permission is denied. This is a little cumbersome if one wants to postprocess the generated files afterwards.

This PR uses the fs-permission of the host.