### PR TITLE
Bugfix: New timestamp in the video introduced some flickering in the …

### DIFF
--- a/lib/video/postprocessing/finetune/addTextToVideo.js
+++ b/lib/video/postprocessing/finetune/addTextToVideo.js
@@ -25,7 +25,7 @@ module.exports = async function(
         : '';
   args.push(
     '-vf',
-    `drawtext=${fontFile}x=(w-(max_glyph_w*13))/2: y=H-h/10:fontcolor=white:borderw=4:fontsize=h/14:text='%{pts\\:hms}'${allTimingMetrics}`
+    `drawtext=${fontFile}x=(w-(max_glyph_w*13))/2: y=H-h/10:fontcolor=white:fontsize=h/14:box=1:boxcolor=0x000000AA:text='%{pts\\:hms}'${allTimingMetrics}`
   );
   args.push('-y', outputFile);
   log.verbose('Adding text with FFMPEG ' + args.join(' '));


### PR DESCRIPTION
…time stamp

If the font size is too large, the characters move.
When # 771 - borderw + (box, boxcolor), Desktop and mobile have stopped moving.