### PR TITLE
Upgrade to 2.30 with haxx

### DIFF
--- a/lib/core/engineDelegate/chromeDelegate.js
+++ b/lib/core/engineDelegate/chromeDelegate.js
@@ -39,7 +39,11 @@ class ChromeDelegate {
     }
 
     // remove irrelevant entries from performance log
-    return runner.getLogs(webdriver.logging.Type.PERFORMANCE);
+    // and since Chromedriver 2.29 there's a bug
+    // https://bugs.chromium.org/p/chromedriver/issues/detail?id=1811
+    // that can be fixed by emptying the logs twice :|
+    return runner.getLogs(webdriver.logging.Type.PERFORMANCE).
+      then(() => runner.getLogs(webdriver.logging.Type.PERFORMANCE));
   }
 
   onStopIteration(runner, index, results) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": "./bin/browsertime.js",
   "dependencies": {
     "adbkit": "2.8.1",
-    "alto-saxophone": "2.28.0",
+    "alto-saxophone": "2.30.0",
     "bluebird": "3.5.0",
     "chrome-har": "0.2.1",
     "execa": "0.6.1",


### PR DESCRIPTION
@tobli and @beenanner can you help me verify that this really works? make sure to _rm -fR node_modules_ and re-install and run:
` bin/browsertime.js --chrome.collectTracingEvents -n 1 https://www.sitespeed.io`
for a couple of different sites. 