### PR TITLE
Verify that the element exists before getting the tagname

### DIFF
--- a/browserscripts/timings/elementTimings.js
+++ b/browserscripts/timings/elementTimings.js
@@ -17,7 +17,7 @@
       startTime: Number(entry.startTime.toFixed(0)),
       naturalHeight: entry.naturalHeight,
       naturalWidth: entry.naturalWidth,
-      tagName: entry.element.tagName
+      tagName: entry.element ? entry.element.tagName : ''
     };
   }
   return elements;


### PR DESCRIPTION
There are cases where we don't get the actual element from Chrome.