### PR TITLE
Fix race in SeleniumRunner#runPrivilegedAsyncScript

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -382,7 +382,7 @@ class SeleniumRunner {
         await this.driver.setContext('chrome');
 
         try {
-          return this.driver.executeAsyncScript(script, args);
+          return await this.driver.executeAsyncScript(script, args);
         } catch (e) {
           log.error(
             "Couldn't execute async script named " + name + ' error:' + e


### PR DESCRIPTION
There was a subtle trace condition in the implementation of
`runPrivilegedAsyncScript`. The code was structured with a
`try..finally` that would reset the JavaScript context after we executed
the async script in the chrome context. However, we were not awaiting
the promise returned by `executeAsyncScript`, which did not guarantee
that the command would run before we reset the context.

This seemed to only effect non-Nightly builds of Firefox. Before this
patch, I could get this to reproduce 100% of the time on Release or
Beta. Now I can no longer reproduce this issue.