### PR TITLE
[DON't MERGE] Run Travis tests inside a Docker container.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 !package.json
 !docker
 !vendor
+!.eslint*
+!test
 !browserscripts
 !browsersupport
 !index.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: node_js
 dist: trusty
 
 install:
-- docker build -t sitespeedio/browsertime .
 - docker build -f ./Dockerfile-test -t sitespeedio/browsertime-test .
-- docker run --rm sitespeedio/browsertime -V
+- docker run --rm sitespeedio/browsertime-test -V
 
 script:
 - docker run --rm sitespeedio/browsertime-test npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 dist: trusty
 
-before_install:
+install:
 - docker build -t sitespeedio/browsertime .
 - docker build -f ./Dockerfile-test -t sitespeedio/browsertime-test .
 - docker run --rm sitespeedio/browsertime -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,76 +1,16 @@
 language: node_js
-node_js:
-- '6'
-- '7'
-env:
-- CXX=g++-4.8
-sudo: required
+
 dist: trusty
-cache:
-  apt: true
-  pip: true
-  directories:
-  - node_modules
-  - ffmpeg-2.1.3-64bit-static
-  - $HOME/.local/lib/python2.7/site-packages
-  - /usr/local/lib/python2.7/site-packages
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - google-chrome
-    packages:
-    - g++-4.8
-    - google-chrome-stable
-    - ipython
-    - ipython-notebook
-    - libjpeg-dev
-    - libatlas-base-dev
-    - gfortran
-    - python
-    - python-dev
-    - python-imaging
-    - python-numpy
-    - python-scipy
-    - python-matplotlib
-    - python-pandas
-    - python-pip
-    - python-sympy
-    - python-nose
-    - xz-utils
-  firefox: latest
+
 before_install:
-- pip install --user --upgrade pip
-- pip --version
-- pip install --user Pillow
-- pip install --user pyssim
-- ls -la /usr/local/lib/
-- pip show Pillow
-- pip show pyssim
-- mkdir /tmp/ffmpeg
-- wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
-  -O /tmp/ffmpeg/download-ffmpeg.tar.xz
-- tar -xf /tmp/ffmpeg/download-ffmpeg.tar.xz -C /tmp/ffmpeg/ --strip=1
-- export PATH=$PATH:/tmp/ffmpeg
-- ffmpeg -version
-- /usr/bin/python --version
-- python --version
-- which python
-- firefox --version 2>/dev/null
-- google-chrome --product-version
-- export DISPLAY=:99.0
-- /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile
-  --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1600x1024x16
+- docker build -t sitespeedio/browsertime .
+- docker build -f ./Dockerfile-test -t sitespeedio/browsertime-test .
+- docker run --shm-size=1g --rm -v "$(pwd)":/browsertime-results sitespeedio/browsertime -V
+
 script:
-- ./vendor/visualmetrics.py --check
-- npm run travis
-- node ./bin/browsertime.js -b firefox -n 2 http://www.browsertime.net --preTask test/prepostscripts/preSample.js
-  --postTask test/prepostscripts/postSample2.js --connectivity.profile cable --connectivity.engine
-  tc
-- node ./bin/browsertime.js -b chrome --skipHar -n 1 --preURL https://www.sitespeed.io/ -r header:value
-  https://www.sitespeed.io/documentation/
-- node ./bin/browsertime.js -b chrome -vv --viewPort=640x480 --video --screenshot
-  --speedIndex -n 1 --chrome.collectTracingEvents https://www.sitespeed.io/
+- docker run --rm sitespeedio/browsertime-test npm run lint
+- docker run --rm sitespeedio/browsertime-test npm test
+
 notifications:
   slack:
     secure: V71EkIzwOf/fZnGTGIKAIFlDyLUit4tK97VDgdV9vZ7CbvOXI1ir3lwRZ57lNqiYD8BUaX+/wKDG+LyrBMgQ4JAGgQx0mECvmOKx1+10Yg9FAkUsMTWe7GOxcVMwhpS2OfHnXwMb0FjcuVl8ovowIZqCWOLeEAYVaTWHndDm2cA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 before_install:
 - docker build -t sitespeedio/browsertime .
 - docker build -f ./Dockerfile-test -t sitespeedio/browsertime-test .
-- docker run --shm-size=1g --rm -v "$(pwd)":/browsertime-results sitespeedio/browsertime -V
+- docker run --rm sitespeedio/browsertime -V
 
 script:
 - docker run --rm sitespeedio/browsertime-test npm run lint

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,8 @@
+FROM sitespeedio/browsertime
+ 
+WORKDIR /usr/src/app
+
+RUN npm install
+
+ENTRYPOINT []
+CMD npm test

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -2,7 +2,9 @@ FROM sitespeedio/browsertime
  
 WORKDIR /usr/src/app
 
+COPY package.json /usr/src/app/
 RUN npm install
+COPY . /usr/src/app
 
 ENTRYPOINT []
 CMD npm test


### PR DESCRIPTION
Include test files and eslint config in base image for now, might revisit that later. Then build separate test container after that, to install dev dependencies.

A better solution might ultimately be to replicate everything in the sitespeedio/browsertime Dockerfile inside the test Dockerfile.