### PR TITLE
Move Firefox specific code out of iteration #1065.

### DIFF
--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -416,6 +416,8 @@ class ChromeDelegate {
     this.hars.push(har);
   }
 
+  async afterCollect() {}
+
   async sendAndGetDevToolsCommand(cmd, params = {}) {
     return this.cdpClient.send(cmd, params);
   }

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -4,7 +4,6 @@ const webdriver = require('selenium-webdriver');
 const log = require('intel').getLogger('browsertime');
 const SeleniumRunner = require('../seleniumRunner');
 const preURL = require('../../support/preURL');
-const pathToFolder = require('../../support/pathToFolder');
 const setResourceTimingBufferSize = require('../../support/setResourceTimingBufferSize');
 const ScreenshotManager = require('../../screenshot/');
 const engineUtils = require('../../support/engineUtils');
@@ -24,7 +23,6 @@ const Android = require('./command/android.js');
 const ChromeDevToolsProtocol = require('./command/chromeDevToolsProtocol.js');
 const { addConnectivity, removeConnectivity } = require('../../connectivity');
 const util = require('../../support/util.js');
-const path = require('path');
 
 const { isAndroidConfigured } = require('../../android');
 
@@ -227,63 +225,8 @@ class Iteration {
                 );
               }
             }
+            result[i].videoRecordingStart = videoMetrics.videoRecordingStart;
             result[i].visualMetrics = videoMetrics.visualMetrics;
-
-            if (
-              options.browser === 'firefox' &&
-              options.firefox &&
-              options.firefox.geckoProfiler
-            ) {
-              const profileFilename = `geckoProfile-${index}.json.gz`;
-              const profileSubdir = pathToFolder(result[i].url, options);
-
-              try {
-                const geckoProfile = JSON.parse(
-                  await this.storageManager.readData(
-                    profileFilename,
-                    profileSubdir
-                  )
-                );
-                if (!geckoProfile.meta) {
-                  geckoProfile.meta = {};
-                }
-
-                // Here we are calculating the unix timestamp of the first frame after orange screen
-                // by adding the time to first frame, time to orange screen to the unix timestamp of
-                // video recording start time
-                const firstFrameStartTime =
-                  result[i].recordingStartTime +
-                  videoMetrics.videoRecordingStart +
-                  result[i].timeToFirstFrame;
-
-                for (let progress of [
-                  'VisualProgress',
-                  'ContentfulSpeedIndexProgress',
-                  'PerceptualSpeedIndexProgress'
-                ]) {
-                  videoMetrics.visualMetrics[
-                    progress
-                  ] = util.adjustVisualProgressTimestamps(
-                    videoMetrics.visualMetrics[progress],
-                    geckoProfile.meta.startTime,
-                    firstFrameStartTime
-                  );
-                }
-                geckoProfile.meta.visualMetrics = videoMetrics.visualMetrics;
-
-                await this.storageManager.writeJson(
-                  path.join(profileSubdir, `geckoProfile-${index}.json`),
-                  geckoProfile,
-                  true
-                );
-              } catch (e) {
-                log.error(
-                  `Could not write visual metrics to ${profileFilename}`,
-                  e
-                );
-              }
-            }
-
             i++;
           } catch (e) {
             // If one of the Visual Metrics runs fail, just swallow and try the next one
@@ -291,6 +234,9 @@ class Iteration {
           }
         }
       }
+
+      await this.engineDelegate.afterCollect(result);
+
       if (commands.meta.description) {
         result.description = commands.meta.description;
       }

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -9,6 +9,7 @@ const pathToFolder = require('../../support/pathToFolder');
 const rename = promisify(fs.rename);
 const { isAndroidConfigured, Android } = require('../../android');
 const geckoProfilerDefaults = require('../geckoProfilerDefaults');
+const util = require('../../support/util.js');
 
 class FirefoxDelegate {
   constructor(storageManager, options) {
@@ -209,6 +210,59 @@ class FirefoxDelegate {
       }
     } catch (e) {
       log.error('Could not get the HAR from Firefox', e);
+    }
+  }
+
+  async afterCollect(result) {
+    if (this.firefoxConfig.geckoProfiler && this.options.visualMetrics) {
+      for (let i = 0; i < result.length; i++) {
+        const index = i + 1;
+        const profileFilename = `geckoProfile-${index}.json.gz`;
+        const profileSubdir = pathToFolder(result[i].url, this.options);
+
+        try {
+          const geckoProfile = JSON.parse(
+            await this.storageManager.readData(profileFilename, profileSubdir)
+          );
+          if (!geckoProfile.meta) {
+            geckoProfile.meta = {};
+          }
+
+          // Here we are calculating the unix timestamp of the first frame after orange screen
+          // by adding the time to first frame, time to orange screen to the unix timestamp of
+          // video recording start time
+          const firstFrameStartTime =
+            result[i].recordingStartTime +
+            result[i].videoRecordingStart +
+            result[i].timeToFirstFrame;
+
+          for (let progress of [
+            'VisualProgress',
+            'ContentfulSpeedIndexProgress',
+            'PerceptualSpeedIndexProgress'
+          ]) {
+            result[i].visualMetrics[
+              progress
+            ] = util.adjustVisualProgressTimestamps(
+              result[i].visualMetrics[progress],
+              geckoProfile.meta.startTime,
+              firstFrameStartTime
+            );
+          }
+          geckoProfile.meta.visualMetrics = result[i].visualMetrics;
+
+          await this.storageManager.writeJson(
+            path.join(profileSubdir, `geckoProfile-${index}.json`),
+            geckoProfile,
+            true
+          );
+        } catch (e) {
+          log.error(
+            `Could not rewrite visual progress using startimes and add visual metrics to ${profileFilename}`,
+            e
+          );
+        }
+      }
     }
   }
 

--- a/lib/safari/webdriver/safariDelegate.js
+++ b/lib/safari/webdriver/safariDelegate.js
@@ -19,6 +19,8 @@ class SafariDelegate {
 
   async beforeCollect() {}
 
+  async afterCollect() {}
+
   async onCollect(runner, index, result) {
     const resource = await runner.runScript(
       'return performance.getEntriesByType("resource");',


### PR DESCRIPTION
Lets move the geckoProfiler fixes to Firefox. First move the code
(and add new delegate hook) then in a follow up we can go through
and rename the hooks so they are easier to understand.