### PR TITLE
Use orange layer on Android too.

### DIFF
--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -1,15 +1,11 @@
 'use strict';
 const log = require('intel').getLogger('browsertime.video');
-const { isAndroidConfigured } = require('../../android');
-module.exports = async function(driver, options) {
+module.exports = async function(driver) {
   log.debug('Add orange color');
-  if (isAndroidConfigured(options)) {
-    // base 64 encoded page that creates an orange background that gets unloaded on unload
-    return driver.get(
-      'data:text/html;base64,PGh0bWw+CjxoZWFkPgo8c3R5bGU+CmJvZHkge2JhY2tncm91bmQtY29sb3I6IHdoaXRlOyBtYXJnaW46IDA7fQojYW5kcm9pZCB7d2lkdGg6MTAwJTsgaGVpZ2h0OiAxMDAlOyBiYWNrZ3JvdW5kLWNvbG9yOiAjREU2NDBEO30KPC9zdHlsZT4KPHNjcmlwdD4Kd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ2JlZm9yZXVubG9hZCcsIGZ1bmN0aW9uKCkgewogIGNvbnN0IGFuZHJvaWQgPSBkb2N1bWVudC5nZXRFbGVtZW50QnlJZCgnYW5kcm9pZCcpCiAgYW5kcm9pZC5wYXJlbnROb2RlLnJlbW92ZUNoaWxkKGFuZHJvaWQpOwp9KTsKPC9zY3JpcHQ+CjwvaGVhZD4KPGJvZHk+PGRpdiBpZD0nYW5kcm9pZCc+PC9kaXY+PC9ib2R5Pgo8L2h0bWw+Cg=='
-    );
-  } else {
-    const orangeScript = `
+  // We tried other ways for Android (access an orange page)
+  // That works fine ... but break scripts
+  // https://github.com/sitespeedio/browsertime/issues/802
+  const orangeScript = `
       (function() {
         const orange = document.createElement('div');
         orange.id = 'browsertime-orange';
@@ -23,6 +19,5 @@ module.exports = async function(driver, options) {
         document.body.appendChild(orange);
         document.body.style.display = '';
       })();`;
-    return driver.executeScript(orangeScript);
-  }
+  return driver.executeScript(orangeScript);
 };


### PR DESCRIPTION
The old implementation use an orange page that was unloaded on unload
on Android. That worked fine but broke when you used a script clicking
on links and measurering visual metrics.

An alternative could be to have the orange page when you don't use a script
but we can fix that later on.

https://github.com/sitespeedio/browsertime/issues/802