### PR TITLE
Enhance --pageCompleteCheck to accept a javascript file (#2084)

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -35,6 +35,9 @@ class Iteration {
     try {
       this.preScripts = engineUtils.loadPrePostScripts(options.preScript);
       this.postScripts = engineUtils.loadPrePostScripts(options.postScript);
+      this.pageCompleteCheck = engineUtils.loadScript(
+        options.pageCompleteCheck
+      );
     } catch (e) {
       log.error(e.message);
       throw e;
@@ -121,7 +124,7 @@ class Iteration {
       }
       await this.engineDelegate.onStartIteration(browser, index);
       result.timestamp = engineUtils.timestamp();
-      await browser.loadAndWait(url, options.pageCompleteCheck);
+      await browser.loadAndWait(url, this.pageCompleteCheck);
 
       // And stop the video when the URL is finished
       if (recordVideo && !combine) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -325,7 +325,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('pageCompleteCheck', {
       describe:
-        'Supply a JavaScript that decides when the browser is finished loading the page and can start to collect metrics. The JavaScript snippet is repeatedly queried to see if page has completed loading (indicated by the script returning true). Use it to fetch timings happening after the loadEventEnd. By default the tests ends 2 seconds after loadEventEnd. Also checkout --pageCompleteCheckInactivity'
+        'Supply a JavaScript (inline or javascript file) that decides when the browser is finished loading the page and can start to collect metrics. The JavaScript snippet is repeatedly queried to see if page has completed loading (indicated by the script returning true). Use it to fetch timings happening after the loadEventEnd. By default the tests ends 2 seconds after loadEventEnd. Also checkout --pageCompleteCheckInactivity'
     })
     .option('pageCompleteCheckInactivity', {
       describe:

--- a/lib/support/engineUtils.js
+++ b/lib/support/engineUtils.js
@@ -16,6 +16,16 @@ module.exports = {
       }
     });
   },
+  loadScript(script) {
+    if (script) {
+      try {
+        return require(path.resolve(script));
+      } catch (e) {
+        // assume the script is a valid inline script
+      }
+    }
+    return script;
+  },
   timestamp() {
     return moment().format();
   }

--- a/test/browserTests/engineTests.js
+++ b/test/browserTests/engineTests.js
@@ -209,5 +209,62 @@ describe('Engine', function() {
           'Waited for ' + browser + ' to quit for too long'
         ));
     });
+
+    describe('#pageCompleteCheck inline - ' + browser, function() {
+      const scripts = {
+        foo: '(function () {return "fff";})()',
+        uri: 'document.documentURI',
+        fourtytwo: '(function () {return 42;})()'
+      };
+
+      beforeEach(function() {
+        engine = new Engine({
+          browser: browser,
+          iterations: 1,
+          pageCompleteCheck:
+            'return (function() { try { var end = window.performance.timing.loadEventEnd; return (end > 0) && (Date.now() > end + 5000); } catch(e) { return true; }})();',
+          skipHar: true
+        });
+        return engine.start();
+      });
+
+      it('should run 5-second pageCompleteCheck from inline javascript', function() {
+        return engine.run('data:text/html;charset=utf-8,', { scripts });
+      });
+
+      afterEach(() =>
+        Promise.resolve(engine.stop()).timeout(
+          10000,
+          'Waited for ' + browser + ' to quit for too long'
+        ));
+    });
+
+    describe('#pageCompleteScript from file - ' + browser, function() {
+      const scripts = {
+        foo: '(function () {return "fff";})()',
+        uri: 'document.documentURI',
+        fourtytwo: '(function () {return 42;})()'
+      };
+
+      beforeEach(function() {
+        engine = new Engine({
+          browser: browser,
+          iterations: 1,
+          pageCompleteCheck: 'test/pagecompletescripts/pageComplete10sec.js',
+          skipHar: true
+        });
+        return engine.start();
+      });
+
+      it('should run 10-second pageCompleteScript from script file', function() {
+        return engine.run('data:text/html;charset=utf-8,', { scripts });
+      });
+
+      afterEach(() =>
+        Promise.resolve(engine.stop()).timeout(
+          10000,
+          'Waited for ' + browser + ' to quit for too long'
+        ));
+    });
   });
 });

--- a/test/pagecompletescripts/pageComplete10sec.js
+++ b/test/pagecompletescripts/pageComplete10sec.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = `
+return (function() {
+  try {
+    var end = window.performance.timing.loadEventEnd;
+    return (end > 0) && (Date.now() > end + 10000);
+  } catch(e) {
+	return true;
+  }
+})();
+`;


### PR DESCRIPTION
This is for https://github.com/sitespeedio/sitespeed.io/issues/2084
The --pageCompleteCheck now accepts an inline javascript (for backward
compatibility) or a path to a javascript file (enhancement request)
2 tests are added - one for previous behavior and one for new behavior