### PR TITLE
Add padding to video when using width/height not divisible by 2. Resolves #565

### DIFF
--- a/lib/video/screenRecording/desktop/ffmpegRecorder.js
+++ b/lib/video/screenRecording/desktop/ffmpegRecorder.js
@@ -32,6 +32,8 @@ function buildX11FfmpegArgs({
     0,
     '-preset',
     'ultrafast',
+    '-vf',
+    'pad=ceil(iw/2)*2:ceil(ih/2)*2',
     filePath
   ];
 }


### PR DESCRIPTION
This change pads width and/or height of video recordings by 1 pixel line at the bottom/right if not divisible by 2.