### PR TITLE
Make it easy to turn off video/visual metrics in Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM sitespeedio/webbrowsers:chrome-78.0-firefox-70.0
 ENV BROWSERTIME_XVFB true
 ENV BROWSERTIME_CONNECTIVITY__ENGINE external
 ENV BROWSERTIME_DOCKER true
-ENV BROWSERTIME_VIDEO true
-ENV BROWSERTIME_visualMetrics true
 
 COPY docker/webpagereplay/wpr /usr/local/bin/
 COPY docker/webpagereplay/wpr_cert.pem /webpagereplay/certs/

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -728,6 +728,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
     set(argv, 'chrome.timeline', true);
   }
 
+  if (argv.docker) {
+    set(argv, 'video', get(argv, 'video', true));
+    set(argv, 'visualMetrics', get(argv, 'visualMetrics', true));
+  }
+
   return {
     urls: argv._,
     options: argv

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -98,6 +98,8 @@ class Video {
         this.visitedPageNumber,
         this.options
       );
+    }
+    if (this.options.video === true) {
       await finetuneVideo(
         this.videoDir,
         this.videoPath,
@@ -106,9 +108,8 @@ class Video {
         timingMetrics,
         this.options
       );
-      if (!this.options.video) {
-        await fileUtil.removeByType(this.videoDir, 'mp4');
-      }
+    } else {
+      await fileUtil.removeFile(this.videoPath);
     }
     return videoMetrics;
   }


### PR DESCRIPTION
Remove the hard coded settings in Dockerfile so that you can
use json configuration to turn off video/visualmetrics.

The way we used to do it with system properties overrides the
json config.