### PR TITLE
Use the Firefox internal window recorder to calcualte visual metrics

### DIFF
--- a/lib/core/engine/command/javaScript.js
+++ b/lib/core/engine/command/javaScript.js
@@ -49,7 +49,10 @@ class JavaScript {
    */
   async runPrivileged(js) {
     try {
-      const value = await this.browser.runPrivilegedScript(js, 'CUSTOM PRIVILEGED');
+      const value = await this.browser.runPrivilegedScript(
+        js,
+        'CUSTOM PRIVILEGED'
+      );
       return value;
     } catch (e) {
       log.error('Could not run privileged JavaScript %s ', js);
@@ -66,7 +69,10 @@ class JavaScript {
    */
   async runPrivilegedAsync(js) {
     try {
-      const value = await this.browser.runPrivilegedAsyncScript(js, 'CUSTOM ASYNC PRIVILEGED');
+      const value = await this.browser.runPrivilegedAsyncScript(
+        js,
+        'CUSTOM ASYNC PRIVILEGED'
+      );
       return value;
     } catch (e) {
       log.error('Could not run async privileged JavaScript %s ', js);

--- a/lib/core/engine/command/javaScript.js
+++ b/lib/core/engine/command/javaScript.js
@@ -40,5 +40,39 @@ class JavaScript {
       throw Error(`Could not run JavaScript ${js}`);
     }
   }
+
+  /**
+   * Run synchronous privileged JavaScript.
+   * @param {string} js
+   * @returns {Promise} Promise object represents when the JavaScript has been executed by the browser
+   * @throws Will throw an error if the JavsScript can't run
+   */
+  async runPrivileged(js) {
+    try {
+      const value = await this.browser.runPrivilegedScript(js, 'CUSTOM PRIVILEGED');
+      return value;
+    } catch (e) {
+      log.error('Could not run privileged JavaScript %s ', js);
+      log.verbose(e);
+      throw e;
+    }
+  }
+
+  /**
+   * Run asynchronous privileged JavaScript.
+   * @param {string} js
+   * @returns {Promise} Promise object represents when the JavaScript has been executed by the browser
+   * @throws Will throw an error if the JavsScript can't run
+   */
+  async runPrivilegedAsync(js) {
+    try {
+      const value = await this.browser.runPrivilegedAsyncScript(js, 'CUSTOM ASYNC PRIVILEGED');
+      return value;
+    } catch (e) {
+      log.error('Could not run async privileged JavaScript %s ', js);
+      log.verbose(e);
+      throw e;
+    }
+  }
 }
 module.exports = JavaScript;

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -58,11 +58,21 @@ class Measure {
     this.testedURLs = {};
   }
 
-  // Have a concistent way of starting the video
+  // Have a consistent way of starting the video
   async _startVideo(numberOfMeasuredPages, index) {
-    this.video = new Video(this.storageManager, this.options);
-    await setOrangeBackground(this.browser.getDriver(), this.options);
-    await this.video.record(numberOfMeasuredPages, index);
+    this.video = new Video(this.storageManager, this.options, this.browser);
+
+    if (this.options.firefox.windowRecorder) {
+      // The Firefox window recorder will only record subsequent
+      // changes after recording has begun.  So the orange frame needs
+      // to come after we start recording.
+      await this.video.record(numberOfMeasuredPages, index);
+      await setOrangeBackground(this.browser.getDriver(), this.options);
+    } else {
+      await setOrangeBackground(this.browser.getDriver(), this.options);
+      await this.video.record(numberOfMeasuredPages, index);
+    }
+
     // Give ffmpeg/video on phone time to settle
     if (isAndroidConfigured(this.options)) {
       return delay(ANDROID_DELAY_TIME);

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -56,7 +56,6 @@ class Iteration {
     this.engineDelegate = engineDelegate;
     this.scriptsByCategory = scriptsByCategory;
     this.asyncScriptsByCategory = asyncScriptsByCategory;
-    this.video = new Video(storageManager, options);
   }
 
   /**
@@ -71,6 +70,7 @@ class Iteration {
       this.storageManager.directory,
       this.options
     );
+    this.video = new Video(this.storageManager, this.options, browser);
     const recordVideo = options.visualMetrics || options.video;
     const videos = [];
     const result = [];

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -295,6 +295,51 @@ class SeleniumRunner {
   }
 
   /**
+   * Run synchronous privileged JavaScript with args.
+   * @param {string} script - the actual script
+   * @param {string} name - the name of the script (for logging)
+   * @param {*} args - arguments to the script
+   * @throws {BrowserError}
+   */
+  async runPrivilegedScript(script, name, args) {
+    if (this.options.browser !== 'firefox') {
+      throw new BrowserError(
+        `Only Firefox browsers can run privileged JavaScript: ${this.options.browser}`,
+        { cause: 'PrivilegeError' }
+      );
+    }
+
+    let scriptTimeout = this.options.timeouts.script;
+
+    if (log.isEnabledFor(log.TRACE)) {
+      log.verbose('Executing privileged script %s', script);
+    } else if (log.isEnabledFor(log.VERBOSE)) {
+      log.verbose('Executing privileged script %s', name);
+    }
+
+    try {
+      const oldContext = this.driver.getContext();
+
+      try {
+        await this.driver.setContext('chrome');
+
+        return timeout(
+          this.driver.executeScript(script, args),
+          scriptTimeout,
+          `Running privileged script ${script} took too long (${scriptTimeout} ms).`
+        );
+      } finally {
+        await this.driver.setContext(oldContext);
+      }
+    } catch (e) {
+      log.error(
+        "Couldn't execute privileged script named " + name + ' error:' + e
+      );
+      throw e;
+    }
+  }
+
+  /**
    * Run a asynchrously JavaScript.
    * @param {string} script - the actual script
    * @param {string} name - the name of the script (for logging)
@@ -312,6 +357,50 @@ class SeleniumRunner {
     } catch (e) {
       log.error("Couldn't execute async script named " + name + ' error:' + e);
       throw e;
+    }
+  }
+
+  /**
+   * Run asynchronous privileged JavaScript with args.
+   * @param {string} script - the actual script
+   * @param {string} name - the name of the script (for logging)
+   * @param {*} args - arguments to the script
+   * @throws {BrowserError}
+   */
+  async runPrivilegedAsyncScript(script, name, args) {
+    if (this.options.browser !== 'firefox') {
+      throw new BrowserError(
+        `Only Firefox browsers can run privileged JavaScript: ${this.options.browser}`,
+        { cause: 'PrivilegeError' }
+      );
+    }
+
+    if (log.isEnabledFor(log.TRACE)) {
+      log.verbose('Executing privileged async script %s', script);
+    } else if (log.isEnabledFor(log.VERBOSE)) {
+      log.verbose('Executing privileged async script %s', name);
+    }
+
+    try {
+      const oldContext = this.driver.getContext();
+
+      try {
+        await this.driver.setContext('chrome');
+
+        try {
+          return this.driver.executeAsyncScript(script, args);
+        } catch (e) {
+          log.error(
+            "Couldn't execute async script named " + name + ' error:' + e
+          );
+          throw e;
+        }
+      } finally {
+        await this.driver.setContext(oldContext);
+      }
+    } catch (ce) {
+      log.error("Couldn't execute async script named " + name + ' error:' + ce);
+      throw ce;
     }
   }
 

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -34,6 +34,12 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     process.env.MOZ_LOG_FILE = `${baseDir}/moz_log.txt`;
   }
 
+  // Output the window recorder image frames to a base directory.
+  // This pref expects a trailing slash.
+  if (firefoxConfig.windowRecorder) {
+    ffOptions.setPreference('layers.windowrecording.path', `${baseDir}/`);
+  }
+
   // try to remove the caching between runs
   /*
    profile.setPreference('dom.enable_resource_timing', true);

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -294,6 +294,15 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
+    .option('firefox.windowRecorder', {
+      describe:
+        'Use the internal compositor-based Firefox window recorder to emit PNG files for each ' +
+        'frame that is a meaningful change.  The PNG output will further be merged into a ' +
+        'variable frame rate video for analysis.',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('firefox.collectMozLog', {
       type: 'boolean',
       describe: 'Collect the MOZ HTTP log',

--- a/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
+++ b/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const log = require('intel').getLogger('browsertime.video');
+const util = require('util');
+const fs = require('fs');
+const path = require('path');
+const execa = require('execa');
+const del = require('del');
+
+const unlink = util.promisify(fs.unlink);
+
+async function enableWindowRecorder(enable, driver) {
+  if (enable) {
+    enable = '1';
+  } else {
+    enable = '0';
+  }
+
+  const oldContext = driver.getContext();
+  await driver.setContext('chrome');
+  const script = 'windowUtils.setCompositionRecording(' + enable + ');';
+  await driver.executeScript(script);
+  return driver.setContext(oldContext);
+}
+
+function findRecordingDirectory(baseDir) {
+  let closest_mtime = 0;
+  let directory = undefined;
+
+  fs.readdirSync(baseDir).forEach(file => {
+    if (file.startsWith('windowrecording-')) {
+      let fullPath = path.join(baseDir, file);
+      let mtime = fs.statSync(fullPath).mtime;
+      if (mtime > closest_mtime) {
+        closest_mtime = mtime;
+        directory = fullPath;
+      }
+    }
+  });
+
+  log.debug('Using window recording directory: ' + directory);
+  if (directory === undefined) {
+    log.error('Could not find window recording directory in ' + baseDir);
+  }
+  return directory;
+}
+
+function findRecordingStartTime(recordingDir) {
+  // Recording directory has the following format:
+  // .../browsertime-results/<web address>/<date time>/windowrecording-<unix recording start time>
+  return recordingDir.substr(recordingDir.lastIndexOf('-') + 1);
+}
+
+function findTimeToFirstFrame(recordingDir) {
+  const files = fs.readdirSync(recordingDir);
+  if (files === undefined || files.length < 1) {
+    log.error('Could not find recordings in ' + recordingDir);
+  } else {
+    // Iterate through files, extract the time from the filenames, and return the smallest time
+    return files.reduce((acc, fileName) => {
+      const time = parseInt(fileName.split('-')[2].split('.')[0], 10);
+      return Math.min(acc, time);
+    }, Infinity);
+  }
+}
+
+function writeFrameDurationsToFile(directoryName, imageFiles) {
+  return new Promise((resolve, reject) => {
+    const stream = fs.createWriteStream(
+      path.join(directoryName, 'durations.txt')
+    );
+    stream.once('open', function() {
+      stream.write(
+        "file '" + path.join(directoryName, imageFiles[0].filename) + "'\n"
+      );
+      for (let i = 1; i < imageFiles.length; i++) {
+        let duration = (imageFiles[i].offset - imageFiles[i - 1].offset) / 1000;
+        stream.write('duration ' + duration.toString() + '\n');
+        stream.write(
+          "file '" + path.join(directoryName, imageFiles[i].filename) + "'\n"
+        );
+      }
+      stream.end();
+      stream.on('finish', () => {
+        resolve(true);
+      });
+      stream.on('error', () => {
+        reject(Error('Error writing durations to file.'));
+      });
+    });
+  });
+}
+
+async function generateVideo(destination, recordingDirectoryName) {
+  let imageFiles = [];
+
+  fs.readdirSync(recordingDirectoryName).forEach(file => {
+    // Format of the filenames are "frame-<num>-<offset>.png"
+    // where num is frame number and offset is time since capture start in ms.
+    let fields = file.split('-');
+    let frameno = ('0000' + fields[1]).slice(-4);
+    let newFilename = 'frame' + frameno + '.png';
+    let offset = fields[2].split('.')[0];
+    fs.copyFileSync(
+      path.join(recordingDirectoryName, file),
+      path.join(recordingDirectoryName, newFilename)
+    );
+    imageFiles.push({ filename: newFilename, offset: offset });
+  });
+
+  imageFiles.sort(function(a, b) {
+    if (a.filename < b.filename) return -1;
+    if (a.filename > b.filename) return 1;
+    return 0;
+  });
+  await writeFrameDurationsToFile(recordingDirectoryName, imageFiles);
+
+  const vfr_args = [
+    '-f',
+    'concat',
+    '-safe',
+    '0',
+    '-i',
+    path.join(recordingDirectoryName, 'durations.txt'),
+    '-vf',
+    'pad=ceil(iw/2)*2:ceil(ih/2)*2',
+    '-vsync',
+    'vfr',
+    '-pix_fmt',
+    'yuv420p',
+    destination
+  ];
+  log.debug('Executing command: ffmpeg ' + vfr_args.join(' '));
+  await execa('ffmpeg', vfr_args);
+  del(recordingDirectoryName);
+}
+
+module.exports = class FirefoxWindowRecorder {
+  constructor(options, browser, baseDir) {
+    this.options = options;
+    this.browser = browser;
+    this.baseDir = baseDir;
+    this.recordingStartTime = null;
+    this.timeToFirstFrame = null;
+  }
+
+  async start() {
+    log.info('Start firefox window recorder.');
+    return enableWindowRecorder(true, this.browser.getDriver());
+  }
+
+  async stop(destination) {
+    log.info('Stop firefox window recorder.');
+    await enableWindowRecorder(false, this.browser.getDriver());
+
+    // FIXME update to rename/move file
+    // The destination file could exist if we use --resultDir
+    // so make sure we remove it first
+    if (this.options.resultDir) {
+      try {
+        await unlink(destination);
+      } catch (e) {
+        // Nothing to see here
+      }
+    }
+
+    let recordingDir = findRecordingDirectory(this.baseDir);
+    this.recordingStartTime = findRecordingStartTime(recordingDir);
+    this.timeToFirstFrame = findTimeToFirstFrame(recordingDir);
+    await generateVideo(
+      destination,
+      recordingDir,
+      this.recordingStartTime,
+      this.timeToFirstFrame
+    );
+    log.debug(`Writing to ${destination}`);
+  }
+};

--- a/lib/video/screenRecording/recorder.js
+++ b/lib/video/screenRecording/recorder.js
@@ -2,11 +2,16 @@
 const { isAndroidConfigured } = require('../../android');
 const AndroidRecorder = require('./android/recorder');
 const X11Recorder = require('./desktop/x11recorder');
+const FirefoxWindowRecorder = require('./firefox/firefoxWindowRecorder');
 
-module.exports = function getRecorder(options) {
+module.exports = function getRecorder(options, browser, baseDir) {
+  if (options.browser === 'firefox' && options.firefox.windowRecorder) {
+    return new FirefoxWindowRecorder(options, browser, baseDir);
+  }
+
   if (isAndroidConfigured(options)) {
     return new AndroidRecorder(options);
-  } else {
-    return new X11Recorder(options);
   }
+
+  return new X11Recorder(options);
 };

--- a/lib/video/video.js
+++ b/lib/video/video.js
@@ -12,11 +12,11 @@ const pathToFolders = require('../support/pathToFolder');
  * @class
  */
 class Video {
-  constructor(storageManager, options) {
+  constructor(storageManager, options, browser) {
     this.options = options;
     this.storageManager = storageManager;
     this.tmpDir = storageManager.directory;
-    this.recorder = getRecorder(options);
+    this.recorder = getRecorder(options, browser, this.tmpDir);
     this.isRecording = false;
   }
 
@@ -26,6 +26,10 @@ class Video {
 
     this.videoDir = await storageManager.createSubDataDir(
       path.join(pathToFolders(url, this.options), 'video')
+    );
+
+    await storageManager.createSubDataDir(
+      path.join(pathToFolders(url, this.options), 'video', 'images', '' + index)
     );
 
     this.filmstripDir = await await storageManager.createSubDataDir(

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "chrome-har": "0.11.4",
     "chrome-remote-interface": "0.28.0",
     "dayjs": "1.8.15",
+    "del": "4.1.1",
     "execa": "2.0.4",
     "fast-stats": "0.0.5",
     "find-up": "4.1.0",


### PR DESCRIPTION
Firefox 67 and above has a built-in window recorder ([bug 1536174](https://bugzilla.mozilla.org/show_bug.cgi?id=1536174)) that is able to dump PNG images of each frame that is painted to the window.   This can be enabled and disabled in the browser console, or through the chrome context with selenium webdriver.

This PR introduces a new privileged API that is able to execute JS in the chrome context, as well as support for generating a variable rate MP4 using the output images from the window recorder.  

The motivation for this work was to introduce a low-overhead video recorder that will not introduce performance disturbances during page loads.