### PR TITLE
Store extra JSON and screenshots per run (and collect stats between r…

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -9,7 +9,6 @@ let Engine = require('../').Engine,
   Promise = require('bluebird'),
   merge = require('lodash.merge'),
   isEmpty = require('lodash.isempty'),
-  forEach = require('lodash.foreach'),
   pick = require('lodash.pick'),
   fs = require('fs'),
   path = require('path'),
@@ -86,15 +85,6 @@ function run(url, options) {
           storageManager.writeJson(harName + '.har', result.har)
         );
       }
-      forEach(result.extraJson, (value, key) =>
-        saveOperations.push(storageManager.writeJson(key, value))
-      );
-      forEach(result.screenshots, (value, index) =>
-        saveOperations.push(
-          storageManager.writeData(`screenshot-${index}.png`, value)
-        )
-      );
-
       return Promise.all(saveOperations).then(() => {
         log.info(
           'Wrote data to %s',

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -28,6 +28,7 @@ const xvfb = require('../support/video/xvfb');
 const extensionServer = require('../support/extensionServer');
 const engineUtils = require('../support/engineUtils');
 const chromeCPU = require('../support/chromeCPU');
+const forEach = require('lodash.foreach');
 
 const defaults = {
   scripts: [],
@@ -52,8 +53,6 @@ class Engine {
     this.collectChromeTimeline =
       options.chrome &&
       options.chrome.collectTracingEvents &&
-      options.chrome.traceCategories &&
-      options.chrome.traceCategories.indexOf('devtools.timeline') > -1 &&
       options.chrome.collectCPUMetrics;
     this.isAndroid = get(options, 'chrome.android.package', false);
     this.recordVideo = options.speedIndex || options.video;
@@ -348,12 +347,11 @@ class Engine {
 
     const iterations = new Array(this.options.iterations),
       runDelegate = this.runDelegate;
+    const statistics = new Statistics();
 
     return Promise.resolve({
       timestamps: [],
       browserScripts: [],
-      screenshots: [],
-      extraJson: {},
       info: {},
       visualMetrics: [],
       cpu: []
@@ -374,19 +372,73 @@ class Engine {
               this.preScripts,
               this.postScripts
             ).then(iterationData => {
+              // From each run, collect the result we want
               results.timestamps.push(iterationData.timestamp);
               results.browserScripts.push(iterationData.browserScripts);
-              if (iterationData.screenshot) {
-                results.screenshots.push(iterationData.screenshot);
-              }
+              // Add all browserscripts to the stats
+              statistics.addDeep(
+                iterationData.browserScripts,
+                (keyPath, value) => {
+                  if (keyPath.endsWith('userTimings.marks')) {
+                    return value.reduce((result, mark) => {
+                      result[mark.name] = mark.startTime;
+                      return result;
+                    }, {});
+                  } else if (keyPath.endsWith('userTimings.measure')) {
+                    return value.reduce((result, mark) => {
+                      result[mark.name] = mark.duration;
+                      return result;
+                    }, {});
+                  } else if (keyPath.endsWith('resourceTimings')) {
+                    return {};
+                  }
+                  return value;
+                }
+              );
+
               if (iterationData.visualMetrics) {
                 results.visualMetrics.push(iterationData.visualMetrics);
+                statistics.addDeep({
+                  visualMetrics: iterationData.visualMetrics
+                });
               }
-              results.extraJson = merge(
-                results.extraJson,
-                iterationData.extraJson
+              const extraWork = [];
+              if (options.screenshot) {
+                extraWork.push(
+                  storageManager.writeData(
+                    `screenshot-${runIndex}.png`,
+                    iterationData.screenshot
+                  )
+                );
+              }
+
+              // Collect CPU data. There are some extra work going on here now
+              // in the future we could use the already stored trace log
+              // but let us change that later on
+              if (collectChromeTimeline) {
+                extraWork.push(
+                  chromeCPU
+                    .get(
+                      iterationData.extraJson[`trace-${runIndex}.json`],
+                      storageManager.baseDir,
+                      runIndex
+                    )
+                    .then(timelinesArray => {
+                      result.cpu.push(timelinesArray);
+                      statistics.addDeep({ cpu: timelinesArray });
+                      return Promise.resolve();
+                    })
+                );
+              }
+
+              // Store all extra JSON metrics
+              forEach(iterationData.extraJson, (value, key) =>
+                extraWork.push(storageManager.writeJson(key, value))
               );
-              return results;
+
+              return Promise.all(extraWork).then(() => {
+                return results;
+              });
             });
 
             if (shouldDelay(runIndex, totalRuns)) {
@@ -400,51 +452,7 @@ class Engine {
       )
       .tap(result => this.runDelegate.onStopRun(result))
       .tap(result => {
-        if (collectChromeTimeline) {
-          const parsingTimelines = [];
-          for (let i = 0; i < this.options.iterations; i++) {
-            parsingTimelines.push(
-              chromeCPU.get(
-                result.extraJson[`trace-${i}.json`],
-                storageManager.baseDir,
-                i
-              )
-            );
-          }
-          return Promise.all(parsingTimelines).then(
-            timelinesArray => (result.cpu = timelinesArray)
-          );
-        }
-      })
-      .tap(result => {
-        const statistics = new Statistics();
-        result.browserScripts.forEach(data =>
-          statistics.addDeep(data, (keyPath, value) => {
-            if (keyPath.endsWith('userTimings.marks')) {
-              return value.reduce((result, mark) => {
-                result[mark.name] = mark.startTime;
-                return result;
-              }, {});
-            } else if (keyPath.endsWith('userTimings.measure')) {
-              return value.reduce((result, mark) => {
-                result[mark.name] = mark.duration;
-                return result;
-              }, {});
-            } else if (keyPath.endsWith('resourceTimings')) {
-              return {};
-            }
-
-            return value;
-          })
-        );
-        result.visualMetrics.forEach(data =>
-          statistics.addDeep({ visualMetrics: data })
-        );
-
-        if (collectChromeTimeline) {
-          result.cpu.forEach(data => statistics.addDeep({ cpu: data }));
-        }
-
+        // add the options metrics we want
         result.statistics = statistics.summarizeDeep(options);
       })
       .tap(result => {


### PR DESCRIPTION
…uns)

We want to make Browsertime as mean and clean as possible: Store all
extra JSONs (chrome trace categories, console log and more), and
the screenshots between runs (before they where stored on exit).
This is good because it will decrease the memory impact but it is a
non backward compatible change! Sitespeed.io and other tools need to
change how they handle extra JSONs and the screenshot.

I've also moved most stats to be collected between runs, that is
needed for CPU stats since we store the data and throws it away
between runs.