### PR TITLE
Create output directory before starting a run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ UNRELEASED
 * Collect and save Chromes netlog with --experimental.dumpChromeNetlog - thank you https://github.com/worenga
 * Option to maximize browser window [#275](https://github.com/sitespeedio/browsertime/pull/275) thanks again @worenga
 
-### Changed
-* Output files will now be created directly at the path given by --resultDir. Previously they were put inside a
-directory named after the current timestamp.
-
 ### Fixed
 * Ensure output directory is created before starting a run (and before storageManager is passed to preScripts).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ UNRELEASED
 * Collect and save Chromes netlog with --experimental.dumpChromeNetlog - thank you https://github.com/worenga
 * Option to maximize browser window [#275](https://github.com/sitespeedio/browsertime/pull/275) thanks again @worenga
 
+### Changed
+* Output files will now be created directly at the path given by --resultDir. Previously they were put inside a
+directory named after the current timestamp.
+
+### Fixed
+* Ensure output directory is created before starting a run (and before storageManager is passed to preScripts).
+
 version 1.0.0-beta.31 2017-03-13
 -------------------------
 ### Added 

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -124,15 +124,6 @@ class Engine {
       options.postScript.unshift(...videoPostScripts);
     }
 
-    if(get(options, 'experimental.dumpChromeNetlog')) {
-      //We need to ensure the directory exists for chrome to write to it.
-      storageManager.createDataDir()
-    }
-
-    options.result_dir = storageManager.directory
-
-
-
     function runScript(runner, script, isAsync, name) {
       // Scripts should be valid statements or IIFEs '(function() {...})()' that can run
       // on their own in the browser console. Prepend with 'return' to return result of statement to Browsertime.
@@ -287,6 +278,8 @@ class Engine {
       visualMetrics: []
     })
       .tap((result) => collectInfo(result, options))
+      .tap(() => storageManager.createDataDir()
+        .tap((baseDir) => options.baseDir = baseDir))
       .tap(() => runDelegate.onStartRun(url, options))
       .tap((result) =>
         Promise.reduce(iterations, (results, item, runIndex, totalRuns) => {

--- a/lib/core/webdriver/chrome.js
+++ b/lib/core/webdriver/chrome.js
@@ -78,7 +78,7 @@ module.exports.configureBuilder = function(builder, options) {
   }
 
   if(get(options, 'experimental.dumpChromeNetlog')) {
-    chromeOptions.addArguments('--log-net-log=' + options.result_dir + '/chromeNetlog-'+options.index+'.json');
+    chromeOptions.addArguments(`--log-net-log=${options.baseDir}/chromeNetlog-${options.index}.json`);
     chromeOptions.addArguments('--net-log-capture-mode=0');
   }
 

--- a/lib/support/storageManager.js
+++ b/lib/support/storageManager.js
@@ -16,8 +16,11 @@ let timestamp = moment().format().replace(/:/g, '');
 
 class StorageManager {
   constructor(url, {resultDir, prettyPrint = false} = {}) {
-    this.baseDir = path.resolve(process.cwd(), resultDir || path.join(defaultDir,
-        this.pathNameFromUrl(url), timestamp));
+    if (resultDir) {
+      this.baseDir = path.resolve(resultDir);
+    } else {
+      this.baseDir = path.resolve(defaultDir, this.pathNameFromUrl(url), timestamp);
+    }
     this.jsonIndentation = prettyPrint ? 2 : 0;
   }
 


### PR DESCRIPTION
Also ensure output directory is created before starting a run (and before storageManager is passed to preScripts).