### PR TITLE
If Visual Metrics fails, add an error to the result so we can signal …

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -230,8 +230,9 @@ class Iteration {
             result[i].visualMetrics = videoMetrics.visualMetrics;
             i++;
           } catch (e) {
-            // If one of the Visual Metrics runs fail, just swallow and try the next one
+            // If one of the Visual Metrics runs fail, try the next one
             log.error('Visual Metrics failed to analyse the video', e);
+            result[i].error.push(e.message);
           }
         }
       }


### PR DESCRIPTION
…the error.

See #1146