### PR TITLE
Fix font usage on macOS

### DIFF
--- a/lib/video/postprocessing/finetune/addTextToVideo.js
+++ b/lib/video/postprocessing/finetune/addTextToVideo.js
@@ -3,6 +3,7 @@
 const execa = require('execa');
 const log = require('intel').getLogger('browsertime.video');
 const getTimingMetrics = require('./getTimingMetrics');
+const getFont = require('./getFont');
 
 module.exports = async function(
   inputFile,
@@ -18,12 +19,7 @@ module.exports = async function(
     timingMetrics,
     options
   );
-  const fontFile =
-    process.platform === 'darwin'
-      ? '/System/Library/Fonts/SFNSText.ttf:'
-      : options.videoParams.fontPath
-      ? options.videoParams.fontPath + ':'
-      : '';
+  const fontFile = getFont(options);
   args.push(
     '-vf',
     `drawtext=${fontFile}x=w/2-(tw/2): y=H-h/10:fontcolor=white:fontsize=h/14:box=1:boxcolor=0x000000AA:text='%{pts\\:hms}'${allTimingMetrics}`

--- a/lib/video/postprocessing/finetune/getFont.js
+++ b/lib/video/postprocessing/finetune/getFont.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const log = require('intel').getLogger('browsertime.video');
+const fs = require('fs');
+module.exports = function(
+  options
+) {
+  // If the font is not part of the params and we're on macOS
+  // we check that SFNSText.ttf is available
+  if (!options.videoParams.fontPath && process.platform === 'darwin') {
+    const systemFontFile = '/System/Library/Fonts/SFNSText.ttf';
+    try {
+      if (fs.existsSync(systemFontFile)) {
+        return systemFontFile + ':';
+      }
+      return '';
+    } catch(err) {
+      return '';
+    }
+  }
+  return options.videoParams.fontPath ? options.videoParams.fontPath + ':' : '';
+}

--- a/lib/video/postprocessing/finetune/getTimingMetrics.js
+++ b/lib/video/postprocessing/finetune/getTimingMetrics.js
@@ -1,5 +1,6 @@
 'use strict';
 const { isAndroidConfigured } = require('../../../android');
+const getFont = require('./getFont');
 
 function isSmallish(options) {
   return (
@@ -12,13 +13,7 @@ function isSmallish(options) {
 
 function get(metric, metricName, pos, options) {
   // We need the fontfile running Android from a Mac
-  const fontFile =
-    process.platform === 'darwin'
-      ? '/System/Library/Fonts/SFNSText.ttf:'
-      : options.videoParams.fontPath
-      ? options.videoParams.fontPath + ':'
-      : '';
-
+  const fontFile = getFont(options);
   let fontSize = 16;
   let x = 8;
   if (isSmallish(options)) {


### PR DESCRIPTION
On macOS, addTextToVideo and getTimingMetrics will fail because the code
makes the assumption /System/Library/Fonts/SFNSText.ttf always exists.

In the new getFont() api, we check that assumption and fallback to
not specifying a font. Also, we make sure to use the font passed
through options.videoParams.fontPath even on macOS because why not.