### PR TITLE
Catch missing measure.stop()

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -55,6 +55,7 @@ class Measure {
     this.asyncScriptsByCategory = asyncScriptsByCategory;
     this.numberOfMeasuredPages = 0;
     this.numberOfVisitedPages = 0;
+    this.areWeMeasuring = false;
   }
 
   // Have a concistent way of starting the video
@@ -158,6 +159,7 @@ class Measure {
       }
       return this.collect(url);
     } else {
+      this.areWeMeasuring = true;
       return this.engineDelegate.clear(this.browser);
     }
   }
@@ -236,6 +238,7 @@ class Measure {
     );
     this.numberOfMeasuredPages++;
     this.numberOfVisitedPages++;
+    this.areWeMeasuring = false;
   }
 }
 

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -151,6 +151,13 @@ class Iteration {
       }
 
       await navigationScript(context, commands);
+      if (commands.measure.areWeMeasuring === true) {
+        // someone forgot to call stop();
+        log.info(
+          'It looks like you missed to call measure.stop() after calling measure.start(..) (without using a URL). Checkout https://www.sitespeed.io/documentation/sitespeed.io/scripting/#measurestartalias'
+        );
+        await commands.measure.stop();
+      }
       await this.engineDelegate.onStopIteration(browser, index, result);
 
       for (const postScript of this.postScripts) {


### PR DESCRIPTION
The implementation of measure.start() and measure.stop() is not obvious,
so let us catch the case with missing measure.stop().

https://github.com/sitespeedio/sitespeed.io/issues/2372