### PR TITLE
[6.0] Use SpeedLine to get Visual Metrics.

### DIFF
--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -41,7 +41,7 @@ async function saveJpg(name, data, url, storageManager, config, options) {
     .resize(config.maxSize, config.maxSize)
     .resize({ fit: 'inside' })
     .toBuffer();
-  storageManager.writeData(
+  return storageManager.writeData(
     `${name}.jpg`,
     buffer,
     path.join(pathToFolder(url, options), 'video', 'images')

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -294,37 +294,41 @@ class ChromeDelegate {
 
       if (
         this.chrome.enableTraceScreenshots &&
-        this.chrome.traceVisualMetrics &&
+        this.chrome.visualMetricsUsingTrace &&
         this.options.cpu
       ) {
-        const tmp = path.join(
-          pathToFolder(result.url, this.options),
-          'trace.tmp.json'
-        );
-        await this.storageManager.createSubDataDir(
-          path.join(pathToFolder(result.url, this.options))
-        );
-        await this.storageManager.writeJson(tmp, trace, false);
-        const speedlineResult = await speedline(
-          path.join(this.storageManager.directory, tmp)
-        );
-        const startTs = speedlineResult.beginning;
-        const visualProgress = speedlineResult.frames
-          .map(frame => {
-            const ts = Math.floor(frame.getTimeStamp() - startTs);
-            return `${ts}=${Math.floor(frame.getProgress())}%`;
-          })
-          .join(', ');
+        try {
+          const tmp = path.join(
+            pathToFolder(result.url, this.options),
+            'trace.tmp.json'
+          );
+          await this.storageManager.createSubDataDir(
+            path.join(pathToFolder(result.url, this.options))
+          );
+          await this.storageManager.writeJson(tmp, trace, false);
+          const speedlineResult = await speedline(
+            path.join(this.storageManager.directory, tmp)
+          );
+          const startTs = speedlineResult.beginning;
+          const visualProgress = speedlineResult.frames
+            .map(frame => {
+              const ts = Math.floor(frame.getTimeStamp() - startTs);
+              return `${ts}=${Math.floor(frame.getProgress())}%`;
+            })
+            .join(', ');
 
-        result.visualMetrics = visualMetricsExtra({
-          FirstVisualChange: speedlineResult.first,
-          LastVisualChange: speedlineResult.complete,
-          SpeedIndex: speedlineResult.speedIndex,
-          PerceptualSpeedIndex: speedlineResult.perceptualSpeedIndex,
-          VisualProgress: visualProgress
-        }).visualMetrics;
+          result.visualMetrics = visualMetricsExtra({
+            FirstVisualChange: speedlineResult.first,
+            LastVisualChange: speedlineResult.complete,
+            SpeedIndex: speedlineResult.speedIndex,
+            PerceptualSpeedIndex: speedlineResult.perceptualSpeedIndex,
+            VisualProgress: visualProgress
+          }).visualMetrics;
 
-        await unlink(path.join(this.storageManager.directory, tmp));
+          await unlink(path.join(this.storageManager.directory, tmp));
+        } catch (e) {
+          log.error('Could not generate Visual Metrics using SpeedLine', e);
+        }
       }
     }
 

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -11,7 +11,7 @@ const { parseCpuTrace } = require('../cpu');
 const webdriver = require('selenium-webdriver');
 const util = require('../../support/util');
 const zlib = require('zlib');
-const sharp = require('sharp');
+const images = require('../../support/images');
 const traceCategoriesParser = require('../traceCategoriesParser');
 const pathToFolder = require('../../support/pathToFolder');
 const path = require('path');
@@ -34,19 +34,6 @@ const CHROME_NAME_AND_VERSION_JS = `return (function() {
   else
     return {};
 })();`;
-
-async function saveJpg(name, data, url, storageManager, config, options) {
-  const buffer = await sharp(data)
-    .jpeg({ quality: config.jpg.quality })
-    .resize(config.maxSize, config.maxSize)
-    .resize({ fit: 'inside' })
-    .toBuffer();
-  return storageManager.writeData(
-    `${name}.jpg`,
-    buffer,
-    path.join(pathToFolder(url, options), 'video', 'images')
-  );
-}
 
 function pad(n) {
   const extraZeroes = 6 - n.toString().length;
@@ -344,7 +331,7 @@ class ChromeDelegate {
             const d = new Date(frame.getTimeStamp() - startTs);
             const name = 'ms_' + pad(d.getTime());
             promises.push(
-              saveJpg(
+              images.saveJpg(
                 name,
                 frame.getImage(),
                 result.url,
@@ -356,6 +343,7 @@ class ChromeDelegate {
                   },
                   maxSize: 400
                 },
+                path.join('filmstrip', index + ''),
                 this.options
               )
             );

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -11,6 +11,7 @@ const { parseCpuTrace } = require('../cpu');
 const webdriver = require('selenium-webdriver');
 const util = require('../../support/util');
 const zlib = require('zlib');
+const sharp = require('sharp');
 const traceCategoriesParser = require('../traceCategoriesParser');
 const pathToFolder = require('../../support/pathToFolder');
 const path = require('path');
@@ -33,6 +34,27 @@ const CHROME_NAME_AND_VERSION_JS = `return (function() {
   else
     return {};
 })();`;
+
+async function saveJpg(name, data, url, storageManager, config, options) {
+  const buffer = await sharp(data)
+    .jpeg({ quality: config.jpg.quality })
+    .resize(config.maxSize, config.maxSize)
+    .resize({ fit: 'inside' })
+    .toBuffer();
+  storageManager.writeData(
+    `${name}.jpg`,
+    buffer,
+    path.join(pathToFolder(url, options), 'video', 'images')
+  );
+}
+
+function pad(n) {
+  const extraZeroes = 6 - n.toString().length;
+  for (let i = 0; i < extraZeroes; i++) {
+    n = '0' + n;
+  }
+  return n;
+}
 
 class ChromeDelegate {
   constructor(storageManager, options) {
@@ -298,17 +320,7 @@ class ChromeDelegate {
         this.options.cpu
       ) {
         try {
-          const tmp = path.join(
-            pathToFolder(result.url, this.options),
-            'trace.tmp.json'
-          );
-          await this.storageManager.createSubDataDir(
-            path.join(pathToFolder(result.url, this.options))
-          );
-          await this.storageManager.writeJson(tmp, trace, false);
-          const speedlineResult = await speedline(
-            path.join(this.storageManager.directory, tmp)
-          );
+          const speedlineResult = await speedline(trace.traceEvents);
           const startTs = speedlineResult.beginning;
           const visualProgress = speedlineResult.frames
             .map(frame => {
@@ -325,7 +337,31 @@ class ChromeDelegate {
             VisualProgress: visualProgress
           }).visualMetrics;
 
-          await unlink(path.join(this.storageManager.directory, tmp));
+          const promises = [];
+          for (let frame of speedlineResult.frames) {
+            // follow the name standard of Visual Metrics
+            // ms_000000.jpg
+            const d = new Date(frame.getTimeStamp() - startTs);
+            const name = 'ms_' + pad(d.getTime());
+            promises.push(
+              saveJpg(
+                name,
+                frame.getImage(),
+                result.url,
+                this.storageManager,
+                {
+                  type: 'jpg',
+                  jpg: {
+                    quality: 80
+                  },
+                  maxSize: 400
+                },
+                this.options
+              )
+            );
+          }
+
+          await Promise.all(promises);
         } catch (e) {
           log.error('Could not generate Visual Metrics using SpeedLine', e);
         }

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -307,7 +307,9 @@ class ChromeDelegate {
         this.options.cpu
       ) {
         try {
+          log.debug('Get Speedline result from the trace');
           const speedlineResult = await speedline(trace.traceEvents);
+          log.debug('Got Speedline result.');
           const startTs = speedlineResult.beginning;
           const visualProgress = speedlineResult.frames
             .map(frame => {

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -14,6 +14,8 @@ const zlib = require('zlib');
 const traceCategoriesParser = require('../traceCategoriesParser');
 const pathToFolder = require('../../support/pathToFolder');
 const path = require('path');
+const speedline = require('speedline-core');
+const visualMetricsExtra = require('../../video/postprocessing/visualmetrics/extraMetrics');
 const CDP = require('chrome-remote-interface');
 
 const unlink = promisify(fs.unlink);
@@ -289,6 +291,37 @@ class ChromeDelegate {
       result.extraJson[`trace-${index}.json`] = trace;
       const cpu = await parseCpuTrace(trace, result.url);
       result.cpu = cpu;
+
+      if (this.chrome.enableTraceScreenshots && !this.options.video) {
+        const tmp = path.join(
+          pathToFolder(result.url, this.options),
+          'trace.tmp.json'
+        );
+        await this.storageManager.createSubDataDir(
+          path.join(pathToFolder(result.url, this.options))
+        );
+        await this.storageManager.writeJson(tmp, trace, false);
+        const speedlineResult = await speedline(
+          path.join(this.storageManager.directory, tmp)
+        );
+        const startTs = speedlineResult.beginning;
+        const visualProgress = speedlineResult.frames
+          .map(frame => {
+            const ts = Math.floor(frame.getTimeStamp() - startTs);
+            return `${ts}=${Math.floor(frame.getProgress())}%`;
+          })
+          .join(', ');
+
+        result.visualMetrics = visualMetricsExtra({
+          FirstVisualChange: speedlineResult.first,
+          LastVisualChange: speedlineResult.complete,
+          SpeedIndex: speedlineResult.speedIndex,
+          PerceptualSpeedIndex: speedlineResult.perceptualSpeedIndex,
+          VisualProgress: visualProgress
+        }).visualMetrics;
+
+        await unlink(path.join(this.storageManager.directory, tmp));
+      }
     }
 
     // lets take the time and format the CPU long tasks

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -307,8 +307,19 @@ class ChromeDelegate {
         this.options.cpu
       ) {
         try {
+          const navStart = trace.traceEvents.filter(
+            task =>
+              task.cat === 'blink.user_timing' &&
+              task.name === 'navigationStart'
+          );
+          navStart.sort(function(a, b) {
+            return a.ts - b.ts;
+          });
           log.debug('Get Speedline result from the trace');
-          const speedlineResult = await speedline(trace.traceEvents);
+          const speedlineResult = await speedline(trace.traceEvents, {
+            timeOrigin: navStart[0].ts,
+            fastMode: true
+          });
           log.debug('Got Speedline result.');
           const startTs = speedlineResult.beginning;
           const visualProgress = speedlineResult.frames

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -17,8 +17,6 @@ const path = require('path');
 const speedline = require('speedline-core');
 const visualMetricsExtra = require('../../video/postprocessing/visualmetrics/extraMetrics');
 const ChromeDevtoolsProtocol = require('./chromeDevtoolsProtocol');
-
-
 const unlink = promisify(fs.unlink);
 
 const { createAndroidConnection } = require('../../android');
@@ -270,10 +268,12 @@ class ChromeDelegate {
             .join(', ');
 
           result.visualMetrics = visualMetricsExtra({
-            FirstVisualChange: speedlineResult.first,
-            LastVisualChange: speedlineResult.complete,
-            SpeedIndex: speedlineResult.speedIndex,
-            PerceptualSpeedIndex: speedlineResult.perceptualSpeedIndex,
+            FirstVisualChange: speedlineResult.first.toFixed(0),
+            LastVisualChange: speedlineResult.complete.toFixed(0),
+            SpeedIndex: speedlineResult.speedIndex.toFixed(0),
+            PerceptualSpeedIndex: speedlineResult.perceptualSpeedIndex.toFixed(
+              0
+            ),
             VisualProgress: visualProgress
           }).visualMetrics;
 

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -292,7 +292,11 @@ class ChromeDelegate {
       const cpu = await parseCpuTrace(trace, result.url);
       result.cpu = cpu;
 
-      if (this.chrome.enableTraceScreenshots && !this.options.video) {
+      if (
+        this.chrome.enableTraceScreenshots &&
+        this.chrome.traceVisualMetrics &&
+        this.options.cpu
+      ) {
         const tmp = path.join(
           pathToFolder(result.url, this.options),
           'trace.tmp.json'

--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -1,39 +1,9 @@
 'use strict';
 
-const sharp = require('sharp');
-const path = require('path');
 const merge = require('lodash.merge');
 const defaultConfig = require('./defaults');
-const pathToFolder = require('../support/pathToFolder');
-
 const SCREENSHOT_DIR = 'screenshots';
-
-async function savePng(name, data, url, storageManager, config, options) {
-  const buffer = await sharp(data)
-    .png({ compressionLevel: config.png.compressionLevel })
-    .resize(config.maxSize, config.maxSize)
-    .resize({ fit: 'inside' })
-    .toBuffer();
-  return storageManager.writeData(
-    `${name}.png`,
-    buffer,
-    path.join(pathToFolder(url, options), SCREENSHOT_DIR)
-  );
-}
-
-async function saveJpg(name, data, url, storageManager, config, options) {
-  const buffer = await sharp(data)
-    .jpeg({ quality: config.jpg.quality })
-    .resize(config.maxSize, config.maxSize)
-    .resize({ fit: 'inside' })
-    .toBuffer();
-  storageManager.writeData(
-    `${name}.jpg`,
-    buffer,
-    path.join(pathToFolder(url, options), SCREENSHOT_DIR)
-  );
-}
-
+const images = require('../support/images');
 class ScreenshotManager {
   constructor(storageManager, options) {
     this.storageManager = storageManager;
@@ -43,21 +13,23 @@ class ScreenshotManager {
 
   async save(name, data, url) {
     if (this.config.type === 'png') {
-      return savePng(
+      return images.savePng(
         name,
         data,
         url,
         this.storageManager,
         this.config,
+        SCREENSHOT_DIR,
         this.options
       );
     } else {
-      return saveJpg(
+      return images.saveJpg(
         name,
         data,
         url,
         this.storageManager,
         this.config,
+        SCREENSHOT_DIR,
         this.options
       );
     }

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -181,6 +181,13 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'chrome'
     })
+    .option('chrome.visualMetricsUsingTrace', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Collect Visual Metrics using Chrome trace log. You need enable trace screenshots --chrome.enableTraceScreenshots and --cpu metrics for this to work.',
+      group: 'chrome'
+    })
     .option('chrome.timeline', {
       describe:
         'Collect the timeline data. Drag and drop the JSON in your Chrome detvools timeline panel or check out the CPU metrics in the Browsertime.json',

--- a/lib/support/images/index.js
+++ b/lib/support/images/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const sharp = require('sharp');
+const pathToFolder = require('../pathToFolder');
+const path = require('path');
+
+module.exports = {
+  async savePng(name, data, url, storageManager, config, dir, options) {
+    const buffer = await sharp(data)
+      .png({ compressionLevel: config.png.compressionLevel })
+      .resize(config.maxSize, config.maxSize)
+      .resize({ fit: 'inside' })
+      .toBuffer();
+    return storageManager.writeData(
+      `${name}.png`,
+      buffer,
+      path.join(pathToFolder(url, options), dir)
+    );
+  },
+
+  async saveJpg(name, data, url, storageManager, config, dir, options) {
+    const buffer = await sharp(data)
+      .jpeg({ quality: config.jpg.quality })
+      .resize(config.maxSize, config.maxSize)
+      .resize({ fit: 'inside' })
+      .toBuffer();
+    storageManager.writeData(
+      `${name}.jpg`,
+      buffer,
+      path.join(pathToFolder(url, options), dir)
+    );
+  }
+};

--- a/lib/video/postprocessing/visualmetrics/single/getVideoMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/single/getVideoMetrics.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 module.exports = async function(
   videoDir,
+  filmstripDir,
   videoPath,
   index,
   visualElements, // results.browserScripts.pageinfo.visualElements
@@ -25,14 +26,13 @@ module.exports = async function(
       true
     );
   }
-  const imageDir = path.join(videoDir, 'images', '' + index);
   const elementsFile = path.join(
     storageManager.directory,
     index + '-visualElements.json.gz'
   );
   const metrics = await visualMetrics.run(
     videoPath,
-    imageDir,
+    filmstripDir,
     elementsFile,
     videoDir,
     index,

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -26,8 +26,9 @@ class Video {
     this.videoDir = await storageManager.createSubDataDir(
       path.join(pathToFolders(url, this.options), 'video')
     );
-    await storageManager.createSubDataDir(
-      path.join(pathToFolders(url, this.options), 'video', 'images', '' + index)
+
+    this.filmstripDir = await await storageManager.createSubDataDir(
+      path.join(pathToFolders(url, this.options), 'filmstrip', '' + index)
     );
   }
 
@@ -86,6 +87,7 @@ class Video {
     if (this.options.visualMetrics) {
       videoMetrics = await getVideoMetrics(
         this.videoDir,
+        this.filmstripDir,
         this.videoPath,
         this.index,
         visualElements,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2551,6 +2551,11 @@
         }
       }
     },
+    "@types/node": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.1.tgz",
+      "integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ=="
+    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -3603,6 +3608,11 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha1-g7Qsei5uS4VQVHf+aRf128VkIOU="
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -3761,6 +3771,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "jpeg-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
+      "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4606,6 +4621,16 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "speedline-core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.2.tgz",
+      "integrity": "sha512-9/5CApkKKl6bS6jJ2D0DQllwz/1xq3cyJCR6DLgAQnkj5djCuq8NbflEdD2TI01p8qzS9qaKjzxM9cHT11ezmg==",
+      "requires": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.1.2"
       }
     },
     "split": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sharp": "0.22.1",
     "@sitespeed.io/geckodriver": "0.24.0",
     "@sitespeed.io/tracium": "0.3.3",
+    "speedline-core": "1.4.2",
     "valid-url": "1.0.9",
     "@cypress/xvfb": "1.2.4",
     "yargs": "13.2.4"


### PR DESCRIPTION
Use SpeedLine and Chrome trace log to collect Visual Metrics and filmstrip screenshots. 

This should go out in the next major: It changes where filmstrip screenshots are stored by default (before video/images, now it is /filmstrip both for VisualMetrics and SpeedLine.

Enable by running `--cpu --chrome.visualMetricsUsingTrace --chrome.enableTraceScreenshots`