### PR TITLE
Make it easier to use SPA:s

### DIFF
--- a/lib/core/defaultPageCompleteCheck.js
+++ b/lib/core/defaultPageCompleteCheck.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = `
-return (function() {
+return (function(waitTime) {
     try { 
         var end = window.performance.timing.loadEventEnd;
-        return (end > 0) && (Date.now() > end + 2000);
+        return (end > 0) && (Date.now() > end + waitTime);
     } catch(e) {
         return true;
     }
-})();
+})(arguments[arguments.length - 1]);
 `;

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -210,7 +210,22 @@ class Iteration {
         h: helpers
       };
 
-      await setResourceTimingBufferSize(browser.getDriver(), 600);
+      if (options.spa) {
+        await setResourceTimingBufferSize(browser.getDriver(), 1000);
+      } else {
+        // at the moment we need Chrome to open once to get correct values for Chrome HAR
+        // but let us fix that
+        /*
+        [2018-12-30 22:37:25] ERROR: RangeError: Invalid time value
+        at Date.toISOString (<anonymous>)
+        at h.d.toISOString (/Users/peter/git/browsertime/node_modules/chrome-har/node_modules/dayjs/dayjs.min.js:1:6434)
+        at module.exports (/Users/peter/git/browsertime/node_modules/chrome-har/lib/entryFromResponse.js:148:53)
+        at Object.harFromMessages (/Users/peter/git/browsertime/node_modules/chrome-har/index.js:307:15)
+        at ChromeDelegate.onCollect (/Users/peter/git/browsertime/lib/chrome/webdriver/chromeDelegate.js:135:31)
+        at process._tickCallback (internal/process/next_tick.js:68:7)
+        */
+        await browser.getDriver().get('data:text/html;charset=utf-8,');
+      }
 
       // On slowish Android phones it takes some time for the
       // browser to get ready

--- a/lib/core/pageCompleteCheckByInactivity.js
+++ b/lib/core/pageCompleteCheckByInactivity.js
@@ -1,10 +1,10 @@
 'use strict';
 
 module.exports = `
-return (function() {
+return (function(waitTime) {
   const timing = window.performance.timing;
   const p = window.performance;
-  const limit = 5000;
+  const limit = waitTime;
 
   if (timing.loadEventEnd === 0) {
     return false;
@@ -25,5 +25,5 @@ return (function() {
   } else {
     return p.now() - lastEntry.responseEnd > limit;
   }
-})();
+})(arguments[arguments.length - 1]);
 `;

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -132,10 +132,10 @@ class SeleniumRunner {
       pageCompleteCheck = this.options.pageCompleteCheckInactivity
         ? pageCompleteCheckByInactivity
         : defaultPageCompleteCheck;
-    }
-
-    if (this.options.spa) {
-      pageCompleteCheck = spaCheck;
+      // if using SPA just override
+      if (this.options.spa) {
+        pageCompleteCheck = spaCheck;
+      }
     }
 
     const driver = this.driver,

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -11,6 +11,7 @@ const log = require('intel').getLogger('browsertime'),
 
 const defaultPageCompleteCheck = require('./defaultPageCompleteCheck');
 const pageCompleteCheckByInactivity = require('./pageCompleteCheckByInactivity');
+const spaCheck = require('./spaInactivity');
 
 const defaults = {
   timeouts: {
@@ -126,18 +127,24 @@ class SeleniumRunner {
    * @throws {UrlLoadError}
    */
   async wait(pageCompleteCheck) {
+    const waitTime = this.options.pageCompleteWaitTime || 5000;
     if (!pageCompleteCheck) {
       pageCompleteCheck = this.options.pageCompleteCheckInactivity
         ? pageCompleteCheckByInactivity
         : defaultPageCompleteCheck;
     }
+
+    if (this.options.spa) {
+      pageCompleteCheck = spaCheck;
+    }
+
     const driver = this.driver,
       pageCompleteCheckTimeout = this.options.timeouts.pageCompleteCheck;
     try {
       const pageCompleteCheckCondition = new Condition(
         'for page complete check script to return true',
         function(d) {
-          return d.executeScript(pageCompleteCheck).then(function(t) {
+          return d.executeScript(pageCompleteCheck, waitTime).then(function(t) {
             return t === true;
           });
         }

--- a/lib/core/spaInactivity.js
+++ b/lib/core/spaInactivity.js
@@ -7,7 +7,12 @@ return (function(waitTime) {
   const resourceTimings = p.getEntriesByType('resource');
   if (resourceTimings.length > 0) {
     const lastEntry = resourceTimings.pop();
-    return p.now() - lastEntry.responseEnd > waitTime;
+    const stop = p.now() - lastEntry.responseEnd > waitTime;
+    if (stop) {
+      // empty resource timings for the next run
+      p.clearResourceTimings();
+      return true;
+    }
   }
   else return false;
 })(arguments[arguments.length - 1]);

--- a/lib/core/spaInactivity.js
+++ b/lib/core/spaInactivity.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = `
+return (function(waitTime) {
+  const timing = window.performance.timing;
+  const p = window.performance;
+  const resourceTimings = p.getEntriesByType('resource');
+  if (resourceTimings.length > 0) {
+    const lastEntry = resourceTimings.pop();
+    return p.now() - lastEntry.responseEnd > waitTime;
+  }
+  else return false;
+})(arguments[arguments.length - 1]);
+`;


### PR DESCRIPTION
1. Make it possible to configure the min wait time for the pageCompleteCheck
2. Pass on --spa to make sure we only look for when last timing happened in the resource timming.

We should also sync this with # as a filename and that the configured pageComplete check is used everywhere.