### PR TITLE
Set a new default font for OS X since the old has been deleted.

### DIFF
--- a/lib/video/postprocessing/finetune/getFont.js
+++ b/lib/video/postprocessing/finetune/getFont.js
@@ -5,7 +5,7 @@ module.exports = function(options) {
   // If the font is not part of the params and we're on macOS
   // we check that SFNSText.ttf is available
   if (!options.videoParams.fontPath && process.platform === 'darwin') {
-    const systemFontFile = '/System/Library/Fonts/SFNSText.ttf';
+    const systemFontFile = '/System/Library/Fonts/SFNS.ttf';
     try {
       if (fs.existsSync(systemFontFile)) {
         return systemFontFile + ':';


### PR DESCRIPTION
There's no need to look for a font that don't exists anymore.