### PR TITLE
Inject navigationStart event if we miss it.

### DIFF
--- a/lib/chrome/traceCategoriesParser.js
+++ b/lib/chrome/traceCategoriesParser.js
@@ -39,13 +39,13 @@ function cleanTrace(trace, url) {
     };
   };
 
-  const makeNavStart = (evt, ts, fid, url) => {
+  const makeNavStart = (evt, ts, tts, fid, url) => {
     return {
       args: {
         data: {
           documentLoaderURL: url,
           isLoadingMainFrame: true,
-          navigationId: 'fake'
+          navigationId: 'insertedByBrowsertime'
         },
         frame: fid
       },
@@ -55,7 +55,7 @@ function cleanTrace(trace, url) {
       pid: evt.pid,
       tid: evt.tid,
       ts: ts || 0,
-      tts: 121451
+      tts: tts || 0
     };
   };
 
@@ -63,12 +63,8 @@ function cleanTrace(trace, url) {
   let data;
   let name;
   let counter;
-  let foundNavStart = false;
 
   traceEvents.forEach((evt, idx) => {
-    if (evt.name === 'navigationStart') {
-      foundNavStart = true;
-    }
     if (evt.name.startsWith('TracingStartedIn')) {
       traceStartEvents.push(idx);
     }
@@ -107,6 +103,9 @@ function cleanTrace(trace, url) {
   const ts =
     traceEvents[traceStartEvents[0]] && traceEvents[traceStartEvents[0]].ts;
 
+  const tts =
+    traceEvents[traceStartEvents[0]] && traceEvents[traceStartEvents[0]].tts;
+
   // account for offset after removing items
   let i = 0;
   for (let dup of traceStartEvents) {
@@ -131,11 +130,18 @@ function cleanTrace(trace, url) {
     );
   }
 
+  // Verify that we got a navigationStart event for that frame. In Chrome 76 we started to get
+  // navigations that doesn't match the main frame.
+  // https://github.com/sitespeedio/browsertime/issues/902
+  const navigationEvents = traceEvents.filter(
+    e => e.args.frame === mostActiveFrame.frame && e.name === 'navigationStart'
+  );
+
   // Tracium needs a navigation start event to fire, but when we test SPAs that
   // isn't happening. Best way for now is just to insert it our selves.
-  if (!foundNavStart) {
+  if (navigationEvents.length === 0) {
     traceEvents.unshift(
-      makeNavStart(mostActiveFrame, ts, mostActiveFrame.frame, url)
+      makeNavStart(mostActiveFrame, ts, tts, mostActiveFrame.frame, url)
     );
   }
 

--- a/lib/chrome/traceCategoriesParser.js
+++ b/lib/chrome/traceCategoriesParser.js
@@ -140,6 +140,9 @@ function cleanTrace(trace, url) {
   // Tracium needs a navigation start event to fire, but when we test SPAs that
   // isn't happening. Best way for now is just to insert it our selves.
   if (navigationEvents.length === 0) {
+    log.info(
+      'Injecting navigationStart event in the trace log since we could not find any for the most active frame.'
+    );
     traceEvents.unshift(
       makeNavStart(mostActiveFrame, ts, tts, mostActiveFrame.frame, url)
     );


### PR DESCRIPTION
In Chrome 76 we started to see missing navigationStart events for the
main frame. https://github.com/sitespeedio/browsertime/issues/902