### PR TITLE
Include last 50 pixel when checking for orange.

### DIFF
--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -780,7 +780,7 @@ def is_color_frame(file, color_file):
             # Bottom
             crops.append('{0:d}x{1:d}+{2:d}+{3:d}'.format(
                 int(width / 2), int(height / 5),
-                int(width / 4), height - int(height / 5) - 50))
+                int(width / 4), height - int(height / 5)))
             for crop in crops:
                 command = ('{0} "{1}" "(" "{2}" -crop {3} -resize 200x200! ")"'
                            ' miff:- | {4} -metric AE - -fuzz 15% null:'


### PR DESCRIPTION
When checking for orange frame, Visual Metrics don't include the bottom
50 px. That is probably ok if your video has the browser window at the
bottom but we crop that out.

We need to verify that this works on mobile too.