### PR TITLE
Get ServerTimings

### DIFF
--- a/browserscripts/timings/serverTimings.js
+++ b/browserscripts/timings/serverTimings.js
@@ -1,0 +1,16 @@
+(function () {
+    // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming
+    const entries = window.performance.getEntriesByType('resource');
+    if (entries.length > 0 && entries[0].serverTiming) {
+        const timings = entries[0].serverTiming;
+        const serverTimings = [];
+        for (let timing of timings) {
+             serverTimings.push({
+                 name: timing.name,
+                 duration: timing.duration,
+                 description: timing.description
+             });
+        }
+        return serverTimings;
+    } else return undefined;
+})();


### PR DESCRIPTION
Using the same format as User Timings. This should work for
both Chrome and Firefox but for Firefox I only get an empty array?
Need to check if it's really is implemented in Firefox.

I'm using the example NodeJS server in
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming
to test it.