### PR TITLE
Fix problems with video debug.

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -196,7 +196,8 @@ class Iteration {
 
       if (recordVideo && options.videoParams.debug) {
         // Just use the first URL
-        const url = result[0].url;
+        const url =
+          result.length > 0 ? result[0].url : 'https://debug.sitespeed.io';
         await this.video.stop(url);
       }
       await browser.stop();
@@ -226,6 +227,13 @@ class Iteration {
       return result;
     } catch (e) {
       log.error(e);
+      if (recordVideo && options.videoParams.debug) {
+        // Just use the first URL
+        const url =
+          result.length > 0 ? result[0].url : 'https://debug.sitespeed.io';
+        await this.video.stop(url);
+      }
+
       // In Docker on Desktop we can use a hardcore way to cleanup
       if (options.docker && recordVideo && !isAndroidConfigured(options)) {
         await stop('ffmpeg');


### PR DESCRIPTION
Sometimes scripts can be hard to debug and the --videoParams.debug
is your best friend. However before this fix the video wasn't stopped
correctly if an error was thrown + if you hadn't started to test
a url, the debug video also was broken.