### PR TITLE
Fix collecting net log when scripting #873

### DIFF
--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -41,7 +41,7 @@ class ChromeDelegate {
     this.collectTracingEvents =
       this.chrome.traceCategories || this.chrome.timeline;
     this.baseDir = storageManager.directory;
-    this.storageManeger = storageManager;
+    this.storageManager = storageManager;
     // We keep track of all alias and URLs
     this.aliasAndUrl = {};
     this.isTracing = false;
@@ -174,7 +174,12 @@ class ChromeDelegate {
     await runner.getLogs(Type.PERFORMANCE);
   }
 
-  async onStopIteration() {}
+  async onStopIteration() {
+    if (this.chrome.collectNetLog && !this.chrome.android) {
+      const netlog = `${this.baseDir}/chromeNetlog.json`;
+      return unlink(netlog);
+    }
+  }
 
   async beforeEachURL() {
     if (this.collectTracingEvents && !this.isTracing) {
@@ -193,6 +198,10 @@ class ChromeDelegate {
 
   async onCollect(runner, index, result) {
     if (this.chrome.collectNetLog && !this.chrome.android) {
+      await this.storageManager.createSubDataDir(
+        path.join(pathToFolder(result.url, this.options))
+      );
+
       const gzip = zlib.createGzip();
       const netlog = `${this.baseDir}/chromeNetlog.json`;
       const input = fs.createReadStream(netlog);
@@ -204,7 +213,10 @@ class ChromeDelegate {
         )
       );
       out.on('finish', function() {
-        return unlink(netlog);
+        // return unlink(netlog);
+      });
+      out.on('error', function(e) {
+        log.error('Could not gzip the Chrome net log', e);
       });
       input.pipe(gzip).pipe(out);
     }

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -7,7 +7,6 @@ const log = require('intel').getLogger('browsertime');
 const Statistics = require('../../support/statistics').Statistics;
 const pathToFolder = require('../../support/pathToFolder');
 const path = require('path');
-const pathToFolders = require('../../support/pathToFolder');
 
 function getNewResult(url, options) {
   return {
@@ -226,7 +225,7 @@ class Collector {
       }
 
       await this.storageManager.createSubDataDir(
-        path.join(pathToFolders(url, this.options))
+        path.join(pathToFolder(url, this.options))
       );
 
       // Store all extra JSON metrics


### PR DESCRIPTION
Getting the netlog for Chrome was broken when suing scripting. This fix
catches an error and changes when we remove the file. If you test multiple URLs
the netlog will contain all interactions for the script. The first file = first URL. The second file = first and second url.