### PR TITLE
Add ability to take a screenshot in error case for verbose > 1

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -302,6 +302,23 @@ class Engine {
             return postScript.run(taskOptions);
           })
         )
+        .catch(function(e) {
+          if (options.verbose >= 1) {
+            runner
+              .takeScreenshot()
+              .tap(pngData =>
+                storageManager.writeData(
+                  'error_screen_for_run_' + (index + 1) + '.png',
+                  pngData
+                )
+              )
+              .catch(BrowserError, e => {
+                // not getting screenshots shouldn't result in a failed test.
+                log.warning(e);
+              });
+          }
+          throw e;
+        })
         .finally(() => runner.stop());
     }
 


### PR DESCRIPTION
In case when you disable screenshots and videos for test (for some reason in my case ffmpeg use a lot off resources on my VM) you maybe want to have screenshots in error case for understanding 'what happens during my test execution that produced an error'