### PR TITLE
Hack to make it possible to measure the same URL multiple times #804

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -56,6 +56,7 @@ class Measure {
     this.numberOfMeasuredPages = 0;
     this.numberOfVisitedPages = 0;
     this.areWeMeasuring = false;
+    this.testedURLs = {};
   }
 
   // Have a concistent way of starting the video
@@ -191,6 +192,20 @@ class Measure {
       }
     }
 
+    if (this.testedURLs[url]) {
+      log.info(
+        '%s has been tested before within the same run, it will get an extra query parameter named browsertime_run. Make sure to use alias to keep track of the URLs',
+        url
+      );
+      this.testedURLs[url] = this.testedURLs[url] + 1;
+      if (url.indexOf('?') > -1) {
+        url = url + '&browsertime_run=' + this.testedURLs[url];
+      } else {
+        url = url + '?browsertime_run=' + this.testedURLs[url];
+      }
+    } else {
+      this.testedURLs[url] = 1;
+    }
     this.result[this.numberOfMeasuredPages].url = url;
 
     const syncScripts = this.scriptsByCategory


### PR DESCRIPTION
This is a hack to make sure you can test the same URLs within the same
script. There are users that logs in and logs out the user on the
same URL and that breakes since we use the URL to create all the files
for that URL.

This hack adds a incremental query parameter to the URL.