### PR TITLE
Run Firefox with insecure HTTPS

### DIFF
--- a/lib/core/webdriver/firefox.js
+++ b/lib/core/webdriver/firefox.js
@@ -298,6 +298,10 @@ module.exports.configureBuilder = function(builder, options) {
     ffOptions.setProxy(proxy.manual(proxySettings));
   }
 
+  if (firefoxConfig.acceptInsecureCerts) {
+    builder.getCapabilities().set('acceptInsecureCerts', true);
+  }
+
   builder.setFirefoxOptions(ffOptions);
 
   // ugly hack for geckodriver

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -35,6 +35,11 @@ module.exports.createWebDriver = function(options) {
       break;
 
     case 'firefox':
+      if (options.firefox && options.firefox.acceptInsecureCerts) {
+        builder
+          .withCapabilities({ acceptInsecureCerts: true })
+          .forBrowser(browser);
+      }
       firefox.configureBuilder(builder, options);
       break;
 

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -22,14 +22,6 @@ module.exports.createWebDriver = function(options) {
     .forBrowser(browser)
     .usingServer(seleniumUrl);
 
-  // Hack for acceptInsecureCerts on Firefox
-  if (options.firefox && options.firefox.acceptInsecureCerts) {
-    builder
-      .withCapabilities({ acceptInsecureCerts: true })
-      .forBrowser(browser)
-      .usingServer(seleniumUrl);
-  }
-
   // Hack for running browsertime on different platforms.
   // Keep it in the dark for now becasue if you don't know
   // what you do, a lot can get wrong

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -22,6 +22,14 @@ module.exports.createWebDriver = function(options) {
     .forBrowser(browser)
     .usingServer(seleniumUrl);
 
+  // Hack for acceptInsecureCerts on Firefox
+  if (options.firefox && options.firefox.acceptInsecureCerts) {
+    builder
+      .withCapabilities({ acceptInsecureCerts: true })
+      .forBrowser(browser)
+      .usingServer(seleniumUrl);
+  }
+
   // Hack for running browsertime on different platforms.
   // Keep it in the dark for now becasue if you don't know
   // what you do, a lot can get wrong
@@ -35,11 +43,6 @@ module.exports.createWebDriver = function(options) {
       break;
 
     case 'firefox':
-      if (options.firefox && options.firefox.acceptInsecureCerts) {
-        builder
-          .withCapabilities({ acceptInsecureCerts: true })
-          .forBrowser(browser);
-      }
       firefox.configureBuilder(builder, options);
       break;
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -196,6 +196,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
+    .option('firefox.acceptInsecureCerts', {
+      describe: 'Accept insecure certs',
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('selenium.url', {
       describe:
         'URL to a running Selenium server (e.g. to run a browser on another machine).',


### PR DESCRIPTION
We can test it with:
`bin/browsertime.js https://self-signed.badssl.com/ -n 1 -b firefox --firefox.acceptInsecureCerts --skipHar`

or `bin/browsertime.js https://untrusted-root.badssl.com/ -n 1 -b firefox --firefox.acceptInsecureCerts --skipHar`