### PR TITLE
Add 0.01% pixel diff to find last frames

### DIFF
--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -639,7 +639,9 @@ def eliminate_duplicate_frames(directory):
 
             # Do another pass looking for the last frame but with an allowance for up
             # to a 10% difference in individual pixels to deal with noise
-            # around text.
+            # around text. We can also have a diff of 0.01% of pixels, without that 
+            # we pickup small changes at the end of the video
+            max_pixel_diff = math.ceil(width * height * 0.0001)
             files = sorted(glob.glob(os.path.join(directory, 'ms_*.png')))
             count = len(files)
             duplicates = []
@@ -648,7 +650,7 @@ def eliminate_duplicate_frames(directory):
                 baseline = files[0]
                 previous_frame = baseline
                 for i in xrange(1, count):
-                    if frames_match(baseline, files[i], 10, 0, crop, None):
+                    if frames_match(baseline, files[i], 10, max_pixel_diff, crop, None):
                         if previous_frame is baseline:
                             duplicates.append(previous_frame)
                         else:


### PR DESCRIPTION
We have had a problem picking up too small changes that makes us
use wrong last visual change, see:

https://phabricator.wikimedia.org/T215160