### PR TITLE
Limit tests to one browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "mocha test/unitTests test/browserTests",
+    "test:unit": "mocha test/unitTests",
+    "test:browser": "mocha test/browserTests",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",

--- a/test/browserTests/engineTests.js
+++ b/test/browserTests/engineTests.js
@@ -1,9 +1,15 @@
 'use strict';
 
 const path = require('path'),
-  Engine = require('../lib/core/engine');
+  Engine = require('../../lib/core/engine');
 
-const BROWSERS = ['chrome', 'firefox'];
+const BROWSERS = [];
+
+if (process.env.BROWSERTIME_TEST_BROWSER) {
+  BROWSERS.push(...process.env.BROWSERTIME_TEST_BROWSER.split(' '));
+} else {
+  BROWSERS.push('chrome', 'firefox');
+}
 
 describe('Engine', function() {
   let engine;

--- a/test/browserTests/engineTests.js
+++ b/test/browserTests/engineTests.js
@@ -158,7 +158,7 @@ describe('Engine', function() {
 
     describe('#pre/post scripts - ' + browser, function() {
       function loadTaskFile(file) {
-        return require(path.resolve(__dirname, 'prepostscripts', file));
+        return require(path.resolve(__dirname, '..', 'prepostscripts', file));
       }
 
       const scripts = {

--- a/test/browserTests/seleniumRunnerTests.js
+++ b/test/browserTests/seleniumRunnerTests.js
@@ -1,8 +1,14 @@
 'use strict';
 
-const SeleniumRunner = require('../lib/core/seleniumRunner');
+const SeleniumRunner = require('../../lib/core/seleniumRunner');
 
-const BROWSERS = ['chrome', 'firefox'];
+const BROWSERS = [];
+
+if (process.env.BROWSERTIME_TEST_BROWSER) {
+  BROWSERS.push(process.env.BROWSERTIME_TEST_BROWSER);
+} else {
+  BROWSERS.push('chrome', 'firefox');
+}
 
 describe('SeleniumRunner', function() {
   let runner;
@@ -15,20 +21,22 @@ describe('SeleniumRunner', function() {
       return runner.start().should.be.rejected;
     });
 
-    it.skip('should handle if Chrome crashes', function() {
-      runner = new SeleniumRunner({
-        browser: 'chrome',
-        chrome: {
-          args: '--crash-test'
-        },
-        verbose: true
-      });
+    if (BROWSERS.includes('chrome')) {
+      it.skip('should handle if Chrome crashes', function() {
+        runner = new SeleniumRunner({
+          browser: 'chrome',
+          chrome: {
+            args: '--crash-test'
+          },
+          verbose: true
+        });
 
-      // Wait for session to actually have Chrome start up.
-      return runner.start().catch(function(e) {
-        throw e;
-      }).should.be.rejected;
-    });
+        // Wait for session to actually have Chrome start up.
+        return runner.start().catch(function(e) {
+          throw e;
+        }).should.be.rejected;
+      });
+    }
   });
 
   BROWSERS.forEach(function(browser) {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,5 @@
 --require ./test/helpers/first
 --reporter spec
 --retries 1
---bail
 --timeout 120s
 --check-leaks

--- a/test/unitTests/browserScriptTests.js
+++ b/test/unitTests/browserScriptTests.js
@@ -2,10 +2,11 @@
 
 let assert = require('assert'),
   path = require('path'),
-  parser = require('../lib/support/browserScript');
+  parser = require('../../lib/support/browserScript');
 
 const TEST_SCRIPTS_FOLDER = path.resolve(
   __dirname,
+  '..',
   'browserscripts',
   'testscripts'
 );

--- a/test/unitTests/harBuilderTests.js
+++ b/test/unitTests/harBuilderTests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let builder = require('../lib/support/harBuilder'),
+let builder = require('../../lib/support/harBuilder'),
   expect = require('chai').expect;
 
 describe('har_builder', function() {

--- a/test/unitTests/statisticsTests.js
+++ b/test/unitTests/statisticsTests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let assert = require('assert'),
-  Statistics = require('../lib/support/statistics').Statistics;
+  Statistics = require('../../lib/support/statistics').Statistics;
 
 describe('statistics', function() {
   let stats;

--- a/test/unitTests/trafficShapeParserTests.js
+++ b/test/unitTests/trafficShapeParserTests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let parser = require('../lib/support/trafficShapeParser'),
+let parser = require('../../lib/support/trafficShapeParser'),
   expect = require('chai').expect;
 
 describe('traffic_shape_parser', function() {

--- a/test/unitTests/userTimingTests.js
+++ b/test/unitTests/userTimingTests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const userTiming = require('../lib/support/userTiming');
+const userTiming = require('../../lib/support/userTiming');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
@@ -8,7 +8,12 @@ const path = require('path');
 describe('userTiming', function() {
   describe('#filterWhitelisted', function() {
     it('should filter out entries based on a whitelist', function() {
-      const timingsFile = path.resolve(__dirname, 'testdata', 'timings.json');
+      const timingsFile = path.resolve(
+        __dirname,
+        '..',
+        'testdata',
+        'timings.json'
+      );
 
       const userTimings = JSON.parse(fs.readFileSync(timingsFile, 'utf-8'))
         .timings.userTimings;


### PR DESCRIPTION
This was helpful initially to keep test short, now it’s better to get the full list of failures (if any) from Travis.