### PR TITLE
Add await in runPrivilegedScript to fix race condition.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -319,7 +319,7 @@ class SeleniumRunner {
       try {
         await this.driver.setContext('chrome');
 
-        return timeout(
+        return await timeout(
           this.driver.executeScript(script, args),
           scriptTimeout,
           `Running privileged script ${script} took too long (${scriptTimeout} ms).`


### PR DESCRIPTION
This patch fixes an issue with gecko profiling where a race condition occurs. The issue happens because the context gets changed from chrome to content before the script has had a chance to run (which requires the chrome context).

It fixes this error: 
```
[2019-12-21 00:43:40] INFO: Testing url https://www.sitespeed.io iteration 1
[2019-12-21 00:43:40] ERROR: No page that could be associated with the error:ReferenceError: Services is not defined
[2019-12-21 00:43:40] ERROR: JavascriptError: ReferenceError: Services is not defined
```
