### PR TITLE
Remove and simplify old code when running with pageLoadStrategy none

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -219,7 +219,7 @@ class SeleniumRunner {
       // the onload event. But you can change that with the --pageLoadStrategy none
       // Then you will be in control immediately and therefore wanna wait some extra time
       // befor you start to run your page complete check
-      await delay(this.options.pageCompleteCheckStartWait || 0);
+      await delay(this.options.pageCompleteCheckStartWait || 500);
       await this.wait(pageCompleteCheck);
     } catch (e) {
       log.error('Could not load URL' + e);

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -213,23 +213,13 @@ class SeleniumRunner {
             });
           });
         })();`;
-
-      const startUri = await driver.executeScript(
-        'return document.documentURI;'
-      );
+      // Navigate to the page
       await driver.executeScript(navigate);
-      // Wait max 50s on navigation
-      for (let i = 0; i < 100; i++) {
-        await delay(500);
-        const newUri = await driver.executeScript(
-          'return document.documentURI;'
-        );
-        // When the URI changed or of we are on the same page
-        // see https://github.com/sitespeedio/browsertime/pull/623
-        if (startUri != newUri || url === newUri) {
-          break;
-        }
-      }
+      // If you run with default settings, the webdriver will give back control after
+      // the onload event. But you can change that with the --pageLoadStrategy none
+      // Then you will be in control immediately and therefore wanna wait some extra time
+      // befor you start to run your page complete check
+      await delay(this.options.pageCompleteCheckStartWait || 0);
       await this.wait(pageCompleteCheck);
     } catch (e) {
       log.error('Could not load URL' + e);

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -495,6 +495,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'The time in ms to wait for running the page complete check the next time.'
     })
+    .option('pageCompleteCheckStartWait', {
+      type: 'number',
+      default: 0,
+      describe:
+        'The time in ms to wait for running the page complete check for the first time. Use this when you have a pageLoadStrategy set to none'
+    })
     .option('pageLoadStrategy', {
       type: 'string',
       default: 'normal',

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -497,7 +497,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('pageCompleteCheckStartWait', {
       type: 'number',
-      default: 0,
+      default: 500,
       describe:
         'The time in ms to wait for running the page complete check for the first time. Use this when you have a pageLoadStrategy set to none'
     })


### PR DESCRIPTION
We had some real old code that didn't add any value. Instead we now
have a simple setup when you run as default, and a sane configurable
setup when you run with a strategy set to none.