### PR TITLE
Make it possible to run scripts per URL

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -110,8 +110,8 @@ class Collector {
       results.info.description = allData.description;
       results.info.title = allData.title;
       // The user can add extra data in a script or post script
-      if (allData.extras) {
-        results.extras.push(allData.extras);
+      if (data.extras) {
+        results.extras.push(data.extras);
       }
       const statistics = this.allStats[url]
         ? this.allStats[url]

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -21,7 +21,8 @@ const aliasAndUrl = {};
 function getNewResult() {
   return {
     extraJson: {},
-    timestamp: engineUtils.timestamp()
+    timestamp: engineUtils.timestamp(),
+    extras: {}
   };
 }
 
@@ -37,6 +38,8 @@ class Measure {
     videos,
     scriptsByCategory,
     asyncScriptsByCategory,
+    postURLScripts,
+    context,
     options
   ) {
     this.browser = browser;
@@ -52,6 +55,8 @@ class Measure {
     this.videos = videos;
     this.scriptsByCategory = scriptsByCategory;
     this.asyncScriptsByCategory = asyncScriptsByCategory;
+    this.postURLScripts = postURLScripts;
+    this.context = context;
     this.numberOfMeasuredPages = 0;
     this.numberOfVisitedPages = 0;
     this.areWeMeasuring = false;
@@ -273,6 +278,7 @@ class Measure {
       await this.video.stop(url);
       this.videos.push(this.video);
     }
+
     // Some sites has crazy amount of user timings:
     // strip them if you want
     if (this.options.userTimingWhitelist) {
@@ -291,6 +297,10 @@ class Measure {
         // not getting screenshots shouldn't result in a failed test.
         log.warning(e);
       }
+    }
+
+    for (const postURLScript of this.postURLScripts) {
+      await postURLScript(this.context);
     }
 
     await this.engineDelegate.onCollect(

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -43,6 +43,9 @@ class Iteration {
     try {
       this.preScripts = engineUtils.loadPrePostScripts(options.preScript);
       this.postScripts = engineUtils.loadPrePostScripts(options.postScript);
+      this.postURLScripts = engineUtils.loadPrePostScripts(
+        options.postURLScript
+      );
       this.pageCompleteCheck = engineUtils.loadScript(
         options.pageCompleteCheck
       );
@@ -81,19 +84,6 @@ class Iteration {
       }
       await browser.start();
       await this.engineDelegate.afterBrowserStart();
-      const measure = new Measure(
-        browser,
-        index,
-        this.pageCompleteCheck,
-        result,
-        this.engineDelegate,
-        this.extensionServer,
-        this.storageManager,
-        videos,
-        this.scriptsByCategory,
-        this.asyncScriptsByCategory,
-        options
-      );
 
       // The data we push to all selenium scripts
       const context = {
@@ -110,6 +100,22 @@ class Iteration {
           driver: browser.getDriver() // The instantiated version of the WebDriver https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html
         }
       };
+
+      const measure = new Measure(
+        browser,
+        index,
+        this.pageCompleteCheck,
+        result,
+        this.engineDelegate,
+        this.extensionServer,
+        this.storageManager,
+        videos,
+        this.scriptsByCategory,
+        this.asyncScriptsByCategory,
+        this.postURLScripts,
+        context,
+        options
+      );
 
       const cdp = new ChromeDevToolsProtocol(
         this.engineDelegate,
@@ -159,7 +165,7 @@ class Iteration {
       }
 
       try {
-        await navigationScript(context, commands);
+        await navigationScript(context, commands, this.postURLScripts);
       } catch (e) {
         commands.error(e.message);
         throw e;


### PR DESCRIPTION
This is the start to fix https://github.com/sitespeedio/sitespeed.io/issues/2754.

There was a miss by me how we handle data from post scripts: It failed collecting metrics per URL when you are using scripting, that made AXE fail in sitespeed.io.

