### PR TITLE
Rehabilitate `--processStartTime` on Android.

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -205,23 +205,29 @@ class Android {
     // for the date formatting trick.
     const MILLIS_PER_S = 1000;
 
-    const awk = `date +%s%3N && awk '{print $1}' /proc/uptime && awk '{print $22}' /proc/self/stat /proc/${pid}/stat`;
-    const statAndTimestamp = await this._runCommand(awk);
+    // It seems that `cut` is more common than `awk`, especially on older OS versions.  It's unclear
+    // if $EPOCHREALTIME is more common than `date +%s%3N` support.  On the x86-7.0 emulator, date
+    // only gives seconds.  In the future, we should try both methods for finding the date, and both
+    // `cut` and `awk`, to make this more robust.
+    const cut = `echo $EPOCHREALTIME && cut -d ' ' -f 1 /proc/uptime && cut -d ' ' -f 22 /proc/self/stat /proc/${pid}/stat`;
+    // const awk = `date +%s%3N && awk '{print $1}' /proc/uptime && awk '{print $22}' /proc/self/stat /proc/${pid}/stat`;
+    const statAndTimestamp = await this._runCommand(cut);
     const output = (await adb.util.readAll(statAndTimestamp)).toString();
 
     const [
-      dateInMs,
+      dateInS,
       systemUptimeInSeconds,
-      awkStartTimeAfterSystemStartTimeInJiffies,
+      utilStartTimeAfterSystemStartTimeInJiffies,
       processStartTimeAfterSystemStartTimeInJiffies
     ] = output
       .trim()
       .split(/[\r\n]+/)
       .map(v => Number.parseFloat(v.trim()));
+    const dateInMs = Math.round(dateInS * 1000.0);
 
     // Usually 100, but this isn't strictly guaranteed by Android.
     const jiffesPerSeconds = Math.round(
-      awkStartTimeAfterSystemStartTimeInJiffies / systemUptimeInSeconds
+      utilStartTimeAfterSystemStartTimeInJiffies / systemUptimeInSeconds
     );
 
     const processStartTimeInMs =
@@ -230,14 +236,17 @@ class Android {
       (processStartTimeAfterSystemStartTimeInJiffies * MILLIS_PER_S) /
         jiffesPerSeconds;
 
-    return {
+    const obj = {
       dateInMs,
       systemUptimeInSeconds,
-      awkStartTimeAfterSystemStartTimeInJiffies,
+      utilStartTimeAfterSystemStartTimeInJiffies,
       processStartTimeAfterSystemStartTimeInJiffies,
       jiffesPerSeconds,
       processStartTimeInMs
     };
+    // log.debug(`_processStartTime`, obj); // Too verbose for regular use.
+
+    return obj;
   }
 
   async processStartTime(pid, count = 3) {

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -150,7 +150,7 @@ class Iteration {
           : 'data:text/html;charset=utf-8,<html><body></body></html>';
       if (options.spa) {
         await setResourceTimingBufferSize(startURL, browser.getDriver(), 1000);
-      } else {
+      } else if (!options.processStartTime) {
         // Before we needed Chrome to open once to get correct values for Chrome HAR
         // but now Firefox first visual change is slower if we remove this ...
         await browser.getDriver().get(startURL);


### PR DESCRIPTION
This still isn't as robust as we'd like, but it works on the three Android devices that Mozilla cares about right now -- x86 emulator, Pixel 2, Moto G5 -- so it would be helpful to have it landed.