### PR TITLE
Disable save passwords popups in Chrome.

### DIFF
--- a/lib/chrome/webdriver/index.js
+++ b/lib/chrome/webdriver/index.js
@@ -55,6 +55,13 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   let chromeOptions = new chrome.Options();
   chromeOptions.setLoggingPrefs(logPrefs);
 
+  // Fixing save password popup
+  chromeOptions.setUserPreferences({
+    'profile.password_manager_enable': false,
+    'profile.default_content_setting_values.notifications': 2,
+    credentials_enable_service: false
+  });
+
   if (options.headless) {
     chromeOptions.headless();
   }


### PR DESCRIPTION
This was introduced when we removed the WebExtension for Chrome.