### PR TITLE
Print Correct Timestamp to Video

### DIFF
--- a/lib/video/postprocessing/finetune/addTextToVideo.js
+++ b/lib/video/postprocessing/finetune/addTextToVideo.js
@@ -25,9 +25,7 @@ module.exports = async function(
         : '';
   args.push(
     '-vf',
-    `drawtext=${fontFile}timecode='00\\:00\\:00\\:00':rate=${
-      options.videoParams.framerate
-    }: x=(w-tw)/2: y=H-h/8:fontcolor=white:fontsize=h/10:box=1:boxcolor=0x000000AA${allTimingMetrics}`
+    `drawtext=${fontFile}x=(w-tw)/2: y=H-h/8:fontcolor=white:fontsize=h/10:box=1:boxcolor=0x000000AA:text='%{pts\\:hms}'${allTimingMetrics}`
   );
   args.push('-y', outputFile);
   log.verbose('Adding text with FFMPEG ' + args.join(' '));


### PR DESCRIPTION
The display of the video's Timestamp is  .00 -> .${framerate} -1 .
ex) When framerate is 30 (default), Timestamp is 0.00 -> 0.29, 1.00 -> 1.29, 2.00 to 2.29, ...
This Change is 0.00 -> 0.99, 1.00 -> 1.99, ...