### PR TITLE
fix: Incorrect log message when failing to start

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -74,7 +74,7 @@ class SeleniumRunner {
         );
         break;
       } catch (e) {
-        log.info(`Browser failed to start, trying one more time: ${e.message}`);
+        log.info(`Browser failed to start, trying ${tries - i - 1} more time(s): ${e.message}`);
       }
     }
     if (!this.driver) {

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -74,7 +74,11 @@ class SeleniumRunner {
         );
         break;
       } catch (e) {
-        log.info(`Browser failed to start, trying ${tries - i - 1} more time(s): ${e.message}`);
+        log.info(
+          `Browser failed to start, trying ${tries - i - 1} more time(s): ${
+            e.message
+          }`
+        );
       }
     }
     if (!this.driver) {


### PR DESCRIPTION
This fixes the log message when the browser fails to start so it shows the right number of remaining attempts.


I tested this manually with the following command:
```
$ ./bin/browsertime.js -n 1 --chrome.binaryPath /dev/null https://www.example.com                                                                       
[2019-10-19 16:30:15] INFO: Running tests using Chrome - 1 iteration(s)
[2019-10-19 16:30:16] INFO: Browser failed to start, trying 2 more time(s): unknown error: Chrome failed to start: exited abnormally
  (chrome not reachable)
  (The process started from chrome location /dev/null is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
[2019-10-19 16:30:17] INFO: Browser failed to start, trying 1 more time(s): unknown error: Chrome failed to start: exited abnormally
  (chrome not reachable)
  (The process started from chrome location /dev/null is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
[2019-10-19 16:30:18] INFO: Browser failed to start, trying 0 more time(s): unknown error: Chrome failed to start: exited abnormally
  (chrome not reachable)
  (The process started from chrome location /dev/null is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
[2019-10-19 16:30:18] ERROR: BrowserError: Could not start the browser with 3 tries
    at SeleniumRunner.start (/home/masonm/src/browsertime/lib/core/seleniumRunner.js:81:13)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
[2019-10-19 16:30:18] ERROR: No data to collect
[2019-10-19 16:30:18] INFO: Wrote data to browsertime-results/www.example.com/2019-10-19T163014-0700
````

I looked into writing a unit test for this, but I don't see any tests that check log output. I think that would require mocking out `intel` using something like [sinon](https://github.com/sinonjs/sinon/), which isn't installed. 