### PR TITLE
Enable verbose logging when using geckodriver. (#1082)

### DIFF
--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -14,6 +14,24 @@ const util = require('../../support/util');
 module.exports.configureBuilder = function(builder, baseDir, options) {
   const firefoxConfig = options.firefox || {};
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
+
+  let geckodriverPath = get(firefoxConfig, 'geckodriverPath');
+  if (!geckodriverPath) {
+    const geckodriver = require('@sitespeed.io/geckodriver');
+    geckodriverPath = geckodriver.binPath();
+  }
+
+  const serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
+  if (options.verbose >= 2) {
+    // This echoes the output from geckodriver to the console.
+    serviceBuilder.setStdio('inherit');
+    // TODO: serviceBuilder.loggingTo(`${baseDir}/geckodriver.log`);
+    if (options.verbose >= 3) {
+      serviceBuilder.enableVerboseLogging();
+    }
+  }
+  builder.setFirefoxService(serviceBuilder);
+
   const ffOptions = new firefox.Options();
 
   const profileTemplatePath = path.resolve(
@@ -189,18 +207,4 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   }
 
   builder.setFirefoxOptions(ffOptions);
-
-  // Ugly hack for geckodriver
-  // We need it until Selenium NodeJS version supports setting geckodriver
-  // Selenium looks for geckodriver in the PATH.
-  let geckodriverPath = get(firefoxConfig, 'geckodriverPath');
-  if (!geckodriverPath) {
-    const geckodriver = require('@sitespeed.io/geckodriver');
-    geckodriverPath = geckodriver.binPath();
-  }
-
-  log.info(`geckodriver is ${geckodriverPath}`);
-
-  const geckoPath = path.dirname(geckodriverPath);
-  process.env.PATH = [geckoPath, process.env.PATH].join(path.delimiter);
 };


### PR DESCRIPTION
This also configure the path to the geckodriver binary without
manipulating PATH.