### PR TITLE
Add `--firefox.args` and `--firefox.env` options for arguments and en…

### DIFF
--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -150,6 +150,21 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
 
   ffOptions.addArguments('-no-remote');
 
+  if (firefoxConfig.args) {
+    ffOptions.addArguments(firefoxConfig.args);
+  }
+
+  const envMap = {}; // Map of string name to string value.
+  const envs = util.toArray(firefoxConfig.env);
+  for (const env of envs) {
+    const name = env.substr(0, env.indexOf('='));
+    let value = env.substr(env.indexOf('=') + 1);
+    envMap[name] = value;
+  }
+  if (envs.length > 0) {
+    ffOptions.firefoxOptions_().env = envMap;
+  }
+
   if (options.headless) {
     ffOptions.headless();
   }

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -303,6 +303,18 @@ module.exports.parseCommandLine = function parseCommandLine() {
         'To add multiple preferences, repeat --firefox.preference once per argument.',
       group: 'firefox'
     })
+    .option('firefox.args', {
+      describe:
+        'Extra command line arguments to pass to the Firefox process (e.g. --MOZ_LOG). ' +
+        'To add multiple arguments to Firefox, repeat --firefox.args once per argument.',
+      group: 'firefox'
+    })
+    .option('firefox.env', {
+      describe:
+        'Extra environment variables to set in the format name=value. ' +
+        'To add multiple environment variables, repeat --firefox.env once per environment variable.',
+      group: 'firefox'
+    })
     .option('firefox.includeResponseBodies', {
       describe: 'Include response bodies in HAR',
       default: 'none',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5188,7 +5188,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -5229,7 +5229,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -6658,7 +6658,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"


### PR DESCRIPTION
…vironment variables. (#1109)

`--firefox.args` is sibling to `chrome.args`; support for this already
exists in `selenium-webdriver`.

`--firefox.env` has no analog, and requires a `geckodriver` with
https://bugzilla.mozilla.org/show_bug.cgi?id=1607960 applied.  That
will likely be whatever release follows 0.26.0.