### PR TITLE
Test out coming timeToContentfulPaint (only Firefox Nightly).

### DIFF
--- a/browserscripts/timings/timeToContentfulPaint.js
+++ b/browserscripts/timings/timeToContentfulPaint.js
@@ -1,0 +1,11 @@
+(function () {
+    // Firefox only timeToContentfulPaint
+    // need pref to be activated
+    const timing = window.performance.timing;
+    if (timing.timeToContentfulPaint) {
+            return Number(
+                (timing.timeToContentfulPaint - timing.navigationStart).toFixed(0)
+            );
+        }
+    else return undefined;
+})();

--- a/lib/firefox/webdriver/firefoxPreferences.js
+++ b/lib/firefox/webdriver/firefoxPreferences.js
@@ -7,6 +7,8 @@ module.exports = {
   'dom.performance.time_to_dom_content_flushed.enabled': true,
   // Use hidden TTFI
   'dom.performance.time_to_first_interactive.enabled': true,
+  // Use hidden TTCP
+  'dom.performance.time_to_contentful_paint.enabled': true,
   // IPV6 sometimes makes DNS slow on Linux
   'network.dns.disableIPv6': true,
   'browser.startup.homepage': 'about:blank',


### PR DESCRIPTION
This is untested since FirefoNightly.app on Mac changed name to Firefox Nightly.app (A SPACE IN THE NAME) and this makes the Selenium bindings for nightly fail.