### PR TITLE
Try out Tracium to parse the Chrome trace log and get better CPU metr…

### DIFF
--- a/lib/chrome/cpu.js
+++ b/lib/chrome/cpu.js
@@ -1,31 +1,50 @@
 'use strict';
 
 const log = require('intel').getLogger('browsertime.chrome.cpu');
-const { parseObject } = require('chrome-trace');
+const Tracium = require('tracium');
+
+function round(num, decimals = 3) {
+  const pow = Math.pow(10, decimals);
+  return Math.round(num * pow) / pow;
+}
 
 module.exports = {
   async parseCpuTrace(tracelog) {
     try {
-      const parsedTrace = parseObject(tracelog);
+      const tasks = Tracium.computeMainThreadTasks(tracelog, {
+        flatten: true
+      });
 
-      let mainThread = parsedTrace.mainThread;
-      // sometimes (since Chrome 70?) we miss out of the main thread
-      // so then take the thread with most eventTypes
-      let maxEvents = 0;
-      if (mainThread === undefined) {
-        for (let thread of Object.keys(parsedTrace.eventTypeTime)) {
-          if (
-            Object.keys(parsedTrace.eventTypeTime[thread]).length > maxEvents
-          ) {
-            // pick the one with most events
-            mainThread = thread;
-            maxEvents = Object.keys(parsedTrace.eventTypeTime[thread]).length;
-          }
+      const categories = {
+        parseHTML: 0,
+        styleLayout: 0,
+        paintCompositeRender: 0,
+        scriptParseCompile: 0,
+        scriptEvaluation: 0,
+        garbageCollection: 0,
+        other: 0
+      };
+
+      const events = {};
+
+      for (const task of tasks) {
+        categories[task.kind] += task.selfTime;
+        if (events[task.event.name]) {
+          events[task.event.name] += task.selfTime;
+        } else {
+          events[task.event.name] = task.selfTime;
         }
       }
 
-      const events = parsedTrace.eventTypeTime[mainThread];
-      const categories = parsedTrace.eventCategoryTime[mainThread];
+      // Fix decimals
+      for (let category of Object.keys(categories)) {
+        categories[category] = round(categories[category], 0);
+      }
+
+      for (let event of Object.keys(events)) {
+        events[event] = round(events[event]);
+      }
+
       return { categories, events };
     } catch (e) {
       log.error('Could not parse the trace log from Chrome', e);

--- a/lib/chrome/cpu.js
+++ b/lib/chrome/cpu.js
@@ -26,6 +26,7 @@ module.exports = {
       };
 
       const events = {};
+      const urls = {};
 
       for (const task of tasks) {
         categories[task.kind] += task.selfTime;
@@ -33,6 +34,16 @@ module.exports = {
           events[task.event.name] += task.selfTime;
         } else {
           events[task.event.name] = task.selfTime;
+        }
+
+        if (task.attributableURLs && task.attributableURLs.length > 0) {
+          for (let url of task.attributableURLs) {
+            if (urls[url]) {
+              urls[url] += task.selfTime;
+            } else {
+              urls[url] = task.selfTime;
+            }
+          }
         }
       }
 
@@ -45,7 +56,11 @@ module.exports = {
         events[event] = round(events[event]);
       }
 
-      return { categories, events };
+      for (let url of Object.keys(urls)) {
+        urls[url] = round(urls[url]);
+      }
+
+      return { categories, events, urls };
     } catch (e) {
       log.error('Could not parse the trace log from Chrome', e);
       return {};

--- a/lib/chrome/cpu.js
+++ b/lib/chrome/cpu.js
@@ -56,8 +56,14 @@ module.exports = {
         events[event] = round(events[event]);
       }
 
+      // Only report URLs with more than 10 ms
+      const limit = 10;
       for (let url of Object.keys(urls)) {
-        urls[url] = round(urls[url]);
+        if (urls[url] > limit) {
+          urls[url] = round(urls[url]);
+        } else {
+          delete urls[url];
+        }
       }
 
       return { categories, events, urls };

--- a/lib/chrome/webdriver/index.js
+++ b/lib/chrome/webdriver/index.js
@@ -15,8 +15,7 @@ const getViewPort = require('../../support/getViewPort');
 
 let hasConfiguredChromeDriverService = false;
 const timelineTraceCategories =
-  '-*, devtools.timeline, disabled-by-default-devtools.timeline, disabled-by-default-devtools.timeline.stack';
-
+  '-*, disabled-by-default-lighthouse, v8, v8.execute, blink.user_timing, devtools.timeline, disabled-by-default-devtools.timeline disabled-by-default-devtools.timeline.stack';
 /**
  * Configure a WebDriver builder based on the specified options.
  * @param builder

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -191,8 +191,12 @@ class Collector {
       // Add CPU data (if we have it)
       if (data.cpu && data.cpu.categories) {
         results.cpu.push(data.cpu);
+        // We skip adding stats per URL .., we should do it per domain instead in sitespeed.io
         statistics.addDeep({
-          cpu: data.cpu
+          cpu: {
+            categories: data.cpu.categories,
+            events: data.cpu.events
+          }
         });
       }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4954,9 +4954,9 @@
       }
     },
     "tracium": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tracium/-/tracium-0.1.1.tgz",
-      "integrity": "sha512-usamXMQDs9K82f2JtyCUC8gHqqEolmmVokh5849Wm3UFwCoRo3WKoCRdoLHcTxC6gg+ghY943F03KuQbv8wUyQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tracium/-/tracium-0.2.0.tgz",
+      "integrity": "sha512-5mzuDXuauD0TR7mwulMilfS5Dhs6W/J7pvtvGIkuHiCFEHN20mUJ8UygVBncacGtcOkFDfWjv5oFv483aklEzA==",
       "requires": {
         "debug": "^4.1.1"
       },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2829,29 +2829,6 @@
         }
       }
     },
-    "chrome-trace": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/chrome-trace/-/chrome-trace-0.2.2.tgz",
-      "integrity": "sha512-lEEGp/8szNDXz5gMIE/+KeNFbL/8XCJ6ai897ngTmThzxxvSPBI+dw6UlnKaPLov5+ie1VPMAuz47YxnCB93rw==",
-      "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -4974,6 +4951,29 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "^1.4.1"
+      }
+    },
+    "tracium": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tracium/-/tracium-0.1.1.tgz",
+      "integrity": "sha512-usamXMQDs9K82f2JtyCUC8gHqqEolmmVokh5849Wm3UFwCoRo3WKoCRdoLHcTxC6gg+ghY943F03KuQbv8wUyQ==",
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "selenium-webdriver": "https://github.com/sitespeedio/selenium/archive/v3.6.0.tar.gz",
     "sharp": "0.21.1",
     "@sitespeed.io/geckodriver": "0.24.0",
-    "tracium": "0.1.1",
+    "tracium": "0.2.0",
     "valid-url": "1.0.9",
     "@cypress/xvfb": "1.2.4",
     "yargs": "12.0.5"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "adbkit": "2.11.0",
     "@sitespeed.io/chromedriver": "74.0.372-9.6-1",
     "chrome-har": "0.9.1",
-    "chrome-trace": "0.2.2",
     "dayjs": "1.7.8",
     "execa": "1.0.0",
     "fast-stats": "0.0.4",
@@ -25,6 +24,7 @@
     "selenium-webdriver": "https://github.com/sitespeedio/selenium/archive/v3.6.0.tar.gz",
     "sharp": "0.21.1",
     "@sitespeed.io/geckodriver": "0.24.0",
+    "tracium": "0.1.1",
     "valid-url": "1.0.9",
     "@cypress/xvfb": "1.2.4",
     "yargs": "12.0.5"


### PR DESCRIPTION
…ics.

The Tracium project is a blessing so we can skip spending time on parsing
the trace log in our own lib.

This also changes the default trace logs collected (following Lighthouse)
and introduces new high level categories. If we want it this way we need
to push this in 5.0.