### PR TITLE
Simplify chrome trace log parsing.

### DIFF
--- a/lib/chrome/cpu.js
+++ b/lib/chrome/cpu.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const fs = require('fs'),
-  path = require('path'),
-  Promise = require('bluebird'),
-  execa = require('execa');
+const fs = require('fs');
+const path = require('path');
+const Promise = require('bluebird');
+const execa = require('execa');
+const log = require('intel');
 
 Promise.promisifyAll(fs);
 
@@ -69,51 +70,56 @@ const mapTimings = {
   Idle: 'Idle'
 };
 
+async function deleteIfPossible(file) {
+  try {
+    return fs.unlinkAsync(file);
+  } catch (e) {
+    log.warning(e);
+  }
+}
+
 module.exports = {
   async parseCpuTrace(tracelog, dir, no) {
+    // To get this to work we:
+    // Store the trace log file to disk
+    // Let the trace-parser script parse the file to a new file
+    // Read the new file and parse what we need to JSON
+    // And then remove the tmp files.
     const tmpFile = path.join(dir, `tmp-${no}.json`);
     const cpuOutputFile = path.join(dir, `cpu-${no}.json`);
-    const scriptArgs = ['-t', tmpFile, '-c', cpuOutputFile];
 
+    let cpu;
+
+    try {
+      await fs.writeFileAsync(tmpFile, JSON.stringify(tracelog));
+      await execa(SCRIPT_PATH, ['-t', tmpFile, '-c', cpuOutputFile]);
+      cpu = await fs.readFileAsync(cpuOutputFile);
+    } finally {
+      await deleteIfPossible(tmpFile);
+      await deleteIfPossible(cpuOutputFile);
+    }
+
+    const { main_thread, slices } = JSON.parse(cpu);
+    const mainThreadTimings = slices[main_thread];
+
+    const events = {};
     const categories = {
       Painting: 0,
       Loading: 0,
       Layout: 0,
       Scripting: 0
     };
-    const events = {};
-    // To get this to work we:
-    // Store the trace log file to disk
-    // Let the trace-parser script parse the file to a new file
-    // Read the new file and parse what we need to JSON
-    // And then remove the tmp files.
-    return fs.writeFileAsync(tmpFile, JSON.stringify(tracelog)).then(() => {
-      return execa(SCRIPT_PATH, scriptArgs).then(() => {
-        return fs
-          .readFileAsync(cpuOutputFile)
-          .then(cpu => {
-            const jsonTrace = JSON.parse(cpu);
-            const mainThread = jsonTrace.main_thread;
-            const mainThreadTimings = jsonTrace.slices[mainThread];
 
-            for (const key of Object.keys(mainThreadTimings)) {
-              let total = 0;
-              for (const val of mainThreadTimings[key]) {
-                total = total + val;
-              }
-              const type = mapTimings[key];
-              if (type) {
-                categories[type] = categories[type] + total / 1000;
-                events[key] = total / 1000;
-              }
-            }
-            return { categories, events };
-          })
-          .tap(() => {
-            fs.unlinkAsync(tmpFile).then(() => fs.unlinkAsync(cpuOutputFile));
-          })
-          .tap(result => result);
-      });
-    });
+    for (const [eventName, samples] of Object.entries(mainThreadTimings)) {
+      let milliSeconds = samples.reduce((sum, time) => sum + time) / 1e3;
+
+      const type = mapTimings[eventName];
+      if (type) {
+        categories[type] += milliSeconds;
+        events[eventName] = milliSeconds;
+      }
+    }
+
+    return { categories, events };
   }
 };

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -62,6 +62,7 @@ class Collector {
   perIteration(data, index) {
     const results = this.results;
     const statistics = this.statistics;
+    // FIXME should this add when there's no errors?
     results.errors.push(data.error);
     // From each iteration, collect the result we want
     results.timestamps.push(data.timestamp);
@@ -118,11 +119,15 @@ class Collector {
           data.extraJson[`trace-${index}.json`],
           this.storageManager.baseDir,
           index
-        ).then(timelinesArray => {
-          results.cpu.push(timelinesArray);
-          statistics.addDeep({ cpu: timelinesArray });
-          return Promise.resolve();
-        })
+        )
+          .then(timelineData => {
+            results.cpu.push(timelineData);
+            statistics.addDeep({ cpu: timelineData });
+          })
+          .catch(e => {
+            log.warning('Failed to parse CPU usage from Chrome.', e);
+            throw e;
+          })
       );
     }
 


### PR DESCRIPTION
Use async/await instead of deep promise chains, to make code more readable.