### PR TITLE
Restore ability to set http(s) proxy for Chrome.

### DIFF
--- a/lib/core/webdriver/chrome.js
+++ b/lib/core/webdriver/chrome.js
@@ -2,6 +2,9 @@
 
 const webdriver = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
+const proxy = require('selenium-webdriver/proxy');
+const pick = require('lodash.pick');
+const isEmpty = require('lodash.isempty');
 const chromedriver = require('alto-saxophone').chromedriver;
 const log = require('intel');
 const get = require('lodash.get');
@@ -86,6 +89,12 @@ module.exports.configureBuilder = function(builder, options) {
   }
 
   let chromeOptions = new chrome.Options();
+
+  const proxySettings = pick(options.proxy, ['http', 'https']);
+
+  if (!isEmpty(proxySettings)) {
+    chromeOptions.setProxy(proxy.manual(proxySettings));
+  }
 
   chromeOptions.setLoggingPrefs(logPrefs);
   const perfLogConf = {enableNetwork: true, enablePage: true};

--- a/lib/core/webdriver/firefox.js
+++ b/lib/core/webdriver/firefox.js
@@ -2,6 +2,9 @@
 
 let path = require('path'),
   firefox = require('selenium-webdriver/firefox'),
+  proxy = require('selenium-webdriver/proxy'),
+  pick = require('lodash.pick'),
+  isEmpty = require('lodash.isempty'),
   log = require('intel'),
   util = require('../../support/util'),
   get = require('lodash.get'),
@@ -257,6 +260,12 @@ module.exports.configureBuilder = function(builder, options) {
   binary.addArguments('-no-remote');
   ffOptions.setBinary(binary);
   ffOptions.setProfile(profile);
+
+  const proxySettings = pick(options.proxy, ['http', 'https']);
+
+  if (!isEmpty(proxySettings)) {
+    ffOptions.setProxy(proxy.manual(proxySettings));
+  }
 
   builder.setFirefoxOptions(ffOptions);
 

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -1,12 +1,9 @@
 'use strict';
 
 let Promise = require('bluebird'),
-  pick = require('lodash.pick'),
-  isEmpty = require('lodash.isempty'),
   webdriver = require('selenium-webdriver'),
   chrome = require('./chrome'),
-  firefox = require('./firefox'),
-  proxy = require('selenium-webdriver/proxy');
+  firefox = require('./firefox');
 
 /**
  * Create a new WebDriver instance based on the specified options.
@@ -20,12 +17,6 @@ module.exports.createWebDriver = function(options) {
   const builder = new webdriver.Builder()
     .forBrowser(browser)
     .usingServer(seleniumUrl);
-
-  const proxySettings = pick(options.proxy, ['http', 'https']);
-
-  if (!isEmpty(proxySettings)) {
-    builder.setProxy(proxy.manual(proxySettings));
-  }
 
   switch (browser) {
     case 'chrome':


### PR DESCRIPTION
Generic Selenium api for setting proxy doesn’t work for Chrome. Instead set proxy using browser specific api for both Chrome and Firefox.

Fixes #338.