### PR TITLE
Use CDP to set headers for Chrome.

### DIFF
--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -9,6 +9,7 @@ const perflogParser = require('chrome-har');
 const fs = require('fs');
 const { parseCpuTrace } = require('../cpu');
 const webdriver = require('selenium-webdriver');
+const util = require('../../support/util');
 const zlib = require('zlib');
 const traceCategoriesParser = require('../traceCategoriesParser');
 const pathToFolder = require('../../support/pathToFolder');
@@ -116,6 +117,19 @@ class ChromeDelegate {
     if (this.options.injectJs) {
       await this.cdpClient.Page.addScriptToEvaluateOnNewDocument({
         source: this.options.injectJs
+      });
+    }
+
+    if (this.options.requestheader) {
+      const headersArray = util.toArray(this.options.requestheader);
+      const headers = {};
+      for (let header of headersArray) {
+        const parts = header.split(':');
+        headers[parts[0]] = parts[1];
+      }
+      await this.cdpClient.Network.enable();
+      await this.cdpClient.Network.setExtraHTTPHeaders({
+        headers
       });
     }
 

--- a/lib/extensionserver/index.js
+++ b/lib/extensionserver/index.js
@@ -30,7 +30,7 @@ class ExtensionServer {
     // always start with running our extension for the setup
     if (
       options.cacheClearRaw ||
-      options.requestheader ||
+      (options.requestheader && options.browser === 'firefox') ||
       options.block ||
       options.basicAuth ||
       options.cookie ||


### PR DESCRIPTION
With this we avoid using the extension server when setting headers
for Chrome and it will also work on Android devices!

See https://github.com/sitespeedio/sitespeed.io/issues/2520