### PR TITLE
SATAVG numbers for white on Android aren't always the same

### DIFF
--- a/lib/support/video/finetune/findFirstFrame.js
+++ b/lib/support/video/finetune/findFirstFrame.js
@@ -2,6 +2,7 @@
 
 const log = require('intel');
 
+const LIMIT = 3;
 module.exports = {
   get(ffprobeOutput) {
     let firstFrame;
@@ -9,16 +10,16 @@ module.exports = {
     // and make sure the frame after has the same value, to make us caught when
     // Chrome has frames with just a little orange in them
     for (var i = 0; i < ffprobeOutput.frames.length; i++) {
+      // Two frames that are lower than the magic number should be ok. On Android
+      // the SATAVG sometimes differ between frames, so lets check against the magic limit.
       if (
-        Number(ffprobeOutput.frames[i].tags['lavfi.signalstats.SATAVG']) < 3
+        Number(ffprobeOutput.frames[i].tags['lavfi.signalstats.SATAVG']) <
+          LIMIT &&
+        Number(ffprobeOutput.frames[i + 1].tags['lavfi.signalstats.SATAVG']) <
+          LIMIT
       ) {
-        if (
-          Number(ffprobeOutput.frames[i].tags['lavfi.signalstats.SATAVG']) ===
-          Number(ffprobeOutput.frames[i + 1].tags['lavfi.signalstats.SATAVG'])
-        ) {
-          firstFrame = i;
-          break;
-        }
+        firstFrame = i;
+        break;
       }
     }
 


### PR DESCRIPTION
We got reports when the number changes between frames:
https://github.com/sitespeedio/sitespeed.io/issues/1830