### PR TITLE
Use async composition recorder API from Firefox 72

### DIFF
--- a/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
+++ b/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
@@ -9,18 +9,29 @@ const del = require('del');
 
 const unlink = util.promisify(fs.unlink);
 
-async function enableWindowRecorder(enable, driver) {
+async function enableWindowRecorder(enable, browser) {
   if (enable) {
-    enable = '1';
+    enable = 'true';
   } else {
-    enable = '0';
+    enable = 'false';
   }
 
-  const oldContext = driver.getContext();
-  await driver.setContext('chrome');
-  const script = 'windowUtils.setCompositionRecording(' + enable + ');';
-  await driver.executeScript(script);
-  return driver.setContext(oldContext);
+  // We wrap windowUtils.setCompositionRecording(...) in Promise.resolve() to
+  // work on both the older (synchronous) and newer (asynchronous)
+  // setCompositionRecorder API.
+  const script = `\
+      const cb = arguments[arguments.length-1];
+      Promise.resolve(
+        windowUtils.setCompositionRecording(${enable})
+      )
+        .then(() => cb());
+  `;
+
+  return browser.runPrivilegedAsyncScript(
+    script,
+    'toggle composition recorder',
+    undefined
+  );
 }
 
 function findRecordingDirectory(baseDir) {
@@ -146,12 +157,12 @@ module.exports = class FirefoxWindowRecorder {
 
   async start() {
     log.info('Start firefox window recorder.');
-    return enableWindowRecorder(true, this.browser.getDriver());
+    return enableWindowRecorder(true, this.browser);
   }
 
   async stop(destination) {
     log.info('Stop firefox window recorder.');
-    await enableWindowRecorder(false, this.browser.getDriver());
+    await enableWindowRecorder(false, this.browser);
 
     // FIXME update to rename/move file
     // The destination file could exist if we use --resultDir


### PR DESCRIPTION
Firefox Nightly 72 now uses an asynchronous
`windowUtils.setCompositionRecording` API. This unfortunately breaks
Browsertime on Firefox 72+.

However, we can support both Firefox <= 71 and >= 72 by wrapping the
return value of `windowUtils.setCompositionRecording(enable)` in
`Promise.resolve()`. When `Promise.resolve()` is passed a promise, the
returned promise will resolve immediately, which solves the problem for
the synchronous API in Firefox <= 71. However, when passed a promise,
`Promise.resolve()` will return the passed promise, which allows us to
support both APIs.