### PR TITLE
Add support for picking up visual element timings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
 - node ./bin/browsertime.js -b chrome --skipHar -n 1 --preURL https://www.sitespeed.io/ -r header:value
   https://www.sitespeed.io/documentation/
 - node ./bin/browsertime.js -b chrome -vv --viewPort=640x480 --video --screenshot
-  --visualMetrics -n 1 --chrome.timeline --videoParams.fontPath /usr/share/fonts/truetype/ubuntu-font-family/Ubuntu-R.ttf https://www.sitespeed.io/
+  --visualMetrics -n 1 --chrome.timeline --videoParams.fontPath /usr/share/fonts/truetype/ubuntu-font-family/Ubuntu-R.ttf --visuaElements https://www.sitespeed.io/
 notifications:
   slack:
     secure: V71EkIzwOf/fZnGTGIKAIFlDyLUit4tK97VDgdV9vZ7CbvOXI1ir3lwRZ57lNqiYD8BUaX+/wKDG+LyrBMgQ4JAGgQx0mECvmOKx1+10Yg9FAkUsMTWe7GOxcVMwhpS2OfHnXwMb0FjcuVl8ovowIZqCWOLeEAYVaTWHndDm2cA=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Browsertime changelog
 ## UNRELEASED
+### Added
+* We support timings for visual elements (```--visuaElements```). Browsertime picks up the largest image and the largest H1. You can also configure your own elements ```--scriptInput.visualElements```. First let give creds to the ones that deserves it: As far as we know [Sergey Chernyshev](https://twitter.com/sergeyche) was the first one that introduced the idea of measuring individual elements in his talk [Using Heat Maps to improve Web Performance Metrics](https://www.youtube.com/watch?v=t6l9U5bC8jA). A couple of years later this was implemented by the people behind [SpeedCurve](), that later on contributed back the implementation to WebPageTest (calling it "hero"-elements). [Patrick Meenan](https://twitter.com/patmeenan) (the creator of WebPageTest) moved on the implementation to [Visual Metrics](https://github.com/WPO-Foundation/visualmetrics) that Browsertime uses to pickup visual metrics from the video. 
+
 ### Fixed
 * In some cases Chrome returns an empty HAR and that made us throw an error. This make sure the HAR has a page before we use it [#630](https://github.com/sitespeedio/browsertime/pull/630).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 * We support timings for visual elements (```--visuaElements```). Browsertime picks up the largest image and the largest H1. You can also configure your own elements ```--scriptInput.visualElements```. First let give creds to the ones that deserves it: As far as we know [Sergey Chernyshev](https://twitter.com/sergeyche) was the first one that introduced the idea of measuring individual elements in his talk [Using Heat Maps to improve Web Performance Metrics](https://www.youtube.com/watch?v=t6l9U5bC8jA). A couple of years later this was implemented by the people behind [SpeedCurve](), that later on contributed back the implementation to WebPageTest (calling it "hero"-elements). [Patrick Meenan](https://twitter.com/patmeenan) (the creator of WebPageTest) moved on the implementation to [Visual Metrics](https://github.com/WPO-Foundation/visualmetrics) that Browsertime uses to pickup visual metrics from the video. 
 
+* We also added a new feature: If you run your own custom script you can now feed it with different input by using ```--scriptInput.*```. Say you have a script named myScript you can pass on data to it with ```--scriptInput.myScript 'super-secret-string' ```.
+
 ### Fixed
 * In some cases Chrome returns an empty HAR and that made us throw an error. This make sure the HAR has a page before we use it [#630](https://github.com/sitespeedio/browsertime/pull/630).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY docker/webpagereplay/deterministic.js /webpagereplay/scripts/deterministic.
 COPY docker/webpagereplay/LICENSE /webpagereplay/
 
 RUN sudo apt-get update && sudo apt-get install libnss3-tools \
-  net-tools fonts-noto* -y && \
+  net-tools -y && \
   mkdir -p $HOME/.pki/nssdb && \
   certutil -d $HOME/.pki/nssdb -N
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY docker/webpagereplay/deterministic.js /webpagereplay/scripts/deterministic.
 COPY docker/webpagereplay/LICENSE /webpagereplay/
 
 RUN sudo apt-get update && sudo apt-get install libnss3-tools \
-  net-tools -y && \
+  net-tools fonts-noto* -y && \
   mkdir -p $HOME/.pki/nssdb && \
   certutil -d $HOME/.pki/nssdb -N
 

--- a/browserscripts/pageinfo/visualElements.js
+++ b/browserscripts/pageinfo/visualElements.js
@@ -1,0 +1,105 @@
+(function (custom) {
+    /**
+     * Collect visual elements from a page and feed the size back in the 
+     * format for Visual Metrics.
+     */
+
+    const elementByType = {};
+    const areaByType = {};
+    const imageTags = [].slice.call(document.body.getElementsByTagName('img'));
+    const h1Tags = [].slice.call(document.body.getElementsByTagName('h1'));
+
+    // When we feed options from the CLI it can be a String or an 
+    // Array with Strings. Make it easy to treat everything the same. 
+    function toArray(arrayLike) {
+        if (arrayLike === undefined || arrayLike === null) {
+            return [];
+        }
+        if (Array.isArray(arrayLike)) {
+            return arrayLike;
+        }
+        return [arrayLike];
+    }
+
+    function isLargest(type, area) {
+        if (!areaByType[type]) {
+            return true;
+        } else return areaByType[type] < area;
+    }
+
+    // Inspired by
+    // https://gomakethings.com/how-to-test-if-an-element-is-in-the-viewport-with-vanilla-javascript/
+    // Only include elements that are fully within the viewport
+    function visibleInViewport(elem) {
+        const bounding = elem.getBoundingClientRect();
+        return (
+            bounding.height > 0 && // is visible
+            bounding.top >= 0 &&
+            bounding.left >= 0 &&
+            bounding.bottom <= document.documentElement.clientHeight &&
+            bounding.right <= document.documentElement.clientWidth
+        );
+    };
+
+    function test(type, element) {
+        const rect = element.getBoundingClientRect();
+        const area = rect.width * rect.height;
+        if (isLargest(type, area)) {
+            const filename = element.src ? element.src.substring(element.src.lastIndexOf('/') + 1) : undefined;
+
+            elementByType[type] = {
+                name: type,
+                x: Math.round(rect.left),
+                y: Math.round(rect.top),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+                filename
+            };
+            areaByType[type] = area;
+        }
+    }
+
+    if (custom) {
+        // Input could be a String or an Array of Strings so convert it
+        const customArray = toArray(custom);
+        for (const nameAndSelector of customArray) {
+            const parts = nameAndSelector.split(':');
+            const type = parts[0];
+            const selector = parts[1];
+            const element = document.body.querySelector(selector);
+            try {
+                 if (visibleInViewport(element)) {
+                     test(type, element);
+                 }
+            } catch (e) {
+                throw new Error('Could not find matching element for selector:' + selector + ' using document.body.querySelector. Do that element exist on the page?');
+            }
+        }
+    }
+
+    let type = 'LargestImage';
+    imageTags.forEach(function (element) {    
+        if (visibleInViewport(element)) {
+            test(type, element);
+        }
+    });
+
+    type = 'Heading';
+    h1Tags.forEach(function (element) {
+        if (visibleInViewport(element)) {
+            test(type, element);
+        }
+    });
+
+    // We need to follow the standard for VisualMetrics
+    return {
+        viewport: {
+            width: document.documentElement.clientWidth,
+            height: document.documentElement.clientHeight
+        },
+        // "heroes" :D https://github.com/sitespeedio/logo/blob/master/png/heroes/Pippi-Sitespeed.io.png
+        heroes: Object.keys(elementByType).map(function (type) {
+            return elementByType[type];
+        })
+    };
+})(arguments[arguments.length - 1]);

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -341,7 +341,11 @@ class SeleniumRunner {
       }
     } else {
       const source = 'return ' + script;
-      return this.runScript(source, name);
+      if (this.options.scriptInput && this.options.scriptInput[name]) {
+        return this.runScript(source, name, this.options.scriptInput[name]);
+      } else {
+        return this.runScript(source, name);
+      }
     }
   }
 

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -380,14 +380,18 @@ class SeleniumRunner {
     const scriptNames = Object.keys(category);
     const results = {};
     for (let scriptName of scriptNames) {
-      const script = category[scriptName];
-      const result = await this.runScriptFromCategory(
-        script,
-        isAsync,
-        scriptName
-      );
-      if (!(result === null || result === undefined)) {
-        results[scriptName] = result;
+      try {
+        const script = category[scriptName];
+        const result = await this.runScriptFromCategory(
+          script,
+          isAsync,
+          scriptName
+        );
+        if (!(result === null || result === undefined)) {
+          results[scriptName] = result;
+        }
+      } catch (e) {
+        log.error('Could not run script ' + scriptName + ':' + e.message);
       }
     }
     return results;

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -276,6 +276,15 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'Collect Visual Metrics like First Visual Change, SpeedIndex, Perceptual Speed Index and Last Visual Change. Requires FFMpeg and Python dependencies'
     })
+    .option('visuaElements', {
+      type: 'boolean',
+      describe:
+        'Collect Visual Metrics from elements. Works only with --visualMetrics turned on. By default you will get visual metrics from the largest image within the view port and the largest h1 (they need to be fully visible within the viewport). You can also configure to pickup your own defined elements with --scriptInput.visualElements'
+    })
+    .option('scriptInput.visualElements', {
+      describe:
+        'Include specific elements in visual elements. Give the element a name and select it with document.body.querySelector. Use like this: --scriptInput.visualElements name:domSelector . Add multiple instances to measure multiple elements. Visual Metrics will use these elements and calculate when they are visible.'
+    })
     .option('browser', {
       alias: 'b',
       default: 'chrome',

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -279,11 +279,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .option('visuaElements', {
       type: 'boolean',
       describe:
-        'Collect Visual Metrics from elements. Works only with --visualMetrics turned on. By default you will get visual metrics from the largest image within the view port and the largest h1 (they need to be fully visible within the viewport). You can also configure to pickup your own defined elements with --scriptInput.visualElements'
+        'Collect Visual Metrics from elements. Works only with --visualMetrics turned on. By default you will get visual metrics from the largest image within the view port and the largest h1. You can also configure to pickup your own defined elements with --scriptInput.visualElements'
     })
     .option('scriptInput.visualElements', {
       describe:
-        'Include specific elements in visual elements. Give the element a name and select it with document.body.querySelector. Use like this: --scriptInput.visualElements name:domSelector . Add multiple instances to measure multiple elements. Visual Metrics will use these elements and calculate when they are visible.'
+        'Include specific elements in visual elements. Give the element a name and select it with document.body.querySelector. Use like this: --scriptInput.visualElements name:domSelector . Add multiple instances to measure multiple elements. Visual Metrics will use these elements and calculate when they are visible and fully rendered.'
     })
     .option('browser', {
       alias: 'b',

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -131,6 +131,21 @@ module.exports = {
       _visualMetrics.LastVisualChange = visualMetricsData.LastVisualChange;
       _visualMetrics.VisualReadiness = visualMetricsData.VisualReadiness;
 
+      if (visualMetricsData.LargestImage) {
+        harPageTimings._largestImage = visualMetricsData.LargestImage;
+        _visualMetrics.LargestImage = visualMetricsData.LargestImage;
+      }
+
+      if (visualMetricsData.Heading) {
+        harPageTimings._heading = visualMetricsData.Heading;
+        _visualMetrics.Heading = visualMetricsData.Heading;
+      }
+
+      if (visualMetricsData.Logo) {
+        harPageTimings._logo = visualMetricsData.Logo;
+        _visualMetrics.Logo = visualMetricsData.Logo;
+      }
+
       // Make the visual progress structure more JSON
       _visualMetrics.VisualProgress = jsonifyVisualProgress(
         visualMetricsData.VisualProgress

--- a/lib/support/storageManager.js
+++ b/lib/support/storageManager.js
@@ -11,6 +11,7 @@ const moment = require('moment');
 
 const writeFile = promisify(fs.writeFile);
 const gzip = promisify(zlib.gzip);
+const unlink = promisify(fs.unlink);
 const mkdirp = promisify(require('mkdirp'));
 
 const defaultDir = 'browsertime-results';
@@ -55,6 +56,10 @@ class StorageManager {
     const dir = path.join(this.baseDir, ...name);
     await mkdirp(dir);
     return dir;
+  }
+
+  async rm(filename) {
+    return unlink(path.join(this.baseDir, filename));
   }
 
   async writeData(filename, data, subdir) {

--- a/lib/video/postprocessing/visualmetrics/runVisualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/runVisualMetrics.js
@@ -4,10 +4,38 @@ const visualMetrics = require('./visualMetrics');
 const log = require('intel').getLogger('browsertime.video');
 const path = require('path');
 
-module.exports = async function(videoDir, videoPath, index, results, options) {
+module.exports = async function(
+  videoDir,
+  videoPath,
+  index,
+  results,
+  storageManager,
+  options
+) {
   log.debug('Running visualMetrics');
+  // If we want to use the Hero functionality of Visual Metrics
+  // we need to create the hero JSON file.
+  if (
+    options.visualElements &&
+    results.browserScripts.pageinfo.visualElements
+  ) {
+    await storageManager.writeJson(
+      index + '-visualElements.json',
+      results.browserScripts.pageinfo.visualElements,
+      true
+    );
+  }
   const imageDir = path.join(videoDir, 'images', '' + index);
-  const metrics = await visualMetrics.run(videoPath, imageDir, options);
+  const elementsFile = path.join(
+    storageManager.directory,
+    index + '-visualElements.json.gz'
+  );
+  const metrics = await visualMetrics.run(
+    videoPath,
+    imageDir,
+    elementsFile,
+    options
+  );
 
   log.debug('Collected metrics ' + JSON.stringify(metrics));
 

--- a/lib/video/postprocessing/visualmetrics/runVisualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/runVisualMetrics.js
@@ -37,6 +37,14 @@ module.exports = async function(
     options
   );
 
+  // Remove the file
+  if (
+    options.visualElements &&
+    results.browserScripts.pageinfo.visualElements
+  ) {
+    await storageManager.rm(index + '-visualElements.json.gz');
+  }
+
   log.debug('Collected metrics ' + JSON.stringify(metrics));
 
   if (!metrics.VisualReadiness) {

--- a/lib/video/postprocessing/visualmetrics/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/visualMetrics.js
@@ -19,7 +19,7 @@ module.exports = {
   async checkDependencies() {
     return execa(SCRIPT_PATH, ['--check']);
   },
-  async run(videoPath, imageDirPath, options) {
+  async run(videoPath, imageDirPath, elementsFile, options) {
     const filmstripQuality = get(options, 'videoParams.filmstripQuality', 75);
     const createFilmstrip = get(options, 'videoParams.createFilmstrip', true);
     const fullSizeFilmstrip = get(
@@ -40,6 +40,11 @@ module.exports = {
       '--json',
       '--viewport'
     ];
+
+    if (options.visualElements) {
+      scriptArgs.push('--herodata');
+      scriptArgs.push(elementsFile);
+    }
 
     if (createFilmstrip) {
       scriptArgs.push('-q');

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -54,6 +54,7 @@ class Video {
         this.videoPath,
         this.index,
         results,
+        this.storageManager,
         this.options
       );
     }

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -642,7 +642,7 @@ def eliminate_duplicate_frames(directory):
                 baseline = files[0]
                 previous_frame = baseline
                 for i in xrange(1, count):
-                    if frames_match(baseline, files[i], 16, 0, crop, None):
+                    if frames_match(baseline, files[i], 10, 0, crop, None):
                         if previous_frame is baseline:
                             duplicates.append(previous_frame)
                         else:

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -642,7 +642,7 @@ def eliminate_duplicate_frames(directory):
                 baseline = files[0]
                 previous_frame = baseline
                 for i in xrange(1, count):
-                    if frames_match(baseline, files[i], 14, 0, crop, None):
+                    if frames_match(baseline, files[i], 16, 0, crop, None):
                         if previous_frame is baseline:
                             duplicates.append(previous_frame)
                         else:

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -642,7 +642,7 @@ def eliminate_duplicate_frames(directory):
                 baseline = files[0]
                 previous_frame = baseline
                 for i in xrange(1, count):
-                    if frames_match(baseline, files[i], 10, 0, crop, None):
+                    if frames_match(baseline, files[i], 14, 0, crop, None):
                         if previous_frame is baseline:
                             duplicates.append(previous_frame)
                         else:

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -642,7 +642,7 @@ def eliminate_duplicate_frames(directory):
                 baseline = files[0]
                 previous_frame = baseline
                 for i in xrange(1, count):
-                    if frames_match(baseline, files[i], 10, 0, crop, None):
+                    if frames_match(baseline, files[i], 16, 0, crop, None):
                         if previous_frame is baseline:
                             duplicates.append(previous_frame)
                         else:


### PR DESCRIPTION
I've merged and cherry picked some changes in Visual Metrics to be able to collect timing metrics for individual elements.

You can try it out like this:
`docker run --shm-size=1g --rm -v "$(pwd)":/browsertime sitespeedio/browsertime https://en.wikipedia.org/wiki/Obama -n 1 --visualElements`

And if you want to pick your own elements (default get the largest image and largest h1):
`docker run --shm-size=1g --rm -v "$(pwd)":/browsertime sitespeedio/browsertime https://en.wikipedia.org/wiki/Obama -n 1 --visualElements --scriptInput.visualElements Logo:#p-logo`

I've added a new feature that maybe should have been in another PR:
You can now pass on parameters from the CLI to your own custom JS. --scriptInput.SCRIPT_NAME will match the SCRIPT_NAME to the filename of the script, and if it matches the params are passed as an args. We use it now to make it possible to pick individual elements on a page but I think this is something that really open up Browsertime to do even more great stuff.
