### PR TITLE
Run the HAR export trigger only on 61 or later

### DIFF
--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -64,7 +64,7 @@ class FirefoxDelegate {
     const match = ua.match(/(Firefox)\/(\S+)/);
     const version = Number(match[2]);
 
-    if (version === 60 || version > 60) {
+    if (version > 60) {
       log.info('Waiting on har-export-trigger to collect the HAR');
       try {
         const harResult = await runner.runAsyncScript(script, 'GET_HAR_SCRIPT');
@@ -96,7 +96,7 @@ class FirefoxDelegate {
         log.error('Could not get the HAR from Firefox', e);
       }
     } else {
-      log.info('You need Firefox 60 (or later) to get the HAR.');
+      log.info('You need Firefox 61 (or later) to get the HAR.');
     }
   }
 


### PR DESCRIPTION
Using the official version of the HAR export trigger needs FF 61, so let us not run the plugin on 60.