### PR TITLE
Disable WebExtension for FF and remove it for Chrome.

### DIFF
--- a/lib/chrome/webdriver/index.js
+++ b/lib/chrome/webdriver/index.js
@@ -8,7 +8,6 @@ const isEmpty = require('lodash.isempty');
 const chromedriver = require('@sitespeed.io/chromedriver');
 const get = require('lodash.get');
 const fs = require('fs');
-const path = require('path');
 const defaultChromeOptions = require('./chromeOptions');
 const defaultAndroidChromeOptions = require('./chromeAndroidOptions');
 const getViewPort = require('../../support/getViewPort');
@@ -22,7 +21,6 @@ let hasConfiguredChromeDriverService = false;
  */
 module.exports.configureBuilder = function(builder, baseDir, options) {
   const chromeConfig = options.chrome || {};
-  const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 
   if (!hasConfiguredChromeDriverService) {
     const chromedriverPath = get(
@@ -88,16 +86,6 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   }
 
   const perfLogConf = { enableNetwork: true, enablePage: true };
-
-  // headless mode doesn't work with extensions
-  if (!chromeConfig.disableWebExtensions && !options.headless) {
-    chromeOptions.addExtensions(
-      fs.readFileSync(
-        path.resolve(moduleRootPath, 'vendor', 'browsertime-extension.crx'),
-        { encoding: 'base64' }
-      )
-    );
-  }
 
   if (options.extension) {
     const extensions = !Array.isArray(options.extension)

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -63,10 +63,24 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     );
   }
 
-  // Browsertime own extension
-  ffOptions.addExtensions(
-    path.resolve(moduleRootPath, 'vendor', 'browsertime-0.18.0-an+fx.xpi')
-  );
+  // Browsertime own extension, only load it when we need it
+  // We should be able to only install it only when needed, but that could break scripting
+
+  if (
+    !firefoxConfig.disableBrowsertimeExtension ||
+    (options.multi ||
+      (options.cacheClearRaw ||
+        options.requestheader ||
+        options.block ||
+        options.basicAuth ||
+        options.cookie ||
+        options.injectJs ||
+        options.clearCacheKeepCookies))
+  ) {
+    ffOptions.addExtensions(
+      path.resolve(moduleRootPath, 'vendor', 'browsertime-0.18.0-an+fx.xpi')
+    );
+  }
 
   if (options.extension) {
     const extensions = !Array.isArray(options.extension)

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -308,6 +308,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'Collect the MOZ HTTP log',
       group: 'firefox'
     })
+    .option('firefox.disableBrowsertimeExtension', {
+      describe: 'Disable installing the browsertime extension.',
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('selenium.url', {
       describe:
         'URL to a running Selenium server (e.g. to run a browser on another machine).',


### PR DESCRIPTION
Chrome doesn't use the WebExtension anymore so we should not
install it in the Browser. For Firefox we make it possible to
disable installing it and only install it for scripting or
if there are indication that you need to use the functionality.