### PR TITLE
📖 Update docs: percentile and decimal options

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -404,6 +404,17 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'Domain to block. Add multiple instances to add multiple domains that will be blocked.'
     })
+    .option('percentiles', {
+      type: 'array',
+      default: [0, 10, 90, 99, 100],
+      describe:
+        'The percentile values within the data browsertime will calculate and report.'
+    })
+    .option('decimals', {
+      type: 'number',
+      default: 0,
+      describe: 'The decimal points browsertime statistics round to.'
+    })
     .option('cacheClearRaw', {
       describe:
         'Use internal browser functionality to clear browser cache between runs instead of only using Selenium.',


### PR DESCRIPTION
When I needed to reduce the number of metrics sending to Graphite, I've seen the option to apply by own set of percentiles that was not documented. This is the documentation for it, and for the decimals option as well.