### PR TITLE
Add experimental support for Edge

### DIFF
--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -13,7 +13,7 @@ async function runBrowsertime() {
     .option('browser', {
       alias: 'b',
       default: 'chrome',
-      choices: ['chrome', 'firefox'],
+      choices: ['chrome', 'firefox', 'edge'],
       describe: 'Specify browser'
     })
     .option('connectivity.latency', {

--- a/lib/chrome/webdriver/chromeDelegate.js
+++ b/lib/chrome/webdriver/chromeDelegate.js
@@ -437,7 +437,7 @@ class ChromeDelegate {
     if (this.skipHar) {
       return;
     }
-    this.hars.push(harBuilder.getEmptyHAR(url, 'Chrome'));
+    this.hars.push(harBuilder.getEmptyHAR(url, this.options.browser));
   }
 
   async onStop() {

--- a/lib/core/engine/command/cache.js
+++ b/lib/core/engine/command/cache.js
@@ -25,7 +25,7 @@ class Cache {
         options
       );
       return this.extensionServer.stop();
-    } else if (this.browserName === 'chrome') {
+    } else if (this.browserName === 'chrome' || this.browserName === 'edge') {
       await this.cdp.send('Network.enable');
       await this.cdp.send('Network.clearBrowserCache');
       return this.cdp.send('Network.clearBrowserCookies');
@@ -50,7 +50,7 @@ class Cache {
         options
       );
       return this.extensionServer.stop();
-    } else if (this.browserName === 'chrome') {
+    } else if (this.browserName === 'chrome' || this.browserName === 'edge') {
       await this.cdp.send('Network.enable');
       return this.cdp.send('Network.clearBrowserCache');
     } else {

--- a/lib/core/engine/command/chromeDevToolsProtocol.js
+++ b/lib/core/engine/command/chromeDevToolsProtocol.js
@@ -9,8 +9,8 @@ class DevToolsProtocol {
   }
 
   async sendAndGet(command, args) {
-    if (this.browserName != 'chrome') {
-      throw new Error('DevToolsProtocol only supported in Chrome');
+    if (this.browserName != 'chrome' || this.browserName != 'edge') {
+      throw new Error('DevToolsProtocol only supported in Chrome and Edge');
     }
     try {
       const result = await this.engineDelegate.sendAndGetDevToolsCommand(

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -98,6 +98,9 @@ class Engine {
       case 'chrome':
         engineDelegate = new ChromeDelegate(storageManager, this.options);
         break;
+      case 'edge':
+        engineDelegate = new ChromeDelegate(storageManager, this.options);
+        break;
       case 'safari':
         engineDelegate = new SafariDelegate(storageManager, this.options);
     }

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -3,6 +3,7 @@
 const webdriver = require('selenium-webdriver');
 const isEmpty = require('lodash.isempty');
 const chrome = require('../../chrome/webdriver/');
+const edge = require('../../edge/webdriver/');
 const firefox = require('../../firefox/webdriver/');
 const safari = require('../../safari/webdriver/');
 
@@ -18,8 +19,9 @@ module.exports.createWebDriver = async function(baseDir, options) {
   const capabilities = options.selenium
     ? options.selenium.capabilities
     : undefined;
+
   const builder = new webdriver.Builder()
-    .forBrowser(browser)
+    .forBrowser(browser === 'edge' ? 'chrome' : browser)
     .usingServer(seleniumUrl);
 
   // Hack for running browsertime on different platforms.
@@ -40,6 +42,10 @@ module.exports.createWebDriver = async function(baseDir, options) {
 
     case 'safari':
       await safari.configureBuilder(builder, baseDir, options);
+      break;
+
+    case 'edge':
+      edge.configureBuilder(builder, baseDir, options);
       break;
 
     default:

--- a/lib/edge/webdriver/index.js
+++ b/lib/edge/webdriver/index.js
@@ -1,0 +1,12 @@
+const chrome = require('../../chrome/webdriver/');
+const log = require('intel').getLogger('browsertime.edge');
+
+module.exports.configureBuilder = function(builder, baseDir, options) {
+  const edgeConfig = options.edge || {};
+  if (!edgeConfig.edgedriverPath) {
+    log.error('Missing --edge.edgedriverPath configuration');
+  } else {
+    options.chrome.chromedriverPath = edgeConfig.edgedriverPath;
+  }
+  chrome.configureBuilder(builder, baseDir, options);
+};

--- a/lib/edge/webdriver/index.js
+++ b/lib/edge/webdriver/index.js
@@ -4,8 +4,13 @@ const log = require('intel').getLogger('browsertime.edge');
 module.exports.configureBuilder = function(builder, baseDir, options) {
   const edgeConfig = options.edge || {};
   if (!edgeConfig.edgedriverPath) {
-    log.error('Missing --edge.edgedriverPath configuration');
+    log.error(
+      'Missing --edge.edgedriverPath configuration, Edge will not work'
+    );
   } else {
+    log.info(
+      'Using Edge is experimental at the moment and use the same configuration as for Chrome'
+    );
     options.chrome.chromedriverPath = edgeConfig.edgedriverPath;
   }
   chrome.configureBuilder(builder, baseDir, options);

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -503,7 +503,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .option('browser', {
       alias: 'b',
       default: 'chrome',
-      choices: ['chrome', 'firefox', 'safari'],
+      choices: ['chrome', 'firefox', 'edge', 'safari'],
       describe: 'Specify browser. Safari only works on OS X.'
     })
     .option('android', {
@@ -879,7 +879,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
 
   // Simplest way to just to get CPU metrics
   if (argv.cpu) {
-    if (argv.browser === 'chrome') {
+    if (argv.browser === 'chrome' || argv.browser === 'edge') {
       set(argv, 'chrome.collectLongTasks', true);
       set(argv, 'chrome.timeline', true);
     } else if (argv.browser === 'firefox') {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -86,6 +86,14 @@ function validateInput(argv) {
     return 'Ooops you passed number of iterations twice, remove one of them and try again.';
   }
 
+  if (argv.browser === 'edge') {
+    if (argv.edge && argv.edge.edgedriverPath) {
+      return true;
+    } else {
+      return 'To run Edge you need to supply the path to the msedgedriver with --edge.edgedriverPath';
+    }
+  }
+
   return true;
 }
 
@@ -862,12 +870,23 @@ module.exports.parseCommandLine = function parseCommandLine() {
   }
 
   if (argv.android) {
-    if (argv.browser != 'firefox') {
+    if (argv.browser === 'chrome') {
       // Default to Chrome Android.
       set(
         argv,
         'chrome.android.package',
         get(argv, 'chrome.android.package', 'com.android.chrome')
+      );
+    } else if (argv.browser === 'edge') {
+      set(
+        argv,
+        'chrome.android.package',
+        get(argv, 'chrome.android.package', 'com.microsoft.emmx')
+      );
+      set(
+        argv,
+        'chrome.android.activity',
+        get(argv, 'chrome.android.activity', 'com.microsoft.ruby.Main')
       );
     }
   }


### PR DESCRIPTION
Let us add some support for the new Chromium based edge. At the moment you need to use `--edge.edgedriverPath` to set the correct path for the Edgedriver.