### PR TITLE
Log the original Visal Metrics error asap.

### DIFF
--- a/lib/video/postprocessing/visualmetrics/single/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/single/visualMetrics.js
@@ -97,6 +97,7 @@ module.exports = {
       }
       return JSON.parse(result.stdout);
     } catch (e) {
+      log.error('VisualMetrics failed to run', e);
       // If something goes wrong, dump the visual metrics log to our log
       const visualMetricLog = await readFile(visualMetricsLogFile);
       log.error('Log from VisualMetrics: %s', visualMetricLog);


### PR DESCRIPTION
If the VM fails, there will be no error log, and that error will be thrown upwards instead.