### PR TITLE
Testing the same URL multiple times should use a unique URL per test.

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -271,19 +271,6 @@ class Measure {
       path.join(pathToFolder(url, this.options))
     );
 
-    // when we have the URL we can use that to stop the video and put it where we want it
-    if (this.recordVideo && !this.options.videoParams.debug) {
-      await this.video.stop(url);
-      this.result[this.numberOfMeasuredPages].recordingStartTime = parseFloat(
-        this.video.getRecordingStartTime()
-      );
-      this.result[this.numberOfMeasuredPages].timeToFirstFrame = parseInt(
-        this.video.getTimeToFirstFrame(),
-        10
-      );
-      this.videos.push(this.video);
-    }
-
     // If we have an alias for the URL, use that URL
     if (
       this.result[this.numberOfMeasuredPages] &&
@@ -312,6 +299,19 @@ class Measure {
       this.testedURLs[url] = 1;
     }
     this.result[this.numberOfMeasuredPages].url = url;
+
+    // when we have the URL we can use that to stop the video and put it where we want it
+    if (this.recordVideo && !this.options.videoParams.debug) {
+      await this.video.stop(url);
+      this.result[this.numberOfMeasuredPages].recordingStartTime = parseFloat(
+        this.video.getRecordingStartTime()
+      );
+      this.result[this.numberOfMeasuredPages].timeToFirstFrame = parseInt(
+        this.video.getTimeToFirstFrame(),
+        10
+      );
+      this.videos.push(this.video);
+    }
 
     if (this.options.screenshot) {
       try {


### PR DESCRIPTION
There was a bug that made it so for the video we used the actual URL instead
of the newly made one #2842.