### PR TITLE
Choose the last visual complete 85/95/99

### DIFF
--- a/lib/video/postprocessing/visualmetrics/extraMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/extraMetrics.js
@@ -29,6 +29,25 @@ module.exports = function(metrics) {
       ) {
         metrics.VisualComplete99 = Number(parts[0]);
       }
+
+      // Oh noo the painting on the screen goes backward
+      // see https://github.com/sitespeedio/sitespeed.io/issues/2259#issuecomment-456878707
+      if (metrics.VisualComplete85 && Number(parts[1].replace('%', '')) < 85) {
+        metrics.VisualComplete85 = undefined;
+        metrics.VisualComplete95 = undefined;
+        metrics.VisualComplete95 = undefined;
+      } else if (
+        metrics.VisualComplete95 &&
+        Number(parts[1].replace('%', '')) < 95
+      ) {
+        metrics.VisualComplete95 = undefined;
+        metrics.VisualComplete95 = undefined;
+      } else if (
+        metrics.VisualComplete99 &&
+        Number(parts[1].replace('%', '')) < 99
+      ) {
+        metrics.VisualComplete99 = undefined;
+      }
     }
   }
   if (metrics.videoRecordingStart) {


### PR DESCRIPTION
The old implementatiom choosed the first occurances of those metrics
even if the complete went down to lower values.

https://github.com/sitespeedio/sitespeed.io/issues/2259 
#731