### PR TITLE
use alias as foldername

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -92,7 +92,7 @@ class Collector {
   async perIteration(allData, index) {
     for (let data of allData) {
       const alias = data.alias;
-      let url = data.url || this.urlFromCli;
+      let url = data.url || alias || this.urlFromCli;
       if (alias && !this.aliasAndUrl[alias]) {
         this.aliasAndUrl[alias] = url;
       } else if (alias && this.aliasAndUrl[alias]) {

--- a/lib/support/pathToFolder.js
+++ b/lib/support/pathToFolder.js
@@ -20,8 +20,10 @@ module.exports = function(url, options) {
           .substring(0, 8);
       pathSegments.push('hash-' + hash);
     }
-
-    pathSegments.unshift(parsedUrl.hostname);
+    
+    if (!isEmpty(parsedUrl.hostname)) {
+      pathSegments.unshift(parsedUrl.hostname);
+    }
 
     pathSegments.unshift('pages');
 


### PR DESCRIPTION
When i use script with alias (not as second params):
```
module.exports = async function (context, commands) {
  await commands.measure.start('login')
  await commands.measure.start('https://www.sitespeed.io/examples/')
}
```

i got error:
```
[2019-02-22 22:17:09] ERROR: Error running browsertime TypeError: Cannot read property 'replace' of null
    at /usr/local/lib/node_modules/browsertime/lib/support/pathToFolder.js:42:37
    at Array.forEach (<anonymous>)
    at module.exports (/usr/local/lib/node_modules/browsertime/lib/support/pathToFolder.js:40:18)
    at Collector.perIteration (/usr/local/lib/node_modules/browsertime/lib/core/engine/collector.js:185:19)
    at <anonymous>
```
 this path  create result directory  with name = alias (without hostname)

Maybe create result folder for every  commands.measure.start call?