### PR TITLE
Fix the bug where a frame is missed after ffmpeg transformation

### DIFF
--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -143,7 +143,7 @@ def extract_frames(video, directory, full_resolution, viewport):
             match = re.search(pattern, line)
             if match:
                 frame_count += 1
-                frame_time = int(math.ceil(float( \
+                frame_time = int(math.floor(float( \
                     match.groupdict().get('timecode')) * 1000))
                 src = os.path.join(
                     directory, 'img-{0:d}.png'.format(frame_count))


### PR DESCRIPTION
This is for issue #1093 

We should return the ceiling value of the timestamp.

I did some testings, and I saw visual metrics numbers stayed the same as without the patch, so this was good. 

Some side effects may be things like `trimming frames from the end`, a frame which was excluded may be included after the patch, however I don't think this is a big problem. 