### PR TITLE
Manually set properties httpProxyPort and sslProxyPort for Firefox

### DIFF
--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -132,7 +132,10 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   const proxySettings = pick(options.proxy, ['http', 'https']);
 
   if (!isEmpty(proxySettings)) {
-    ffOptions.setProxy(proxy.manual(proxySettings));
+    let seleniumProxySettings = proxy.manual(proxySettings);
+    seleniumProxySettings.httpProxyPort = proxySettings.http.split(":")[1];
+    seleniumProxySettings.sslProxyPort = proxySettings.https.split(":")[1];
+    ffOptions.setProxy(seleniumProxySettings);
   }
 
   if (firefoxConfig.acceptInsecureCerts) {

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -133,8 +133,8 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
 
   if (!isEmpty(proxySettings)) {
     let seleniumProxySettings = proxy.manual(proxySettings);
-    seleniumProxySettings.httpProxyPort = proxySettings.http.split(":")[1];
-    seleniumProxySettings.sslProxyPort = proxySettings.https.split(":")[1];
+    seleniumProxySettings.httpProxyPort = proxySettings.http.split(':')[1];
+    seleniumProxySettings.sslProxyPort = proxySettings.https.split(':')[1];
     ffOptions.setProxy(seleniumProxySettings);
   }
 


### PR DESCRIPTION
Closes #701.  This provides a workaround that allows the proxy port to be set properly for Firefox until the problem in Selenium is addressed.  