### PR TITLE
Use PageLoadStrategy none as default with higher default wait times.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -220,6 +220,9 @@ class SeleniumRunner {
     // befor you start to run your page complete check
     if (this.options.pageLoadStrategy === 'none') {
       await delay(this.options.pageCompleteCheckStartWait || 5000);
+    } else {
+      // Give the browser some time to navigate
+      await delay(2000);
     }
 
     // We give it a couple of times to finish loading, this makes it

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -156,6 +156,7 @@ class SeleniumRunner {
         'for page complete check script to return true',
         function(d) {
           return d.executeScript(pageCompleteCheck, waitTime).then(function(t) {
+            log.verbose('PageCompleteCheck returned %s', t);
             return t === true;
           });
         }
@@ -169,7 +170,7 @@ class SeleniumRunner {
           pageCompleteCheckCondition,
           pageCompleteCheckTimeout,
           undefined,
-          this.options.pageCompleteCheckPollTimeout || 200
+          this.options.pageCompleteCheckPollTimeout || 1500
         ),
         pageCompleteCheckTimeout,
         `Running page complete check ${pageCompleteCheck} took too long`
@@ -213,11 +214,13 @@ class SeleniumRunner {
         })();`;
     // Navigate to the page
     await driver.executeScript(navigate);
-    // If you run with default settings, the webdriver will give back control after
-    // the onload event. But you can change that with the --pageLoadStrategy none
-    // Then you will be in control immediately and therefore wanna wait some extra time
+
+    // If you run with default settings, the webdriver will give back
+    // control ASAP. Therefore you wanna wait some extra time
     // befor you start to run your page complete check
-    await delay(this.options.pageCompleteCheckStartWait || 500);
+    if (this.options.pageLoadStrategy === 'none') {
+      await delay(this.options.pageCompleteCheckStartWait || 5000);
+    }
 
     // We give it a couple of times to finish loading, this makes it
     // more stable in real case scenarios on slow servers.

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -606,24 +606,23 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('pageCompleteCheckPollTimeout', {
       type: 'number',
-      default: 200,
+      default: 1500,
       describe:
         'The time in ms to wait for running the page complete check the next time.'
     })
     .option('pageCompleteCheckStartWait', {
       type: 'number',
-      default: 500,
+      default: 5000,
       describe:
         'The time in ms to wait for running the page complete check for the first time. Use this when you have a pageLoadStrategy set to none'
     })
     .option('pageLoadStrategy', {
       type: 'string',
-      default: 'normal',
+      default: 'none',
       choices: ['eager', 'none', 'normal'],
       describe:
-        'Set the strategy to waiting for document readiness after a navigation event. After the strategy is ready, your pageCompleteCheck will start runninhg. This only for Firefox and Chrome and please check which value each browser implements.'
+        'Set the strategy to waiting for document readiness after a navigation event. After the strategy is ready, your pageCompleteCheck will start runninhg.'
     })
-
     .option('iterations', {
       alias: 'n',
       type: 'number',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test": "mocha test/unitTests test/browserTests test/commandTests",
     "test:unit": "mocha test/unitTests",
     "test:browser": "mocha test/browserTests",
+    "test:selenium": "mocha test/browserTests/seleniumRunnerTests.js",
     "test:commands": "mocha test/commandTests",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Using load strategy none and wait before doing the first check (and
the continous checks) decreases communication between the driver
and the browser.