### PR TITLE
If element not found, log to the console (not error)

### DIFF
--- a/browserscripts/pageinfo/visualElements.js
+++ b/browserscripts/pageinfo/visualElements.js
@@ -74,7 +74,7 @@
                      keepLargestElementByType(type, element);
                  }
             } catch (e) {
-                console.error('Could not find matching element for selector:' + selector + ' using document.body.querySelector. Do that element exist on the page?');
+                console.log('Could not find matching element for selector:' + selector + ' using document.body.querySelector. Do that element exist on the page?');
             }
         }
     }


### PR DESCRIPTION
We used to log as an error but that works bad if you are tracking a
element that someties are there and sometimes not (like a banner)
becasue it created an error entry in sitespeed.io that makes it hard
to alert on console errors.