### PR TITLE
[6.0 and Chrome 77] Always get long task events (for Chrome).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
     throttle
   - node ./bin/browsertime.js -b chrome --skipHar -n 1 --preURL https://www.sitespeed.io/ -r header:value --chrome.CPUThrottlingRate 2 --chrome.cdp.performance https://www.sitespeed.io/documentation/
   - node ./bin/browsertime.js -b chrome -vv --viewPort=640x480 --video --screenshot
-    --visualMetrics -n 1 --chrome.timeline --videoParams.fontPath /usr/share/fonts/truetype/ubuntu-font-family/Ubuntu-R.ttf --visualElements --chrome.collectLongTasks https://www.sitespeed.io/
+    --visualMetrics -n 1 --chrome.timeline --videoParams.fontPath /usr/share/fonts/truetype/ubuntu-font-family/Ubuntu-R.ttf --visualElements https://www.sitespeed.io/
   - node ./bin/browsertime.js -b chrome test/navigationscript/measure.js -n 1 --preScript test/prepostscripts/preSample.js --postScript test/prepostscripts/postSample.js
   - node ./bin/browsertime.js -b chrome test/navigationscript/navigateAndStartInTwoSteps.js -n 1
   - node ./bin/browsertime.js -b firefox test/navigationscript/multi.js https://www.sitespeed.io/blog/ -n 1

--- a/browserscripts/pageinfo/longTask.js
+++ b/browserscripts/pageinfo/longTask.js
@@ -1,24 +1,25 @@
 (function(minLength) {
-  if (window.__bt_longtask) {
-    const cleaned = [];
-    for (let event of window.__bt_longtask.e) {
-      if (event.duration >= minLength) {
-        const e = {};
-        e.duration = event.duration;
-        e.name = event.name;
-        e.startTime = event.startTime;
-        e.attribution = [];
-        for (let at of event.attribution) {
-          const a = {};
-          a.containerId = at.containerId;
-          a.containerName = at.containerName;
-          a.containerSrc = at.containerSrc;
-          a.containerType = at.containerType;
-          e.attribution.push(a);
-        }
-        cleaned.push(e);
+  const observer = new PerformanceObserver(list => {});
+  observer.observe({ type: 'longtask', buffered: true });
+  const entries = observer.takeRecords();
+  const cleaned = [];
+  for (let event of entries) {
+    if (event.duration >= minLength) {
+      const e = {};
+      e.duration = event.duration;
+      e.name = event.name;
+      e.startTime = event.startTime;
+      e.attribution = [];
+      for (let at of event.attribution) {
+        const a = {};
+        a.containerId = at.containerId;
+        a.containerName = at.containerName;
+        a.containerSrc = at.containerSrc;
+        a.containerType = at.containerType;
+        e.attribution.push(a);
       }
+      cleaned.push(e);
     }
-    return cleaned;
   }
+  return cleaned;
 })(arguments[arguments.length - 1]);

--- a/browserscripts/pageinfo/longTask.js
+++ b/browserscripts/pageinfo/longTask.js
@@ -1,6 +1,6 @@
 (function(minLength) {
   const observer = new PerformanceObserver(list => {});
-  observer.observe({ type: 'longtask', buffered: true });
+  observer.observe({ entryTypes: ['longtask'], buffered: true });
   const entries = observer.takeRecords();
   const cleaned = [];
   for (let event of entries) {

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -89,10 +89,6 @@ class ChromeDelegate {
       await this.cdpClient.setRequestHeaders(this.options.requestheader);
     }
 
-    if (this.chrome.collectLongTasks) {
-      await this.cdpClient.setupLongTask();
-    }
-
     if (this.chrome.CPUThrottlingRate && this.chrome.CPUThrottlingRate > 1) {
       await this.cdpClient.setupCPUThrottling(this.chrome.CPUThrottlingRate);
     }

--- a/lib/chrome/webdriver/chromeDevtoolsProtocol.js
+++ b/lib/chrome/webdriver/chromeDevtoolsProtocol.js
@@ -69,19 +69,6 @@ class ChromeDevtoolsProtocol {
     await this.cdpClient.Performance.enable();
   }
 
-  async setupLongTask() {
-    const source = `
-    !function() {
-      let lt = window.__bt_longtask={e:[]};
-      lt.o = new PerformanceObserver(function(a) {
-        lt.e=lt.e.concat(a.getEntries());
-      });
-      lt.o.observe({entryTypes:['longtask']});
-    }();`;
-
-    return this.cdpClient.Page.addScriptToEvaluateOnNewDocument({ source });
-  }
-
   async startTrace() {
     this.events = [];
     this.cdpClient.Tracing.dataCollected(({ value }) => {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -203,11 +203,6 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'Collect Chromes console log and save to disk.',
       group: 'chrome'
     })
-    .option('chrome.collectLongTasks', {
-      type: 'boolean',
-      describe: 'Collect CPU long tasks, using the Long Task API',
-      group: 'chrome'
-    })
     .option('cpu', {
       type: 'boolean',
       describe: 'Easy way to enable both chrome.timeline and CPU long tasks.',


### PR DESCRIPTION
With Chrome 77 you can get buffered data from PerformanceObservers,
meaning we don't need to inject JS early when loading the page.