### PR TITLE
Make it easier for users to choose when to end the tests

### DIFF
--- a/lib/core/defaultPageCompleteCheck.js
+++ b/lib/core/defaultPageCompleteCheck.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = `
+return (function() {
+    try { 
+        var end = window.performance.timing.loadEventEnd;
+        return (end > 0) && (Date.now() > end + 2000);
+    } catch(e) {
+        return true;
+    }
+})();
+`;

--- a/lib/core/pageCompleteCheckByInactivity.js
+++ b/lib/core/pageCompleteCheckByInactivity.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = `
+return (function() {
+  const timing = window.performance.timing;
+  const p = window.performance;
+  const limit = 2000;
+
+  if (timing.loadEventEnd === 0) {
+    return false;
+  }
+
+  let lastEntry = null;
+  const resourceTimings = p.getEntriesByType('resource');
+  if (resourceTimings.length > 0) {
+    lastEntry = resourceTimings.pop();
+    // This breaks getting resource timings so ...
+    p.clearResourceTimings();
+  }
+
+  const loadTime = timing.loadEventEnd - timing.navigationStart;
+
+  if (!lastEntry || lastEntry.responseEnd < loadTime) {
+    return p.now() - loadTime > limit;
+  } else {
+    return p.now() - lastEntry.responseEnd > limit;
+  }
+})();
+`;

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -9,9 +9,9 @@ const log = require('intel'),
   BrowserError = require('../support/errors').BrowserError,
   getViewPort = require('../support/getViewPort');
 
-const defaultPageCompleteCheck =
-  'return (function() {try { var end = window.performance.timing.loadEventEnd;' +
-  'return (end > 0) && (Date.now() > end + 2000);} catch(e) {return true;}})()';
+const defaultPageCompleteCheck = require('./defaultPageCompleteCheck');
+const pageCompleteCheckByInactivity = require('./pageCompleteCheckByInactivity');
+
 const defaults = {
   timeouts: {
     browserStart: 60000,
@@ -126,7 +126,12 @@ class SeleniumRunner {
    * @param {string} pageCompleteCheck - JavaScript that checks if the page has finished loading
    * @throws {UrlLoadError}
    */
-  async loadAndWait(url, pageCompleteCheck = defaultPageCompleteCheck) {
+  async loadAndWait(url, pageCompleteCheck) {
+    if (!pageCompleteCheck) {
+      pageCompleteCheck = this.options.pageCompleteCheckInactivity
+        ? pageCompleteCheckByInactivity
+        : defaultPageCompleteCheck;
+    }
     let driver = this.driver,
       pageCompleteCheckTimeout = this.options.timeouts.pageCompleteCheck;
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -312,7 +312,13 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('pageCompleteCheck', {
       describe:
-        'Supply a Javascript that decides when the browser is finished loading the page and can start to collect metrics. The Javascript snippet is repeatedly queried to see if page has completed loading (indicated by the script returning true). Use it to fetch timings happening after the loadEventEnd.'
+        'Supply a JavaScript that decides when the browser is finished loading the page and can start to collect metrics. The JavaScript snippet is repeatedly queried to see if page has completed loading (indicated by the script returning true). Use it to fetch timings happening after the loadEventEnd. By default the tests ends 2 seconds after loadEventEnd. Also checkout --pageCompleteCheckInactivity'
+    })
+    .option('pageCompleteCheckInactivity', {
+      describe:
+        'Alternative way to choose when to end your test. This will wait for 2 seconds of inactivity that happens after loadEventEnd.',
+      type: 'boolean',
+      default: false
     })
     .option('iterations', {
       alias: 'n',


### PR DESCRIPTION
Lets make it easy to configure tests to end when we don't have any activity on the wire. Instead of https://github.com/sitespeedio/browsertime/pull/498