### PR TITLE
Create a unique Chromedriver log per run

### DIFF
--- a/lib/core/webdriver/chrome.js
+++ b/lib/core/webdriver/chrome.js
@@ -84,7 +84,7 @@ module.exports.configureBuilder = function(builder, options) {
 
     let serviceBuilder = new chrome.ServiceBuilder(chromedriverPath);
     if (options.verbose >= 2) {
-      serviceBuilder.loggingTo('./chromedriver.log');
+      serviceBuilder.loggingTo(`./chromedriver-${options.index}.log`);
       if (options.verbose >= 3) serviceBuilder.enableVerboseLogging();
     }
     chrome.setDefaultService(serviceBuilder.build());


### PR DESCRIPTION
This makes it easier when we file bug reports about the Chromedriver.
Next step is to remove options.index, options should be handled
as immutable so we should pass on the runIndex in another way.