### PR TITLE
Set path on the sdcard for Android for window recording.

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -86,6 +86,15 @@ class Android {
     }
   }
 
+  getFullPathOnSdCard(path) {
+    return `${this.sdcard}/${path}`;
+  }
+
+  async mkDirOnSdCard(dirName) {
+    const command = `mkdir ${this.sdcard}/${dirName}`;
+    return this._runCommand(command);
+  }
+
   async removeFileOnSdCard(file) {
     const command = `rm -- "${this.sdcard}/${file}"`;
     if (!this.sdcard || !file) {

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -10,6 +10,7 @@ const get = require('lodash.get');
 const defaultFirefoxPreferences = require('./firefoxPreferences');
 const disableSafeBrowsingPreferences = require('./disableSafeBrowsingPreferences');
 const util = require('../../support/util');
+const { Android } = require('../../android');
 
 module.exports.configureBuilder = function(builder, baseDir, options) {
   const firefoxConfig = options.firefox || {};
@@ -55,7 +56,18 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   // Output the window recorder image frames to a base directory.
   // This pref expects a trailing slash.
   if (firefoxConfig.windowRecorder) {
-    ffOptions.setPreference('layers.windowrecording.path', `${baseDir}/`);
+    if (options.android) {
+      const android = new Android(options);
+      const pathToRecording = android.getFullPathOnSdCard(
+        'browsertime-firefox-windowrecording'
+      );
+      ffOptions.setPreference(
+        'layers.windowrecording.path',
+        `${pathToRecording}/`
+      );
+    } else {
+      ffOptions.setPreference('layers.windowrecording.path', `${baseDir}/`);
+    }
   }
 
   Object.keys(defaultFirefoxPreferences).forEach(function(pref) {

--- a/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
+++ b/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
@@ -164,6 +164,7 @@ module.exports = class FirefoxWindowRecorder {
       await this.android.removePathOnSdCard(
         'browsertime-firefox-windowrecording'
       );
+      await this.android.mkDirOnSdCard('browsertime-firefox-windowrecording');
     }
 
     return enableWindowRecorder(true, this.browser);
@@ -174,10 +175,10 @@ module.exports = class FirefoxWindowRecorder {
     await enableWindowRecorder(false, this.browser);
 
     if (this.options.android) {
-      await this.android._downloadDir(
-        '/sdcard/browsertime-firefox-windowrecording',
-        this.baseDir
+      const fullPathOnSdCard = this.android.getFullPathOnSdCard(
+        'browsertime-firefox-windowrecording'
       );
+      await this.android._downloadDir(fullPathOnSdCard, this.baseDir);
     }
 
     // FIXME update to rename/move file


### PR DESCRIPTION
And making sure /sdcard/ isn't hardcoded, instead use the path that
we get from the phone.

This fixes parts of #1098 but there's still no png files on the phone.