### PR TITLE
Move video out of pre/post scripts

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -10,10 +10,10 @@ const engineDelegate = require('./engineDelegate');
 const SeleniumRunner = require('./seleniumRunner');
 const webdriver = require('selenium-webdriver');
 const { BrowserError, UrlLoadError } = require('../support/errors');
-const startVideo = require('../support/video/scripts/startVideo');
+const startVideoDesktop = require('../support/video/scripts/startVideo');
 const startVideoAndroid = require('../support/video/scripts/startVideoAndroid');
 const pullNetLogAndroid = require('../support/pullNetLogAndroid');
-const stopVideo = require('../support/video/scripts/stopVideo');
+const stopVideoDesktop = require('../support/video/scripts/stopVideo');
 const stopVideoAndroid = require('../support/video/scripts/stopVideoAndroid');
 const runVisualMetrics = require('../support/video/scripts/runVisualMetrics');
 const removeVideo = require('../support/video/scripts/removeVideo');
@@ -54,6 +54,8 @@ class Engine {
       options.chrome.traceCategories &&
       options.chrome.traceCategories.indexOf('devtools.timeline') > -1 &&
       options.chrome.collectCPUMetrics;
+    this.isAndroid = get(options, 'chrome.android.package', false);
+    this.recordVideo = options.speedIndex || options.video;
   }
 
   startExtensionServer() {
@@ -86,7 +88,6 @@ class Engine {
       return xvfb.stopXvfb(this.xvfbSession);
     } else return Promise.resolve();
   }
