### PR TITLE
More descriptive name for cpu trace parser func.

### DIFF
--- a/lib/chrome/cpu.js
+++ b/lib/chrome/cpu.js
@@ -70,7 +70,7 @@ const mapTimings = {
 };
 
 module.exports = {
-  get(tracelog, dir, no) {
+  async parseCpuTrace(tracelog, dir, no) {
     const tmpFile = path.join(dir, `tmp-${no}.json`);
     const cpuOutputFile = path.join(dir, `cpu-${no}.json`);
     const scriptArgs = ['-t', tmpFile, '-c', cpuOutputFile];

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -4,7 +4,7 @@ const get = require('lodash.get');
 const version = require('../../../package').version;
 const engineUtils = require('../../support/engineUtils');
 const log = require('intel');
-const chromeCPU = require('../../chrome/cpu');
+const { parseCpuTrace } = require('../../chrome/cpu');
 const Statistics = require('../../support/statistics').Statistics;
 const ScreenshotManager = require('../../screenshot/');
 
@@ -52,6 +52,7 @@ class Collector {
     this.results.statistics = this.statistics.summarizeDeep(this.options);
     return this.results;
   }
+
   /**
    * Collect all individual runs, add it to the statistics, and store
    * data that needs to be on disk (trace logs, sceenshots etc).
@@ -113,17 +114,15 @@ class Collector {
     // but let us change that later on
     if (this.collectChromeTimeline) {
       extraWork.push(
-        chromeCPU
-          .get(
-            data.extraJson[`trace-${index}.json`],
-            this.storageManager.baseDir,
-            index
-          )
-          .then(timelinesArray => {
-            results.cpu.push(timelinesArray);
-            statistics.addDeep({ cpu: timelinesArray });
-            return Promise.resolve();
-          })
+        parseCpuTrace(
+          data.extraJson[`trace-${index}.json`],
+          this.storageManager.baseDir,
+          index
+        ).then(timelinesArray => {
+          results.cpu.push(timelinesArray);
+          statistics.addDeep({ cpu: timelinesArray });
+          return Promise.resolve();
+        })
       );
     }
 


### PR DESCRIPTION
Rename function to ”parseCpuTrace” from just ”get” to avoid confusion with the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get syntax.