### PR TITLE
Add Firefox timeToFirstInteractive

### DIFF
--- a/browserscripts/timings/timeToFirstInteractive.js
+++ b/browserscripts/timings/timeToFirstInteractive.js
@@ -1,0 +1,11 @@
+(function () {
+    // Firefox only TTFI
+    // need pref to be activated
+    // If the "event" has happend, it will return 0
+    const timing = window.performance.timing;
+    if (timing.timeToFirstInteractive && timing.timeToFirstInteractive > 0) {
+        return Number(
+            (timing.timeToFirstInteractive - timing.navigationStart).toFixed(0)
+        );
+    } else return undefined;
+})();

--- a/lib/firefox/webdriver/firefoxPreferences.js
+++ b/lib/firefox/webdriver/firefoxPreferences.js
@@ -5,6 +5,8 @@ module.exports = {
   'dom.performance.time_to_non_blank_paint.enabled': true,
   // Use hidden time to DOM Content flush
   'dom.performance.time_to_dom_content_flushed.enabled': true,
+  // Use hidden TTFI
+  'dom.performance.time_to_first_interactive.enabled': true,
   // IPV6 sometimes makes DNS slow on Linux
   'network.dns.disableIPv6': true,
   'browser.startup.homepage': 'about:blank',


### PR DESCRIPTION
You need to wait before the TTFI is calculated (before it is 0), so in
practice this would probably need a new pageCompleteCheck to work.

This is Firefox Nightly at the moment so try it out like this (Mac):
`bin/browsertime.js --firefox.nightly https://www.wikipedia.org -n 1`