-
   start() {
     return Promise.all([
       this.startXvfb(),
@@ -97,53 +98,53 @@ class Engine {
 
   run(url, scriptsByCategory, asyncScriptsByCategory) {
     const options = this.options;
+    const recordVideo = this.recordVideo;
+    const extensionServer = this.extensionServer;
     const isAndroid = get(options, 'chrome.android.package', false);
     const storageManager = new StorageManager(url, options);
     const collectChromeTimeline = this.collectChromeTimeline;
     const taskData = {};
 
-    if (options.preURL) {
-      this.preScripts.push(preURL);
+    if (isAndroid && options.chrome.collectNetLog) {
+      this.postScripts.push(pullNetLogAndroid);
     }
 
-    if (options.speedIndex || options.video) {
-      if (options.videoParams.combine) {
-        this.preScripts.unshift(isAndroid ? startVideoAndroid : startVideo);
-      } else {
-        this.preScripts.push(isAndroid ? startVideoAndroid : startVideo);
-      }
-      const videoPostScripts = [isAndroid ? stopVideoAndroid : stopVideo];
+    function startVideo(conf) {
+      return isAndroid
+        ? startVideoAndroid.run(conf)
+        : startVideoDesktop.run(conf);
+    }
 
+    function stopVideo(conf) {
+      return isAndroid
+        ? stopVideoAndroid.run(conf)
+        : stopVideoDesktop.run(conf);
+    }
+    function postProcessVideo() {
+      const postProcess = [];
       if (options.speedIndex) {
-        videoPostScripts.push(runVisualMetrics);
+        postProcess.push(runVisualMetrics);
       }
 
       if (options.video) {
-        videoPostScripts.push(finetuneVideo);
+        postProcess.push(finetuneVideo);
       } else {
-        videoPostScripts.push(removeVideo);
+        postProcess.push(removeVideo);
       }
-
-      if (options.videoParams.combine) {
-        this.postScripts.push(...videoPostScripts);
-      } else {
-        this.postScripts.unshift(...videoPostScripts);
-      }
-
-      if (isAndroid && options.chrome.collectNetLog) {
-        this.postScripts.push(pullNetLogAndroid);
-      }
+      return postProcess;
     }
 
-    // always start with running our extension for the setup
-    if (
-      options.cacheClearRaw ||
-      options.requestheader ||
-      options.block ||
-      options.basicAuth
-    ) {
-      const port = this.extensionServer.address().port;
-      this.preScripts.unshift(extensionSetup(port, url));
+    function setupExtension(url) {
+      // always start with running our extension for the setup
+      if (
+        options.cacheClearRaw ||
+        options.requestheader ||
+        options.block ||
+        options.basicAuth
+      ) {
+        const port = extensionServer.address().port;
+        return extensionSetup(port, url);
+      } else return Promise.resolve();
     }
 
     function runScript(runner, script, isAsync, name) {
@@ -246,14 +247,35 @@ class Engine {
         extraJson: {}
       })
         .tap(() => runner.start())
+        .tap(() => setupExtension(url))
+        .tap(() => {
+          if (options.videoParams.combine && recordVideo) {
+            return startVideo(taskOptions);
+          } else return Promise.resolve();
+        })
         .tap(() =>
           Promise.mapSeries(preScripts, preScript => preScript.run(taskOptions))
         )
+        .tap(() => {
+          if (options.preURL) {
+            return preURL.run(taskOptions);
+          } else return Promise.resolve();
+        })
         .tap(() => runDelegate.onStartIteration(runner, index))
         .tap(result => {
           result.timestamp = engineUtils.timestamp();
         })
+        .tap(() => {
+          if (!options.videoParams.combine && recordVideo) {
+            return startVideo(taskOptions);
+          } else return Promise.resolve();
+        })
         .tap(() => runner.loadAndWait(url, options.pageCompleteCheck))
+        .tap(() => {
+          if (!options.videoParams.combine && recordVideo) {
+            return stopVideo(taskOptions);
+          } else return Promise.resolve();
+        })
         .tap(result => {
           const syncScripts = runScripts(runner, scriptsByCategory),
             asyncScripts = runScripts(runner, asyncScriptsByCategory, true);
@@ -293,7 +315,7 @@ class Engine {
                 // not getting screenshots shouldn't result in a failed test.
                 log.warning(e);
               });
-          }
+          } else return Promise.resolve();
         })
         .tap(results => runDelegate.onStopIteration(runner, index, results))
         .tap(results =>
@@ -302,7 +324,20 @@ class Engine {
             return postScript.run(taskOptions);
           })
         )
-        .finally(() => runner.stop());
+        .tap(() => {
+          if (options.videoParams.combine && recordVideo) {
+            return stopVideo(taskOptions);
+          } else return Promise.resolve();
+        })
+        .finally(() => runner.stop())
+        .tap(results => {
+          if (recordVideo) {
+            taskOptions.results = results;
+            return Promise.mapSeries(postProcessVideo(), steps =>
+              steps.run(taskOptions)
+            );
+          } else return Promise.resolve();
+        });
     }
 
     function shouldDelay(runIndex, totalRuns) {
@@ -417,9 +452,7 @@ class Engine {
           const numPages = result.har.log.pages.length;
           if (numPages !== this.options.iterations) {
             log.error(
-              `Number of HAR pages (${
-                numPages
-              }) does not match number of iterations (${
+              `Number of HAR pages (${numPages}) does not match number of iterations (${
                 this.options.iterations
               })`
             );

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -32,7 +32,8 @@ const chromeCPU = require('../support/chromeCPU');
 const defaults = {
   scripts: [],
   iterations: 3,
-  delay: 0
+  delay: 0,
+  videoParams: {}
 };
 
 class Engine {

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -452,7 +452,9 @@ class Engine {
           const numPages = result.har.log.pages.length;
           if (numPages !== this.options.iterations) {
             log.error(
-              `Number of HAR pages (${numPages}) does not match number of iterations (${
+              `Number of HAR pages (${
+                numPages
+              }) does not match number of iterations (${
                 this.options.iterations
               })`
             );


### PR DESCRIPTION
When we first started with the video we used the pre/post structure.
That was ok to move fast but one of the negatives is that stopping the
video happen after we collected all metrics.

Let us move video to separate functionality. This will mostly just change
the structure so the order is correct, then is following PRs
we can tune and move things around and make the code easier to understand
(and change).