### PR TITLE
Add possibility to register alias for a URL from a script.

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -109,6 +109,10 @@ class Collector {
         });
       }
 
+      if (data.alias) {
+        results.info.alias = data.alias;
+      }
+
       if (
         data.browserScripts &&
         data.browserScripts.timings &&

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -82,7 +82,10 @@ class Measure {
    */
   async start(urlOrAlias, optionalAlias) {
     let url, alias;
-    if (urlOrAlias && urlOrAlias.startsWith('http')) {
+    if (
+      (urlOrAlias && urlOrAlias.startsWith('http')) ||
+      urlOrAlias.startsWith('data:text')
+    ) {
       url = urlOrAlias;
       log.info('Testing url %s iteration %s', url, this.index);
     } else if (urlOrAlias) {

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -75,13 +75,19 @@ class Measure {
   /**u
    *  Start collecting metrics for a URL. If you supply a URL to this method, the browser will navigate to that URL.
    *  If you do not use an URL (start()) everything is prepared for a new page to measure except the browser do not
-   *  navigate to a new URL.
-   * @param {string} url
+   *  navigate to a new URL. You can also add an alias for the URL.
+   * @param {string} urlOrAlias
+   * @param {string} optionalAlias
    * @returns {Promise} Promise object represents when the URL has been navigated and finished loading according to the pageCompleteCheck or when everything is setup for measuring a new URL (if no URL is supplied).
    */
-  async start(url) {
-    if (url) {
+  async start(urlOrAlias, optionalAlias) {
+    let url, alias;
+    if (urlOrAlias && urlOrAlias.startsWith('http')) {
+      url = urlOrAlias;
       log.info('Testing url %s iteration %s', url, this.index);
+    } else if (urlOrAlias) {
+      alias = urlOrAlias;
+      log.info('Start to measure %s', alias);
     } else {
       log.info('Start to measure');
     }
@@ -92,6 +98,10 @@ class Measure {
     }
     this.result.push(getNewResult());
     this.result[this.noPages].timestamp = engineUtils.timestamp();
+
+    if (alias || optionalAlias) {
+      this.result[this.noPages].alias = alias || optionalAlias;
+    }
 
     if (this.recordVideo) {
       await this._startVideo(this.noPages, this.index);


### PR DESCRIPTION
I'm not 100% sure how we would solve this, but I think adding a alias when you create the script is pretty straight forward. Then we need to pick up the alias in sitespeed.io