### PR TITLE
Configurable wait time for phone to prepare the video

### DIFF
--- a/lib/support/video/scripts/stopVideoAndroid.js
+++ b/lib/support/video/scripts/stopVideoAndroid.js
@@ -2,11 +2,18 @@
 
 const Promise = require('bluebird');
 const fs = require('fs');
+const get = require('lodash.get');
 const convert = require('../finetune/convertToFps');
 
 module.exports = {
   run(context) {
     const taskData = context.taskData;
+    const videoWait = get(
+      context,
+      'options.videoParams.androidVideoWaitTime',
+      5000
+    );
+
     context.log.debug('Stop screenrecord');
     return (
       taskData.client
@@ -15,7 +22,7 @@ module.exports = {
           'kill -2 $(ps screenrecord | grep -Eo [0-9]+ | grep -m 1 -Eo [0-9]+)'
         )
         // give the phone the time needed to process the video
-        .then(() => Promise.delay(5000))
+        .then(() => Promise.delay(videoWait))
         .then(() => {
           return taskData.client
             .pull(taskData.deviceid, '/sdcard/browsertime.mp4')
@@ -23,6 +30,9 @@ module.exports = {
               return new Promise(function(resolve, reject) {
                 var fn = taskData.mpegPath;
                 transfer.on('end', function() {
+                  context.log.info(
+                    'Finished transfering the video from mobile to your server'
+                  );
                   taskData.videoPaths = taskData.videoPaths || {};
                   taskData.videoPaths['' + context.index] = taskData.mpegPath;
                   convert.convert(context).then(() => {


### PR DESCRIPTION
Make the wait time (default 5000 ms) configurable for moving the video from the phone to the server.

https://github.com/sitespeedio/sitespeed.io/issues/1780