### PR TITLE
Make it easy to only get the devtools.timeline

### DIFF
--- a/lib/core/webdriver/chrome.js
+++ b/lib/core/webdriver/chrome.js
@@ -44,6 +44,8 @@ const defaultChromeOptions = [
 const defaultTimelineTraceCategories =
   '-*, toplevel, blink.console,blink.user_timing, devtools.timeline, disabled-by-default-devtools.timeline,disabled-by-default-devtools.timeline.frame,disabled-by-default-devtools.timeline.stack';
 
+const devtoolsTimelineCategory = 'devtools.timeline';
+
 function migrateLegacyOption(options, from, to) {
   if (get(options, from)) {
     log.warn(
@@ -98,7 +100,7 @@ module.exports.configureBuilder = function(builder, options) {
     webdriver.logging.Level.ALL
   );
 
-  if (chromeConfig.traceCategories) {
+  if (chromeConfig.traceCategories || chromeConfig.devtoolsTimeline) {
     chromeConfig.collectTracingEvents = true;
   }
   if (chromeConfig.collectTracingEvents) {
@@ -129,9 +131,12 @@ module.exports.configureBuilder = function(builder, options) {
 
   if (chromeConfig.collectTracingEvents) {
     perfLogConf.traceCategories =
-      chromeConfig.traceCategories || defaultTimelineTraceCategories;
-    if (chromeConfig.traceCategories) {
-      log.info('Use Chrome trace categories: %s', chromeConfig.traceCategories);
+      chromeConfig.traceCategories ||
+      (chromeConfig.devtoolsTimeline ? devtoolsTimelineCategory : false) ||
+      defaultTimelineTraceCategories;
+
+    if (chromeConfig.collectTracingEvents) {
+      log.info('Use Chrome trace categories: %s', perfLogConf.traceCategories);
     }
   }
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -144,6 +144,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'string',
       group: 'chrome'
     })
+    .option('chrome.devtoolsTimeline', {
+      describe:
+        'Collect only the devtools.timeline trace log from Chrome. (implies chrome.collectTracingEvents)',
+      type: 'boolean',
+      group: 'chrome'
+    })
     .option('chrome.collectPerfLog', {
       type: 'boolean',
       describe:


### PR DESCRIPTION
The default trace categories we have is making Chrome unstable. Maybe we should just change the default to devtools.timeline, but that needs to happen in 3.0 if thats the case.