### PR TITLE
Refactor Android code.

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -11,6 +11,11 @@ const path = require('path');
 
 class Android {
   constructor(options) {
+    if (Android.instance) {
+      return Android.instance;
+    }
+
+    Android.instance = this;
     this.client = adb.createClient();
     this.id = get(
       options,
@@ -18,22 +23,27 @@ class Android {
       get(options, 'firefox.android.deviceSerial')
     );
     this.port = options.devToolsPort;
+    return this;
   }
 
-  async initConnection() {
+  async _init() {
     if (!this.id) {
       const devices = await this.client.listDevices();
       // just take the first phone online
       this.id = devices[0].id;
     }
 
-    this.sdcard = await this._runCommandAndGet('echo $EXTERNAL_STORAGE');
+    if (!this.sdcard) {
+      this.sdcard = await this._runCommandAndGet('echo $EXTERNAL_STORAGE');
+    }
 
-    return this.client.forward(
-      this.id,
-      'tcp:' + this.port,
-      'localabstract:chrome_devtools_remote'
-    );
+    if (!this.forward) {
+      return this.client.forward(
+        this.id,
+        'tcp:' + this.port,
+        'localabstract:chrome_devtools_remote'
+      );
+    }
   }
 
   async _runCommand(command) {
@@ -235,9 +245,7 @@ class Android {
 }
 
 module.exports = {
-  createAndroidConnection(options) {
-    return new Android(options);
-  },
+  Android,
   isAndroidConfigured(options) {
     return get(
       options,

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -17,7 +17,7 @@ const path = require('path');
 const speedline = require('speedline-core');
 const visualMetricsExtra = require('../../video/postprocessing/visualmetrics/extraMetrics');
 const ChromeDevtoolsProtocol = require('./chromeDevtoolsProtocol');
-const { createAndroidConnection } = require('../../android');
+const { Android } = require('../../android');
 const unlink = promisify(fs.unlink);
 
 function pad(n) {
@@ -47,8 +47,7 @@ class ChromeDelegate {
     this.hars = [];
     this.events = [];
     if (this.chrome.android) {
-      this.android = createAndroidConnection(this.options);
-      return this.android.initConnection();
+      this.android = new Android(this.options);
     }
   }
 

--- a/lib/core/engine/command/android.js
+++ b/lib/core/engine/command/android.js
@@ -1,14 +1,10 @@
 'use strict';
 
 const log = require('intel').getLogger('browsertime.command.android');
-const {
-  createAndroidConnection,
-  isAndroidConfigured
-} = require('../../../android');
+const { AndroidInstance, isAndroidConfigured } = require('../../../android');
 
 class Android {
   constructor(options) {
-    this.a = createAndroidConnection(options);
     this.options = options;
   }
 
@@ -20,9 +16,9 @@ class Android {
    */
   async shell(command) {
     if (isAndroidConfigured(this.options)) {
-      await this.a.initConnection();
       log.debug('Run %s', command);
       try {
+        this.a = AndroidInstance(this.options);
         return this.a._runCommandAndGet(command);
       } catch (e) {
         log.error('Could not run shell command %s', command, e);

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -6,10 +6,7 @@ const Video = require('../../../video/video');
 const merge = require('lodash.merge');
 const setOrangeBackground = require('../../../video/screenRecording/setOrangeBackground');
 const { filterWhitelisted } = require('../../../support/userTiming');
-const {
-  isAndroidConfigured,
-  createAndroidConnection
-} = require('../../../android');
+const { isAndroidConfigured, Android } = require('../../../android');
 const delay = ms => new Promise(res => setTimeout(res, ms));
 
 // Make this configurable
@@ -354,8 +351,7 @@ class Measure {
       }
 
       if (packageName) {
-        const android = createAndroidConnection(this.options);
-        await android.initConnection();
+        const android = Android(this.options);
         const pid = await android.pidof(packageName);
 
         if (pid) {

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -16,6 +16,7 @@ const XVFB = require('../../support/xvfb');
 const ExtensionServer = require('../../extensionserver/');
 const Iteration = require('./iteration');
 const Collector = require('./collector');
+const { Android } = require('../../android/');
 const run = require('./run');
 const engineUtils = require('../../support/engineUtils');
 
@@ -72,6 +73,12 @@ class Engine {
     if (!this.options.connectivity.variance) {
       await addConnectivity(this.options);
     }
+
+    if (this.options.android) {
+      const android = new Android(this.options);
+      await android._init();
+    }
+
     return Promise.all([this.myXVFB.start(), this.myExtensionServer.start()]);
   }
 

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -7,10 +7,7 @@ const path = require('path');
 const harBuilder = require('../../support/har/');
 const pathToFolder = require('../../support/pathToFolder');
 const rename = promisify(fs.rename);
-const {
-  isAndroidConfigured,
-  createAndroidConnection
-} = require('../../android');
+const { isAndroidConfigured, Android } = require('../../android');
 const geckoProfilerDefaults = require('../geckoProfilerDefaults');
 
 class FirefoxDelegate {
@@ -135,8 +132,7 @@ class FirefoxDelegate {
       );
 
       if (isAndroidConfigured(this.options)) {
-        let android = createAndroidConnection(this.options);
-        await android.initConnection();
+        const android = Android(this.options);
         await android._downloadFile(deviceProfileFilename, destinationFilename);
       }
     }

--- a/lib/video/screenRecording/android/recorder.js
+++ b/lib/video/screenRecording/android/recorder.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const get = require('lodash.get');
 const log = require('intel').getLogger('browsertime.video');
 const videoDefaults = require('../../defaults');
-const { createAndroidConnection } = require('../../../android');
+const { Android } = require('../../../android');
 const unlink = util.promisify(fs.unlink);
 
 const delay = ms => new Promise(res => setTimeout(res, ms));
@@ -12,7 +12,6 @@ const delay = ms => new Promise(res => setTimeout(res, ms));
 module.exports = class AndroidRecorder {
   constructor(options) {
     this.waitTime = get(options, 'videoParams.androidVideoWaitTime', 5000);
-    this.android = createAndroidConnection(options);
     this.framerate = get(
       options,
       'videoParams.framerate',
@@ -22,7 +21,7 @@ module.exports = class AndroidRecorder {
   }
 
   async start() {
-    await this.android.initConnection();
+    this.android = Android(this.options);
     return this.android.startVideo();
   }
 

--- a/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
+++ b/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const execa = require('execa');
 const del = require('del');
-const { createAndroidConnection } = require('../../../android');
+const { Android } = require('../../../android');
 
 const unlink = util.promisify(fs.unlink);
 
@@ -160,8 +160,7 @@ module.exports = class FirefoxWindowRecorder {
     log.info('Start firefox window recorder.');
 
     if (this.options.firefox.android) {
-      this.android = createAndroidConnection(this.options);
-      await this.android.initConnection();
+      this.android = Android(this.options);
       await this.android.removePathOnSdCard(
         'browsertime-firefox-windowrecording'
       );


### PR DESCRIPTION
Move android code to a singleton pattern #1010.
This isn't perfect but it at least better than before. We init
the android connection early in the engine.

This will make it easier to add Android setup code.