### PR TITLE
Calculate contentful speed index using edge detection integration

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -176,7 +176,7 @@ class Collector {
       if (data.visualMetrics) {
         if (this.options.iterations > 1) {
           log.info(
-            `VisualMetrics FirstVisualChange: ${data.visualMetrics.FirstVisualChange} SpeedIndex: ${data.visualMetrics.SpeedIndex} PerceptualSpeedIndex: ${data.visualMetrics.PerceptualSpeedIndex} LastVisualChange: ${data.visualMetrics.LastVisualChange}`
+            `VisualMetrics FirstVisualChange: ${data.visualMetrics.FirstVisualChange} SpeedIndex: ${data.visualMetrics.SpeedIndex} PerceptualSpeedIndex: ${data.visualMetrics.PerceptualSpeedIndex} ContentfulSpeedIndex: ${data.visualMetrics.ContentfulSpeedIndex} LastVisualChange: ${data.visualMetrics.LastVisualChange}`
           );
         }
         results.visualMetrics.push(data.visualMetrics);

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -32,6 +32,7 @@ function addTimingsToHAR(harPage, visualMetricsData, timings, cpu) {
       'VisualReadiness',
       'SpeedIndex',
       'PerceptualSpeedIndex',
+      'ContentfulSpeedIndex',
       'VisualProgress'
     ];
 

--- a/lib/video/postprocessing/visualmetrics/single/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/single/visualMetrics.js
@@ -34,6 +34,7 @@ module.exports = {
       videoPath,
       '--orange',
       '--perceptual',
+      '--contentful',
       '--force',
       '--renderignore',
       5,

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -1294,7 +1294,7 @@ def sample_frames(frames, interval, start_ms, skip_frames):
 ##########################################################################
 
 
-def calculate_visual_metrics(histograms_file, start, end, perceptual, dirs, progress_file, hero_elements_file):
+def calculate_visual_metrics(histograms_file, start, end, perceptual, contentful, dirs, progress_file, hero_elements_file):
     metrics = None
     histograms = load_histograms(histograms_file, start, end)
     if histograms is not None and len(histograms) > 0:
@@ -1319,6 +1319,9 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, dirs, prog
             if perceptual:
                 metrics.append({'name': 'Perceptual Speed Index',
                                 'value': calculate_perceptual_speed_index(progress, dirs)})
+            if contentful:
+                metrics.append({'name': 'Contentful Speed Index',
+                                'value': calculate_contentful_speed_index(progress, dirs)})
             if hero_elements_file is not None and os.path.isfile(hero_elements_file):
                 logging.debug('Calculating hero element times')
                 hero_data = None
@@ -1360,6 +1363,8 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, dirs, prog
             ]
             if perceptual:
                 metrics.append({'name': 'Perceptual Speed Index', 'value': 0})
+            if contentful:
+                metrics.append({'name': 'Contentful Speed Index', 'value': 0})
         prog = ''
         for p in progress:
             if len(prog):
@@ -1457,6 +1462,33 @@ def calculate_speed_index(progress):
         last_progress = p['progress'] / 100.0
     return int(si)
 
+def calculate_contentful_speed_index(progress, directory):
+    dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), directory)
+    content = []
+    maxContent=0
+    for p in progress[1:]:
+        # Full Path of the Current Frame
+        current_frame = os.path.join(dir, "ms_{0:06d}.png".format(p["time"]))
+        logging.debug("contentfulSpeedIndex: Current Image is %s" % current_frame)
+        # Takes full path of PNG frames to compute contentfulness value
+        command = '{0} {1} -canny 2x2+8%+8% -define histogram:unique-colors=true -format %c histogram:info:-'.format(
+            image_magick['convert'], current_frame)
+        output = subprocess.check_output(command, shell=True)
+        value  = int(output.split()[7].split(':')[0])
+        if value > maxContent:
+            maxContent = value
+        content.append(value)
+
+    for i,value in enumerate(content):
+        content[i] = float(content[i]) / float(maxContent)
+
+    # Assume 0 content for first frame
+    cont_si = 1 * (progress[1]['time'] - progress[0]['time'])
+    for i in xrange(1,len(progress)-1):
+        elapsed = progress[i+1]['time'] - progress[i]['time']
+        #print i,' time =',p['time'],'elapsed =',elapsed,'content = ',content[i]
+        cont_si += elapsed * (1.0 - content[i])
+    return int(cont_si)
 
 def calculate_perceptual_speed_index(progress, directory):
     from ssim import compute_ssim
@@ -1726,6 +1758,8 @@ def main():
                              "sampling (to 10fps, 1fps, etc).")
     parser.add_argument('-k', '--perceptual', action='store_true', default=False,
                         help="Calculate perceptual Speed Index")
+    parser.add_argument('--contentful', action='store_true', default=False,
+                        help="Calculate contentful Speed Index")
     parser.add_argument('-j', '--json', action='store_true', default=False,
                         help="Set output format to JSON")
     parser.add_argument('--progress', help="Visual progress output file.")
@@ -1737,7 +1771,7 @@ def main():
         parser.error("A video, Directory of images or histograms file needs to be provided.\n\n"
                      "Use -h to see available options")
 
-    if options.perceptual:
+    if options.perceptual or options.contentful:
         if not options.video:
             parser.error(
                 "A video file needs to be provided.\n\n"
@@ -1837,7 +1871,7 @@ def main():
                 # Calculate the histograms and visual metrics
                 calculate_histograms(directory, histogram_file, options.force)
                 metrics = calculate_visual_metrics(histogram_file, options.start, options.end,
-                                                   options.perceptual, directory, options.progress,
+                                                   options.perceptual, options.contentful, directory, options.progress,
                                                    options.herodata)
 
                 if options.screenshot is not None:


### PR DESCRIPTION
Contentful speed index is a new SI metric developed by Bas Schouten at Mozilla which uses edge detection to calculate the amount of "content" that is visible on each frame.   

It was primarily designed for two main purposes:
1.  Have a good metric to measure the amount of text that is visible.
2.  Design a metric that is not easily fooled by the pop up splash/login screens that commonly occur at the end of a page load.  These can often disturb the speed index numbers since the last frame that is being used as reference is not accurate.