### PR TITLE
If a page fails, use a empty HAR.

### DIFF
--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -185,6 +185,13 @@ class ChromeDelegate {
     this.hars.push(har);
   }
 
+  failing(url) {
+    if (this.skipHar) {
+      return;
+    }
+    this.hars.push(harBuilder.getEmptyHAR(url, 'Chrome'));
+  }
+
   async onStop() {
     if (!this.skipHar) {
       return { har: harBuilder.mergeHars(this.hars) };

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -77,12 +77,16 @@ class Collector {
   addFullyLoaded(url, fullyLoaded) {
     const statistics = this.allStats[url];
     const results = this.allResults[url];
-    results.fullyLoaded.push(fullyLoaded);
-    statistics.addDeep({
-      timings: {
-        fullyLoaded: fullyLoaded
-      }
-    });
+    if (results) {
+      results.fullyLoaded.push(fullyLoaded);
+    }
+    if (fullyLoaded) {
+      statistics.addDeep({
+        timings: {
+          fullyLoaded: fullyLoaded
+        }
+      });
+    }
   }
 
   /**

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -160,6 +160,7 @@ class Measure {
         // how many pages we tried to measure
         this.numberOfMeasuredPages++;
         this.numberOfVisitedPages++;
+        this.engineDelegate.failing(url);
         throw e;
       }
       return this.collect(url);

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -43,15 +43,22 @@ function addExtraFieldsToHar(totalResults, har, options) {
         const browserScript =
           totalResults[pageNumber].browserScripts[harPageNumber];
         const cpu = totalResults[pageNumber].cpu[harPageNumber];
-        harUtil.addExtrasToHAR(
+
+        harUtil.addMetaToHAR(
           harPageNumber,
           harPage,
-          visualMetric,
-          browserScript.timings,
-          cpu,
           totalResults[pageNumber].info.url,
           options
         );
+
+        if (browserScript) {
+          harUtil.addTimingsToHAR(
+            harPage,
+            visualMetric,
+            browserScript.timings,
+            cpu
+          );
+        }
         harPageNumber++;
       }
     } else {
@@ -64,16 +71,20 @@ function addExtraFieldsToHar(totalResults, har, options) {
           const visualMetric = totalResults[page].visualMetrics[iteration];
           const browserScript = totalResults[page].browserScripts[iteration];
           const cpu = totalResults[page].cpu[iteration];
+
+          harUtil.addMetaToHAR(
+            iteration,
+            har.log.pages[harIndex],
+            totalResults[page].info.url,
+            options
+          );
           // Only add the metrics if we was able to collect the metrics and have a HAR
           if (browserScript && har.log.pages[harIndex]) {
-            harUtil.addExtrasToHAR(
-              iteration,
+            harUtil.addTimingsToHAR(
               har.log.pages[harIndex],
               visualMetric,
               browserScript.timings,
-              cpu,
-              totalResults[page].info.url,
-              options
+              cpu
             );
           }
         }

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -115,6 +115,13 @@ class FirefoxDelegate {
     }
   }
 
+  failing(url) {
+    if (this.skipHar) {
+      return;
+    }
+    this.hars.push(harBuilder.getEmptyHAR(url, 'Firefox'));
+  }
+
   async onStop() {
     if (!this.skipHar && this.hars.length > 0) {
       return { har: harBuilder.mergeHars(this.hars) };

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -5,6 +5,7 @@ const pick = require('lodash.pick');
 const isEmpty = require('lodash.isempty');
 const get = require('lodash.get');
 const forEach = require('lodash.foreach');
+const dayjs = require('dayjs');
 const version = require('../../../package').version;
 const pathToFolder = require('../pathToFolder');
 
@@ -133,19 +134,33 @@ module.exports = {
 
     return combinedHar;
   },
-  addExtrasToHAR(
-    index,
-    harPage,
-    visualMetricsData,
-    timings,
-    cpu,
-    url,
-    options
-  ) {
+  addMetaToHAR(index, harPage, url, options) {
     const _meta = (harPage._meta = {});
-    // If we have alias, use that.
     _meta.connectivity = get(options, 'connectivity.profile', 'native');
     _meta.connectivity = get(options, 'connectivity.alias', _meta.connectivity);
+
+    if (options.resultURL) {
+      const base = options.resultURL.endsWith('/')
+        ? options.resultURL
+        : options.resultURL + '/';
+      if (options.screenshot) {
+        _meta.screenshot = `${base}${pathToFolder(
+          url,
+          options
+        )}screenshots/${index + 1}.${options.screenshotParams.type}`;
+      }
+      if (options.video) {
+        _meta.video = `${base}${pathToFolder(url, options)}video/${index +
+          1}.mp4`;
+      }
+      if (options.chrome && options.chrome.timeline) {
+        _meta.timeline = `${base}${pathToFolder(url, options)}trace-${index +
+          1}.json.gz`;
+      }
+    }
+  },
+
+  addTimingsToHAR(harPage, visualMetricsData, timings, cpu) {
     const harPageTimings = harPage.pageTimings;
 
     const _visualMetrics = (harPage._visualMetrics = {});
@@ -185,24 +200,32 @@ module.exports = {
       harPageTimings._domContentLoadedTime =
         timings.pageTimings.domContentLoadedTime;
     }
-    if (options.resultURL) {
-      const base = options.resultURL.endsWith('/')
-        ? options.resultURL
-        : options.resultURL + '/';
-      if (options.screenshot) {
-        _meta.screenshot = `${base}${pathToFolder(
-          url,
-          options
-        )}screenshots/${index + 1}.${options.screenshotParams.type}`;
+  },
+  getEmptyHAR(url, browser) {
+    return {
+      log: {
+        version: '1.2',
+        creator: {
+          name: 'Browsertime',
+          version: version,
+          comment: ''
+        },
+        browser: {
+          name: browser,
+          version: ''
+        },
+        pages: [
+          {
+            startedDateTime: dayjs().format(),
+            id: 'failing_page',
+            title: url,
+            pageTimings: {},
+            comment: ''
+          }
+        ],
+        entries: [],
+        comment: ''
       }
-      if (options.video) {
-        _meta.video = `${base}${pathToFolder(url, options)}video/${index +
-          1}.mp4`;
-      }
-      if (options.chrome && options.chrome.timeline) {
-        _meta.timeline = `${base}${pathToFolder(url, options)}trace-${index +
-          1}.json.gz`;
-      }
-    }
+    };
   }
 };

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -42,10 +42,14 @@ module.exports = {
         // get the id
         let pageId = results.har.log.pages[index].id;
         let entriesByPage = groupBy(results.har.log.entries, 'pageref');
-        requests = entriesByPage[pageId].length + ' requests';
-        for (const request of entriesByPage[pageId]) {
-          // transfer size
-          totalSize += request.response.bodySize;
+        requests = entriesByPage[pageId]
+          ? entriesByPage[pageId].length + ' requests'
+          : '0 requests';
+        if (entriesByPage[pageId]) {
+          for (const request of entriesByPage[pageId]) {
+            // transfer size
+            totalSize += request.response.bodySize;
+          }
         }
         if (totalSize > 1024) {
           totalSize = (totalSize / 1024).toFixed(2) + ' kb';


### PR DESCRIPTION
This fixes the problem that if one (of multiple pages) fails to load, we can still handle that in sitespeed.io, so that you as user knows what page failed.

This is a first step to better error handling.