### PR TITLE
Disable shm usage in chrome

### DIFF
--- a/lib/chrome/webdriver/chromeOptions.js
+++ b/lib/chrome/webdriver/chromeOptions.js
@@ -20,6 +20,7 @@ module.exports = [
   '--disable-datasaver-prompt',
   '--disable-default-apps',
   '--disable-domain-reliability',
+  '--disable-dev-shm-usage',
   '--safebrowsing-disable-auto-update',
   '--ignore-certificate-errors'
 ];


### PR DESCRIPTION
"By default, Docker runs a container with a /dev/shm shared memory space 64MB. This is typically too small for Chrome and will cause Chrome to crash when rendering large pages. To fix, run the container with docker run --shm-size=1gb to increase the size of /dev/shm. Since Chrome 65, this is no longer necessary. Instead, launch the browser with the --disable-dev-shm-usage flag"

refs: https://github.com/GoogleChrome/puppeteer/blob/v1.0.0/docs/troubleshooting.md#tips

Can i update readme in browsertime and sitespeed ?