### PR TITLE
Fixed broken Firefox Android support.

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -245,6 +245,9 @@ class Android {
 module.exports = {
   Android,
   isAndroidConfigured(options) {
+    if (options.android === true) {
+      return true;
+    }
     return get(
       options,
       'chrome.android.package',

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -132,7 +132,7 @@ class FirefoxDelegate {
       );
 
       if (isAndroidConfigured(this.options)) {
-        const android = Android(this.options);
+        const android = new Android(this.options);
         await android._downloadFile(deviceProfileFilename, destinationFilename);
       }
 


### PR DESCRIPTION
When I refectored the Android code the support for running Android with geckoProfiler turned on was broken.