### PR TITLE
Add await calls to handle race conditions.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -278,7 +278,7 @@ class SeleniumRunner {
     }
 
     try {
-      return timeout(
+      return await timeout(
         this.driver.executeScript(script, args),
         scriptTimeout,
         `Running script ${script} took too long (${scriptTimeout} ms).`
@@ -339,7 +339,7 @@ class SeleniumRunner {
       log.verbose('Executing async script %s', name);
     }
     try {
-      return this.driver.executeAsyncScript(script, args);
+      return await this.driver.executeAsyncScript(script, args);
     } catch (e) {
       log.error("Couldn't execute async script named " + name + ' error:' + e);
       throw e;
@@ -368,7 +368,7 @@ class SeleniumRunner {
     }
 
     try {
-      const oldContext = this.driver.getContext();
+      const oldContext = await this.driver.getContext();
 
       try {
         await this.driver.setContext('chrome');


### PR DESCRIPTION
This patch fixes a race condition that occurs (only on Android from what I've seen) when a privileged script runs before a non-privileged script that requires the 'content' context. What happens there is that the privileged script changes the context to 'chrome' and then finishes without being able to set the context back to the original one. Two other await calls were also added because without them the try/catch wasn't being used.

The error that is fixed here is the following:
```
[task 2019-12-24T03:06:28.323Z] 03:06:05     INFO -  [2019-12-24 03:06:05] VERBOSE: [browsertime] Executing privileged script windowSize
[task 2019-12-24T03:06:28.323Z] 03:06:05     INFO -  [2019-12-24 03:06:05] VERBOSE: [browsertime] Executing script documentHeight
[task 2019-12-24T03:06:28.323Z] 03:06:05     INFO -  [2019-12-24 03:06:05] VERBOSE: [browsertime] current context is chrome
[task 2019-12-24T03:06:28.323Z] 03:06:05    ERROR -  [2019-12-24 03:06:05] ERROR: [browsertime] Couldn't execute script named documentHeight error:JavascriptError: TypeError: body is null
[task 2019-12-24T03:06:28.323Z] 03:06:05    ERROR -  [2019-12-24 03:06:05] ERROR: [browsertime] Failed to execute user script: JavascriptError: TypeError: body is null
[task 2019-12-24T03:06:28.323Z] 03:06:05     INFO -  [2019-12-24 03:06:05] VERBOSE: [browsertime] Executing script elementTimings
...
[task 2019-12-24T03:06:28.324Z] 03:06:05     INFO -  [2019-12-24 03:06:05] VERBOSE: [browsertime] Executing script rumSpeedIndex
[task 2019-12-24T03:06:28.324Z] 03:06:05     INFO -  [2019-12-24 03:06:05] VERBOSE: [browsertime] current context is chrome
[task 2019-12-24T03:06:28.324Z] 03:06:05    ERROR -  [2019-12-24 03:06:05] ERROR: [browsertime] Couldn't execute script named rumSpeedIndex error:JavascriptError: TypeError: SpeedIndex is undefined
[task 2019-12-24T03:06:28.324Z] 03:06:05    ERROR -  [2019-12-24 03:06:05] ERROR: [browsertime] Failed to execute user script: JavascriptError: TypeError: SpeedIndex is undefined
```