### PR TITLE
Remove Firefox version check for HAR export trigger

### DIFF
--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -55,48 +55,35 @@ class FirefoxDelegate {
       triggerExport();
     `;
 
-    // Hack to get version of Firefox to make sure we only run the HAR export
-    // trigger in Firefoxen that supports it.
-    const ua = await runner.runScript(
-      'return window.navigator.userAgent',
-      'GET_VERSION_SCRIPT'
-    );
-    const match = ua.match(/(Firefox)\/(\S+)/);
-    const version = Number(match[2]);
-
-    if (version > 60) {
-      log.info('Waiting on har-export-trigger to collect the HAR');
-      try {
-        const harResult = await runner.runAsyncScript(script, 'GET_HAR_SCRIPT');
-        if (harResult.har) {
-          if (
-            this.includeResponseBodies === 'none' ||
-            this.includeResponseBodies === 'html'
-          ) {
-            for (let entry of harResult.har.log.entries) {
-              if (this.includeResponseBodies === 'none') {
-                delete entry.response.content.text;
-              } else if (
-                entry.response.content.mimeType &&
-                entry.response.content.mimeType.indexOf('text/html') === -1
-              ) {
-                delete entry.response.content.text;
-              }
+    log.info('Waiting on har-export-trigger to collect the HAR');
+    try {
+      const harResult = await runner.runAsyncScript(script, 'GET_HAR_SCRIPT');
+      if (harResult.har) {
+        if (
+          this.includeResponseBodies === 'none' ||
+          this.includeResponseBodies === 'html'
+        ) {
+          for (let entry of harResult.har.log.entries) {
+            if (this.includeResponseBodies === 'none') {
+              delete entry.response.content.text;
+            } else if (
+              entry.response.content.mimeType &&
+              entry.response.content.mimeType.indexOf('text/html') === -1
+            ) {
+              delete entry.response.content.text;
             }
           }
-          this.hars.push(harResult.har);
-        } else {
-          // We got an error from HAR exporter
-          log.error(
-            'Got an error from HAR Export Trigger ' +
-              JSON.stringify(harResult.error)
-          );
         }
-      } catch (e) {
-        log.error('Could not get the HAR from Firefox', e);
+        this.hars.push(harResult.har);
+      } else {
+        // We got an error from HAR exporter
+        log.error(
+          'Got an error from HAR Export Trigger ' +
+            JSON.stringify(harResult.error)
+        );
       }
-    } else {
-      log.info('You need Firefox 61 (or later) to get the HAR.');
+    } catch (e) {
+      log.error('Could not get the HAR from Firefox', e);
     }
   }
 


### PR DESCRIPTION
We had a check that FF is 61 or later for the HAR export trigger to work. However that fix makes sitespeed.io break when you run with mobile options, see https://github.com/sitespeedio/sitespeed.io/issues/2178#issuecomment-428638659

It also makes Firefox tests to break as long as you set a different user agent.

We are now on FF 62 so we can just remove the check.