### PR TITLE
Specifically check if type of FF preference is a boolean value along with isNaN()

### DIFF
--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -84,7 +84,7 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
       // Firefox handles 0, "0", false differently. Turning of OSCP
       // security.OCSP.enabled:0
       // Only accepts a zero as integer
-      if (isNaN(value)) {
+      if (isNaN(value) || typeof value === "boolean") {
         profile.setPreference(nameAndValue[0], value);
       } else {
         profile.setPreference(nameAndValue[0], Number(value));


### PR DESCRIPTION
Resolves #684 

boolean firefox preferences are not being set properly because they fail the isNaN() check below and therefore the preferences are set to 0 or 1 instead, which doesn't work.  