### PR TITLE
Restore ability to set http(s) proxy for Chrome.

### DIFF
--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -17,15 +17,7 @@ let Promise = require('bluebird'),
 module.exports.createWebDriver = function(options) {
   const browser = options.browser || 'chrome';
   const seleniumUrl = options.selenium ? options.selenium.url : undefined;
-  const builder = new webdriver.Builder()
-    .forBrowser(browser)
-    .usingServer(seleniumUrl);
-
-  const proxySettings = pick(options.proxy, ['http', 'https']);
-
-  if (!isEmpty(proxySettings)) {
-    builder.setProxy(proxy.manual(proxySettings));
-  }
+  const builder = new webdriver.Builder().usingServer(seleniumUrl);
 
   switch (browser) {
     case 'chrome':
@@ -38,6 +30,13 @@ module.exports.createWebDriver = function(options) {
 
     default:
       return Promise.reject(new Error('Unsupported browser: ' + browser));
+  }
+
+  // Proxy settings need to be set last, since options for Chrome will overwrite them otherwise.
+  const proxySettings = pick(options.proxy, ['http', 'https']);
+
+  if (!isEmpty(proxySettings)) {
+    builder.setProxy(proxy.manual(proxySettings));
   }
 
   return Promise.try(() => builder.build());


### PR DESCRIPTION
When setting ChromeOptions, any proxy settings will be overwritten (see https://github.com/SeleniumHQ/selenium/blob/d7bdd7cc42faafb1eba031c26b7c369cdea026d5/javascript/node/selenium-webdriver/chrome.js#L654). Fix by setting our proxy settings after any browser specific options.

For the same reason, there’s no need to specify browser to the webdriver.Builder. By setting ChromeOptions/FirefoxOptions the browser name will be overwritten anyway.

Fixes #338.