### PR TITLE
Fix: Turn off visual metrics with --visualMetrics false

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -182,7 +182,7 @@ class Iteration {
       }
       await browser.stop();
 
-      if (recordVideo && !options.videoParams.debug) {
+      if (options.visualMetrics && !options.videoParams.debug) {
         let i = 0;
         for (let myVideo of videos) {
           try {


### PR DESCRIPTION
As reported in https://github.com/mozilla/browsertime/issues/23