### PR TITLE
Compare "bare" domain names in URL retry logic as equal. (#1157)

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -196,7 +196,12 @@ class SeleniumRunner {
    */
   async loadAndWait(url, pageCompleteCheck) {
     const driver = this.driver;
-    const startURI = await driver.executeScript('return document.documentURI;');
+    // Browsers may normalize 'https://x.com' differently; in particular, Firefox normalizes to
+    // 'https://x.com/'.  This is a first normalization attempt; there are deeper options that order
+    // query parameters, order fragments, etc.  We don't want to change url itself 'cuz it can be
+    // used for indexing collected data and it is possible that normalization could change a key.
+    const normalizedURI = new URL(url).toString();
+    const startURI = new URL(await driver.executeScript('return document.documentURI;')).toString();
     // To learn more about the event loop and request animation frame
     // watch Jake Archibald on ‘The Event Loop’ https://vimeo.com/254947206
     // TODO do we only want to do this when we record a video?
@@ -226,17 +231,16 @@ class SeleniumRunner {
     for (let i = 0; i < tries; ++i) {
       try {
         await this.wait(pageCompleteCheck);
-        const newURI = await driver.executeScript(
-          'return document.documentURI;'
-        );
+        const newURI = new URL(await driver.executeScript('return document.documentURI;')).toString();
+
         // If we use a SPA it could be that we don't test a new URL so just do one try
         // and make sure your page complete check take care of other things
         if (this.options.spa) {
           break;
-        } else if (url === startURI) {
+        } else if (normalizedURI === startURI) {
           // You are navigating to the current page
           break;
-        } else if (url.startsWith('data:text')) {
+        } else if (normalizedURI.startsWith('data:text')) {
           // Navigations between data/text seems to don't change the URI
           break;
         } else if (newURI !== startURI) {


### PR DESCRIPTION
This fixes an issue introduced in #1077: URL comparisons are failing
because the similar looking URLs for "bare" domain names like
https://x.com and https://x.com/ do not string-compare as ===.  It's
probably not worth fully normalizing URLs (i.e., sorting query
parameters) but it is worth normalizing trailing slashes in such
cases, which we do by parsing with `new URL(...)` (which is present
since Node v8).