### PR TITLE
Remove unneeded pip upgrade in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ addons:
     - xz-utils
   firefox: 'latest-nightly'
 before_install:
-- pip install --user --upgrade pip
 - pip --version
 - pip install --user Pillow
 - pip install --user pyssim


### PR DESCRIPTION
This step frequently fails in the Travis build, and shouldn’t be needed anyway.