### PR TITLE
Simplify gecko profiler code.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -7,7 +7,6 @@ const { isAndroidConfigured } = require('../android');
 const { UrlLoadError, BrowserError } = require('../support/errors');
 const builder = require('./webdriver');
 const getViewPort = require('../support/getViewPort');
-
 const defaultPageCompleteCheck = require('./defaultPageCompleteCheck');
 const pageCompleteCheckByInactivity = require('./pageCompleteCheckByInactivity');
 const spaCheck = require('./spaInactivity');
@@ -304,33 +303,24 @@ class SeleniumRunner {
         { cause: 'PrivilegeError' }
       );
     }
-
-    let scriptTimeout = this.options.timeouts.script;
-
     if (log.isEnabledFor(log.TRACE)) {
       log.verbose('Executing privileged script %s', script);
     } else if (log.isEnabledFor(log.VERBOSE)) {
       log.verbose('Executing privileged script %s', name);
     }
 
+    const oldContext = await this.driver.getContext();
+
     try {
-      const oldContext = await this.driver.getContext();
-
-      try {
-        await this.driver.setContext('chrome');
-
-        return timeout(
-          this.driver.executeScript(script, args),
-          scriptTimeout,
-          `Running privileged script ${script} took too long (${scriptTimeout} ms).`
-        );
-      } finally {
-        await this.driver.setContext(oldContext);
-      }
+      await this.driver.setContext('chrome');
+      const result = await this.driver.executeScript(script, args);
+      await this.driver.setContext(oldContext);
+      return result;
     } catch (e) {
       log.error(
         "Couldn't execute privileged script named " + name + ' error:' + e
       );
+      await this.driver.setContext(oldContext);
       throw e;
     }
   }


### PR DESCRIPTION
Remove nested tries (they always scare me) and remove the timeout (at least
for now).

We also need to make sure that the code we run in the browser finished loading
before we switch context.