### PR TITLE
Wait longer before Firefox has navigatated

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -152,7 +152,8 @@ class SeleniumRunner {
       await driver.executeScript(navigate);
       // artificially wait until we start to check if the browser
       // finished loading because the browser needs to start navigating first
-      await delay(1000);
+      // it seems that for Firefox this can take longer time to actually navigate
+      await delay(this.options.browser === 'firefox' ? 3000 : 1000);
       const pageCompleteCheckCondition = new Condition(
         'for page complete check script to return true',
         function(d) {
@@ -180,7 +181,10 @@ class SeleniumRunner {
       const uri = await driver.executeScript('return document.documentURI;');
       // Verify that the page succesfully loaded
       if (!uri.match(/^http(s)?:\/\//i)) {
-        throw new UrlLoadError('Failed to load/verify ' + url, url);
+        throw new UrlLoadError(
+          'Failed to load/verify ' + url + ' uri:' + uri,
+          url
+        );
       }
     }
   }


### PR DESCRIPTION
It seems like Firefox on Linux take longer time than Chrome to navigate.
We wait 1s for Chrome and now 3s for Firefox.

See: https://github.com/sitespeedio/sitespeed.io/issues/2040