### PR TITLE
Log errors instead of throw

### DIFF
--- a/browserscripts/pageinfo/visualElements.js
+++ b/browserscripts/pageinfo/visualElements.js
@@ -74,7 +74,7 @@
                      keepLargestElementByType(type, element);
                  }
             } catch (e) {
-                throw new Error('Could not find matching element for selector:' + selector + ' using document.body.querySelector. Do that element exist on the page?');
+                console.error('Could not find matching element for selector:' + selector + ' using document.body.querySelector. Do that element exist on the page?');
             }
         }
     }


### PR DESCRIPTION
This will make it lots easier if you run campaigns that output elements in specific ids etc. Before missing elements made everything fail, now we just logs the error. 