### PR TITLE
Simplify Android usage.

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const yargs = require('yargs');
+const get = require('lodash.get');
+const set = require('lodash.set');
 const urlValidator = require('valid-url');
 const util = require('util');
 const hasbin = require('hasbin');
@@ -295,6 +297,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       choices: ['chrome', 'firefox'],
       describe: 'Specify browser'
     })
+    .option('android', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Short key to use Android. Will automatically use com.android.chrome'
+    })
     /** Screenshot */
     .option('screenshot', {
       type: 'boolean',
@@ -556,6 +564,14 @@ module.exports.parseCommandLine = function parseCommandLine() {
     (argv.firefox.nightly || argv.firefox.beta || argv.firefox.developer)
   ) {
     argv.browser = 'firefox';
+  }
+
+  if (argv.android) {
+    set(
+      argv,
+      'chrome.android.package',
+      get(argv, 'chrome.android.package', 'com.android.chrome')
+    );
   }
 
   return {

--- a/lib/support/xvfb.js
+++ b/lib/support/xvfb.js
@@ -5,6 +5,7 @@ const { promisify } = require('util');
 const get = require('lodash.get');
 const videoDefaults = require('../video/defaults');
 const getViewPort = require('../support/getViewPort');
+const { isAndroidConfigured } = require('../android');
 
 function buildXvfbArgs({ display, screen = 0, size, silent }) {
   return {
@@ -51,7 +52,10 @@ class XVFB {
     // This is the fix for the current use of ENV in Docker
     // we should do a better fix for that
     const useXvfb = get(this.options, 'xvfb', false);
-    if (useXvfb === true || useXvfb === 'true') {
+    if (
+      useXvfb === true ||
+      (useXvfb === 'true' && !isAndroidConfigured(this.options))
+    ) {
       this.xvfbSession = await startXvfb({
         size: getViewPort(this.options),
         options: this.options


### PR DESCRIPTION
Use --android to run default Chrome. And if using Android always skip
xvfb (even if it is configured).