### PR TITLE
Stable finding first frame

### DIFF
--- a/lib/video/postprocessing/finetune/ffprobe.js
+++ b/lib/video/postprocessing/finetune/ffprobe.js
@@ -11,7 +11,7 @@ module.exports = async function ffprobe(videoPath) {
     '-i',
     "movie='" + videoPath.replace('=', '\\=') + "',signalstats",
     '-show_entries',
-    'frame_tags=lavfi.signalstats.SATAVG',
+    'frame_tags=lavfi.signalstats.SATLOW',
     '-v',
     'quiet',
     '-print_format',

--- a/lib/video/postprocessing/finetune/findFirstFrame.js
+++ b/lib/video/postprocessing/finetune/findFirstFrame.js
@@ -5,7 +5,7 @@ const log = require('intel').getLogger('browsertime.video');
 const LIMIT = 3;
 
 function isWhiteFrame(frame) {
-  return Number(frame.tags['lavfi.signalstats.SATAVG']) < LIMIT;
+  return Number(frame.tags['lavfi.signalstats.SATLOW']) < LIMIT;
 }
 
 module.exports = function findFirstFrame(ffprobeOutput) {

--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -1,13 +1,20 @@
 'use strict';
 const log = require('intel').getLogger('browsertime.video');
-const delay = ms => new Promise(res => setTimeout(res, ms));
 module.exports = async function(driver) {
   // start on a blank page and lets make the background orange
   // that will make it easier for VisualMetrics to know when the
   // page is requested
   log.debug('Change background color to orange');
-  await delay(1000);
-  return driver.executeScript(
-    'document.body.innerHTML = ""; document.body.style.background = "#DE640D";'
-  );
+  const orangeScript = `
+    const orange = document.createElement('div');
+    orange.style.position = 'absolute';
+    orange.style.top = '0';
+    orange.style.left = '0';
+    orange.style.width = document.body.clientWidth + 'px';
+    orange.style.height = document.body.clientHeight + 'px';
+    orange.style.backgroundColor = '#DE640D';
+    orange.style.zIndex = '2147483647';
+    document.body.appendChild(orange);
+  `;
+  return driver.executeScript(orangeScript);
 };

--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -4,8 +4,11 @@ module.exports = async function(driver) {
   // start on a blank page and lets make the background orange
   // that will make it easier for VisualMetrics to know when the
   // page is requested
-  log.debug('Change background color to orange');
+  log.debug('Add orange color');
+  // This is following the same structure as WPT to get rid of the problem
+  // when testing with preScripts.
   const orangeScript = `
+  (function() {
     const orange = document.createElement('div');
     orange.style.position = 'absolute';
     orange.style.top = '0';
@@ -15,6 +18,7 @@ module.exports = async function(driver) {
     orange.style.backgroundColor = '#DE640D';
     orange.style.zIndex = '2147483647';
     document.body.appendChild(orange);
+  })();
   `;
   return driver.executeScript(orangeScript);
 };

--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -7,7 +7,7 @@ module.exports = async function(driver) {
   // page is requested
   log.debug('Change background color to orange');
   await delay(1000);
-  await driver.executeScript(
+  return driver.executeScript(
     'document.body.innerHTML = ""; document.body.style.background = "#DE640D";'
   );
 };


### PR DESCRIPTION
There has been two problems: First finding the first frame. For reason I used avg instead of lowest value that was kind of wrong :( Sorry. And then there was a problem that the screen never turned orange when running preScript, at least in the test scenarios I've been testing now.

See sitespeedio/sitespeed.io#1949