### PR TITLE
Setup the browser the same way when measuring and navigating.

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -103,6 +103,9 @@ class Measure {
         this.options
       );
     }
+    if (this.numberOfVisitedPages === 0) {
+      await this.engineDelegate.onStartIteration(this.browser, this.index);
+    }
     this.numberOfVisitedPages++;
     return this.browser.loadAndWait(url, this.pageCompleteCheck);
   }


### PR DESCRIPTION
This fixes the problem with missed long tasks when first navigating
to a page and then measure the next.