### PR TITLE
Added PCAP trace capture feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY docker/webpagereplay/deterministic.js /webpagereplay/scripts/deterministic.
 COPY docker/webpagereplay/LICENSE /webpagereplay/
 
 RUN sudo apt-get update && sudo apt-get install libnss3-tools \
-  net-tools -y && \
+  net-tools tcpdump -y && \
   mkdir -p $HOME/.pki/nssdb && \
   certutil -d $HOME/.pki/nssdb -N
 

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -9,6 +9,7 @@ const setResourceTimingBufferSize = require('../../support/setResourceTimingBuff
 const filterWhitelisted = require('../../support/userTiming').filterWhitelisted;
 const engineUtils = require('../../support/engineUtils');
 const Video = require('../../video/video');
+const TCPDUMP = require('../../support/tcpdump');
 const setOrangeBackground = require('../../video/screenRecording/setOrangeBackground');
 const stop = require('../../support/stop');
 const {
@@ -89,6 +90,11 @@ class Iteration {
 
     log.info('Testing url %s iteration %s', url, index);
     try {
+
+      // Start TCPDUMP
+      const myTCPDUMP = new TCPDUMP(this.storageManager.directory, this.options, index);
+      myTCPDUMP.start();
+
       await browser.start();
       await setResourceTimingBufferSize(browser.getDriver(), 600);
       await extensionServer.setupExtension(url, browser);
@@ -185,9 +191,18 @@ class Iteration {
       if (recordVideo) {
         await video.postProcessing(result);
       }
+
+      // Stop TCPDUMP
+      myTCPDUMP.stop();
+
       return result;
     } catch (e) {
       log.error(e);
+
+      // Stop TCPDUMP in case of error
+      if (myTCPDUMP)
+        myTCPDUMP.stop();
+
       // Take a screenshot in error case for verbose > 1
       if (options.verbose >= 1) {
         try {

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -88,11 +88,16 @@ class Iteration {
       await video.setupDirs(index);
     }
 
+    // Instantiate a TCPDUMP instance
+    const myTCPDUMP = new TCPDUMP(
+      this.storageManager.directory,
+      this.options,
+      index
+    );
+
     log.info('Testing url %s iteration %s', url, index);
     try {
-
       // Start TCPDUMP
-      const myTCPDUMP = new TCPDUMP(this.storageManager.directory, this.options, index);
       myTCPDUMP.start();
 
       await browser.start();
@@ -200,8 +205,7 @@ class Iteration {
       log.error(e);
 
       // Stop TCPDUMP in case of error
-      if (myTCPDUMP)
-        myTCPDUMP.stop();
+      if (myTCPDUMP) myTCPDUMP.stop();
 
       // Take a screenshot in error case for verbose > 1
       if (options.verbose >= 1) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -487,6 +487,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
       default: false,
       describe: 'Start xvfb before the browser is started'
     })
+    .option('pcap', {
+      type: 'boolean',
+      default: false,
+      describe: 'Capture traffic trace during the navigation. If running as normal user, tcpdump bin must have the SUID bit set.'
+    })
     .option('xvfbParams.display', {
       default: videoDefaults.xvfbDisplay,
       describe: 'The display used for xvfb'

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -490,7 +490,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .option('pcap', {
       type: 'boolean',
       default: false,
-      describe: 'Capture traffic trace during the navigation. If running as normal user, tcpdump bin must have the SUID bit set.'
+      describe:
+        'Capture traffic trace during the navigation. If running as normal user, tcpdump bin must have the SUID bit set.'
     })
     .option('xvfbParams.display', {
       default: videoDefaults.xvfbDisplay,

--- a/lib/support/tcpdump.js
+++ b/lib/support/tcpdump.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { spawn } = require('child_process');
+const get = require('lodash.get');
+const mkdirp = require('mkdirp');
+
+/**
+ * Create a new TCPDUMP instance
+ * @class
+ */
+class TCPDUMP {
+  constructor(directory, options, iteration) {
+    this.directory = directory;
+    this.options = options;
+    this.iteration = iteration;
+  }
+
+  start() {
+    const useTcpDump = get(this.options, 'pcap', false);
+    if (useTcpDump === true || useTcpDump === 'true') {
+
+      // Create Capture dir
+      const capture_dir = this.directory + "/capture";
+      mkdirp(capture_dir);
+
+      // Start TcpDump
+      // Sould set suid bit with "sudo chmod +s /usr/sbin/tcpdump" if running outside docker
+      const capture_file = capture_dir + "/" + this.iteration + ".pcap";
+      this.tcpdump_process = spawn('tcpdump', ['-i', 'any', '-w', capture_file]);
+    }
+  }
+
+  stop() {
+    if (this.tcpdump_process) {
+      this.tcpdump_process.kill('SIGINT');
+    }
+  }
+}
+
+module.exports = TCPDUMP;

--- a/lib/support/tcpdump.js
+++ b/lib/support/tcpdump.js
@@ -18,15 +18,19 @@ class TCPDUMP {
   start() {
     const useTcpDump = get(this.options, 'pcap', false);
     if (useTcpDump === true || useTcpDump === 'true') {
-
       // Create Capture dir
-      const capture_dir = this.directory + "/capture";
+      const capture_dir = this.directory + '/capture';
       mkdirp(capture_dir);
 
       // Start TcpDump
       // Sould set suid bit with "sudo chmod +s /usr/sbin/tcpdump" if running outside docker
-      const capture_file = capture_dir + "/" + this.iteration + ".pcap";
-      this.tcpdump_process = spawn('tcpdump', ['-i', 'any', '-w', capture_file]);
+      const capture_file = capture_dir + '/' + this.iteration + '.pcap';
+      this.tcpdump_process = spawn('tcpdump', [
+        '-i',
+        'any',
+        '-w',
+        capture_file
+      ]);
     }
   }
 


### PR DESCRIPTION
As [previously](https://github.com/sitespeedio/browsertime/issues/591) discussed, I try a PR for the PCAP capture feature.

**How:**
* `Browsertime` starts a `tcpdump` child process that captures all traffic. So far, it captures traffic from **any** interface. It assumes that you machine/container is not doing other work, as its traffic may be captured.

**Dependencies:**
* TCPDump: the feature uses `tcpdump`. As `tcpdump` requires `root`, you need to set `SUID` bit to the `tcpdump` executable. This issue should not be present in the docker container.

**Command Line:**
* Added the `--pcap` option.

**Output:**
* This feature produces one `pcap` file per run. They are stored in the results dir under a subdirectory called `capture`. Each run creates a pcap file, named `<iteration>.pcap`.
E.g., with 3 runs I get:
```
capture/
├── 1.pcap
├── 2.pcap
└── 3.pcap
```

**Code:**
* I created a file in `lib/support` called `tcpdump.js` that is a wrapper for the `tcdump` executable
* It is called by `lib/core/engine/iteration.js` in the method `run`, to start/stop a capture at each run.

