### PR TITLE
Don't alter the options object.

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -7,7 +7,6 @@ const log = require('intel');
 
 class Android {
   constructor(options) {
-    this.baseDir = options.baseDir;
     this.client = adb.createClient();
     this.id = get(options, 'chrome.android.deviceSerial');
   }
@@ -44,9 +43,9 @@ class Android {
     return this._runCommand(`rm ${this.sdcard}/${file}`);
   }
 
-  async pullNetLog(index) {
-    const sourcePath = `${this.sdcard}/chromeNetlog-${index}.json`;
-    const destinationPath = `${this.baseDir}/chromeNetlog-${index}.json`;
+  async pullNetLog(index, baseDir) {
+    const sourcePath = `${this.sdcard}/chromeNetlog.json`;
+    const destinationPath = `${baseDir}/chromeNetlog-${index}.json`;
     log.info(`Pulling netlog from ${this.id}`);
 
     return this._downloadFile(sourcePath, destinationPath);

--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -43,12 +43,11 @@ class Android {
     return this._runCommand(`rm ${this.sdcard}/${file}`);
   }
 
-  async pullNetLog(index, baseDir) {
+  async pullNetLog(destination) {
     const sourcePath = `${this.sdcard}/chromeNetlog.json`;
-    const destinationPath = `${baseDir}/chromeNetlog-${index}.json`;
     log.info(`Pulling netlog from ${this.id}`);
 
-    return this._downloadFile(sourcePath, destinationPath);
+    return this._downloadFile(sourcePath, destination);
   }
 
   async startVideo() {

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -1,10 +1,14 @@
 'use strict';
 
 const log = require('intel');
+const { promisify } = require('util');
 const { Type } = require('selenium-webdriver').logging;
 const harBuilder = require('../../support/har/');
 const perflogParser = require('chrome-har');
+const fs = require('fs');
 const traceCategoriesParser = require('../traceCategoriesParser');
+
+const rename = promisify(fs.rename);
 
 const CHROME_NAME_AND_VERSION_JS = `return (function() {
   var match = navigator.userAgent.match(/(Chrom(e|ium))\\/(([0-9]+\\.?)*)/);
@@ -21,11 +25,12 @@ const CHROME_NAME_AND_VERSION_JS = `return (function() {
 const PAGE_TITLE_JS = 'return document.title;';
 
 class ChromeDelegate {
-  constructor({ skipHar = false, chrome = {} }) {
+  constructor(baseDir, { skipHar = false, chrome = {} }) {
     this.skipHar = skipHar;
     this.logPerfEntries = !!chrome.collectPerfLog;
     this.collectTracingEvents = !!chrome.collectTracingEvents;
     this.chrome = chrome;
+    this.baseDir = baseDir;
   }
 
   async onStartRun() {
@@ -80,6 +85,13 @@ class ChromeDelegate {
     }
 
     this.hars.push(har);
+
+    if (this.chrome.collectNetLog && !this.chrome.android) {
+      await rename(
+        `${this.baseDir}/chromeNetlog.json`,
+        `${this.baseDir}/chromeNetlog-${index}.json`
+      );
+    }
   }
 
   async onStopRun(result) {

--- a/lib/chrome/webdriver/index.js
+++ b/lib/chrome/webdriver/index.js
@@ -20,7 +20,7 @@ const defaultTimelineTraceCategories =
  * @param builder
  * @param {Object} options the options for a web driver.
  */
-module.exports.configureBuilder = function(builder, options) {
+module.exports.configureBuilder = function(builder, baseDir, options) {
   const chromeConfig = options.chrome || {};
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 
@@ -33,7 +33,7 @@ module.exports.configureBuilder = function(builder, options) {
 
     let serviceBuilder = new chrome.ServiceBuilder(chromedriverPath);
     if (options.verbose >= 2) {
-      serviceBuilder.loggingTo(`${options.baseDir}/chromedriver.log`);
+      serviceBuilder.loggingTo(`${baseDir}/chromedriver.log`);
       if (options.verbose >= 3) serviceBuilder.enableVerboseLogging();
     }
     chrome.setDefaultService(serviceBuilder.build());
@@ -104,10 +104,8 @@ module.exports.configureBuilder = function(builder, options) {
 
   if (chromeConfig.collectNetLog) {
     // FIXME this shouldn't hard code path to external storage
-    const dir = !chromeConfig.android ? options.baseDir : '/sdcard';
-    chromeOptions.addArguments(
-      `--log-net-log=${dir}/chromeNetlog-${options.index}.json`
-    );
+    const dir = !chromeConfig.android ? baseDir : '/sdcard';
+    chromeOptions.addArguments(`--log-net-log=${dir}/chromeNetlog.json`);
     chromeOptions.addArguments('--net-log-capture-mode=0');
   }
 

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -55,10 +55,6 @@ class Engine {
     this.myXVFB = new XVFB(this.options);
     this.myExtensionServer = new ExtensionServer(this.options);
     this.options.viewPort = engineUtils.calculateViewport(this.options);
-    this.engineDelegate =
-      options.browser === 'firefox'
-        ? new FirefoxDelegate(options)
-        : new ChromeDelegate(options);
   }
 
   /**
@@ -84,7 +80,10 @@ class Engine {
   async run(url, scriptsByCategory, asyncScriptsByCategory) {
     const options = this.options;
     const storageManager = new StorageManager(url, options);
-    const engineDelegate = this.engineDelegate;
+    const engineDelegate =
+      this.options.browser === 'firefox'
+        ? new FirefoxDelegate(storageManager.directory, this.options)
+        : new ChromeDelegate(storageManager.directory, this.options);
     const collector = new Collector(url, storageManager, options);
     const iteration = new Iteration(
       storageManager,
@@ -94,10 +93,8 @@ class Engine {
       asyncScriptsByCategory,
       options
     );
-
-    // FIXME We shouldn't alter options
-    options.baseDir = await storageManager.createDataDir();
     try {
+      await storageManager.createDataDir();
       await engineDelegate.onStartRun(url, options);
 
       for (let index = 0; index < options.iterations; index++) {

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -155,7 +155,9 @@ class Iteration {
       if (isAndroidConfigured(options) && options.chrome.collectNetLog) {
         const android = createAndroidConnection(options);
         await android.initConnection();
-        await android.pullNetLog(index, this.storageManager.directory);
+        await android.pullNetLog(
+          `${this.storageManager.directory}/chromeNetlog-${index}.json`
+        );
       }
 
       await this.engineDelegate.onStopIteration(browser, index, result);

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -55,7 +55,10 @@ class Iteration {
    */
   async run(url, index) {
     const options = this.options;
-    const browser = new SeleniumRunner(this.options);
+    const browser = new SeleniumRunner(
+      this.storageManager.directory,
+      this.options
+    );
     const extensionServer = this.extensionServer;
     const recordVideo = this.recordVideo;
     const combine = options.videoParams.combine;
@@ -73,8 +76,6 @@ class Iteration {
         return browser.runWithDriver(driverScript);
       }
     };
-    // we need to get rid off this HACK since it do not work
-    this.options.index = index;
 
     const result = {
       extraJson: {}
@@ -154,7 +155,7 @@ class Iteration {
       if (isAndroidConfigured(options) && options.chrome.collectNetLog) {
         const android = createAndroidConnection(options);
         await android.initConnection();
-        await android.pullNetLog(index);
+        await android.pullNetLog(index, this.storageManager.directory);
       }
 
       await this.engineDelegate.onStopIteration(browser, index, result);

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -53,8 +53,9 @@ async function timeout(promise, ms, errorMessage) {
  * @class
  */
 class SeleniumRunner {
-  constructor(options) {
+  constructor(baseDir, options) {
     this.options = merge({}, defaults, options);
+    this.baseDir = baseDir;
   }
 
   /**
@@ -68,7 +69,7 @@ class SeleniumRunner {
     for (let i = 0; i < tries; ++i) {
       try {
         this.driver = await timeout(
-          builder.createWebDriver(this.options),
+          builder.createWebDriver(this.baseDir, this.options),
           this.options.timeouts.browserStart,
           `Failed to start browser in ${this.options.timeouts.browserStart /
             1000} seconds.`

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -12,7 +12,7 @@ let Promise = require('bluebird'),
  * @returns {!Promise<webdriver.WebDriver>} a promise that resolves to the webdriver,
  * or rejects if the current configuration is invalid.
  */
-module.exports.createWebDriver = async function(options) {
+module.exports.createWebDriver = async function(baseDir, options) {
   const browser = options.browser || 'chrome';
   const seleniumUrl = options.selenium ? options.selenium.url : undefined;
   const capabilities = options.selenium
@@ -31,11 +31,11 @@ module.exports.createWebDriver = async function(options) {
 
   switch (browser) {
     case 'chrome':
-      chrome.configureBuilder(builder, options);
+      chrome.configureBuilder(builder, baseDir, options);
       break;
 
     case 'firefox':
-      firefox.configureBuilder(builder, options);
+      firefox.configureBuilder(builder, baseDir, options);
       break;
 
     default:

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -2,23 +2,28 @@
 
 const harBuilder = require('../../support/har/');
 const log = require('intel');
+const fs = require('fs');
+const { promisify } = require('util');
+const rename = promisify(fs.rename);
+
 class FirefoxDelegate {
-  constructor(options) {
+  constructor(baseDir, options) {
     // Lets keep this and hope that we in the future will have HAR for FF again
     this.skipHar = options.skipHar;
+    this.baseDir = baseDir;
     this.includeResponseBodies = options.firefox
       ? options.firefox.includeResponseBodies
       : 'none';
+    this.firefoxConfig = options.firefox || {};
   }
 
   async onStartRun() {
-    this.index = 1;
     this.hars = [];
   }
 
   async onStartIteration() {}
 
-  async onStopIteration(runner) {
+  async onStopIteration(runner, index) {
     if (this.skipHar) {
       return;
     }
@@ -67,7 +72,13 @@ class FirefoxDelegate {
     } else {
       log.info('You need Firefox 60 (or later) to get the HAR.');
     }
-    this.index++;
+
+    if (this.firefoxConfig.collectMozLog) {
+      await rename(
+        `${this.baseDir}/moz_log.txt`,
+        `${this.baseDir}/moz_log-${index}.txt`
+      );
+    }
   }
 
   async onStopRun(result) {

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -11,7 +11,7 @@ const get = require('lodash.get');
 const geckodriver = require('soprano-saxophone').geckodriver;
 const defaultFirefoxPreferences = require('./firefoxPreferences');
 
-module.exports.configureBuilder = function(builder, options) {
+module.exports.configureBuilder = function(builder, baseDir, options) {
   const firefoxConfig = options.firefox || {};
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 
@@ -28,10 +28,8 @@ module.exports.configureBuilder = function(builder, options) {
 
   if (firefoxConfig.collectMozLog) {
     process.env.MOZ_LOG =
-      'timestamp,rotate:200,nsHttp:5,cache2:5,nsSocketTransport:5,nsHostResolver:5';
-    process.env.MOZ_LOG_FILE = `${options.baseDir}/moz_log-${
-      options.index
-    }.txt`;
+      'timestamp,nsHttp:5,cache2:5,nsSocketTransport:5,nsHostResolver:5';
+    process.env.MOZ_LOG_FILE = `${baseDir}/moz_log.txt`;
   }
 
   // try to remove the caching between runs

--- a/test/browserTests/seleniumRunnerTests.js
+++ b/test/browserTests/seleniumRunnerTests.js
@@ -3,6 +3,7 @@
 const SeleniumRunner = require('../../lib/core/seleniumRunner');
 
 const BROWSERS = [];
+const BASE_PATH = '/tmp/';
 
 if (process.env.BROWSERTIME_TEST_BROWSER) {
   BROWSERS.push(process.env.BROWSERTIME_TEST_BROWSER);
@@ -30,7 +31,7 @@ describe('SeleniumRunner', function() {
 
   describe('#start', function() {
     it('should reject when passed incorrect configuration', function() {
-      runner = new SeleniumRunner({
+      runner = new SeleniumRunner(BASE_PATH, {
         browser: 'invalid'
       });
       return runner.start().should.be.rejected;
@@ -38,7 +39,7 @@ describe('SeleniumRunner', function() {
 
     if (BROWSERS.includes('chrome')) {
       it.skip('should handle if Chrome crashes', function() {
-        runner = new SeleniumRunner({
+        runner = new SeleniumRunner(BASE_PATH, {
           browser: 'chrome',
           chrome: {
             args: '--crash-test'
@@ -57,7 +58,7 @@ describe('SeleniumRunner', function() {
   BROWSERS.forEach(function(browser) {
     describe('#loadAndWait - ' + browser, function() {
       beforeEach(function() {
-        runner = new SeleniumRunner({
+        runner = new SeleniumRunner(BASE_PATH, {
           browser: browser,
           timeouts: {
             browserStart: 60000,
@@ -179,7 +180,7 @@ describe('SeleniumRunner', function() {
 
     describe('#takeScreenshot - ' + browser, function() {
       beforeEach(function() {
-        runner = new SeleniumRunner({
+        runner = new SeleniumRunner(BASE_PATH, {
           browser: browser,
           timeouts: {
             browserStart: 60000,


### PR DESCRIPTION
Remove options.index and options.baseDir. As an extra bonus, we now create one MOZ-log and Chrome net-log per run, instead of having one large file.