### PR TITLE
Try to find partly orange frames.

### DIFF
--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -790,7 +790,7 @@ def is_color_frame(file, color_file):
                 out, err = compare.communicate()
                 if re.match('^[0-9]+$', err):
                     different_pixels = int(err)
-                    if different_pixels < 200:
+                    if different_pixels < 10000:
                         match = True
                         break
         except Exception:


### PR DESCRIPTION
We are comparing 40000 pixels and if diff is less than 100 pixels
it is the same. Or was before our change. That doesn't seems correct
since we are trying to find vsync issues with Chrome where parts of
the screen is orange. It should be if the diff < 40000 it is still orange,
but lets be conservative with the change.