### PR TITLE
Record video/visual metrics on OS x #1179

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -145,9 +145,13 @@ class Iteration {
         android: new Android(options)
       };
 
+      // Safari can't load data:text URLs at startup, so you can either choose
+      // your own URL or use the blank one
       const startURL =
         options.browser === 'safari'
-          ? 'data:text/html;'
+          ? options.safari && options.safari.startURL
+            ? options.safari.startURL
+            : 'https://www.sitespeed.io/blank.html'
           : 'data:text/html;charset=utf-8,<html><body></body></html>';
       if (options.spa) {
         await setResourceTimingBufferSize(startURL, browser.getDriver(), 1000);

--- a/lib/video/screenRecording/desktop/ffmpegRecorder.js
+++ b/lib/video/screenRecording/desktop/ffmpegRecorder.js
@@ -9,33 +9,56 @@ function buildX11FfmpegArgs({
   framerate = 30,
   origin = '0,0',
   size,
-  filePath
+  filePath,
+  offset
 }) {
-  return [
-    '-hide_banner',
-    '-video_size',
-    size,
-    '-f',
-    'x11grab',
-    '-framerate',
-    framerate,
-    '-probesize',
-    '10M',
-    '-y',
-    '-draw_mouse',
-    '0',
-    '-i',
-    `:${display}.${screen}+${origin}`,
-    '-codec:v',
-    'libx264rgb',
-    '-crf',
-    0,
-    '-preset',
-    'ultrafast',
-    '-vf',
-    'pad=ceil(iw/2)*2:ceil(ih/2)*2',
-    filePath
-  ];
+  if (process.platform === 'darwin') {
+    const widthAndHeight = size.split('x');
+    return [
+      '-f',
+      'avfoundation',
+      '-i',
+      1,
+      // `:${0}.${0}+${origin}`,
+      '-r',
+      30,
+      '-filter:v',
+      `crop=${widthAndHeight[0] * 2}:${widthAndHeight[1] * 2}:${offset.x *
+        2}:${offset.y * 2}`,
+      '-codec:v',
+      'libx264rgb',
+      '-crf',
+      '0',
+      '-preset',
+      'ultrafast',
+      filePath
+    ];
+  } else
+    return [
+      '-hide_banner',
+      '-video_size',
+      size,
+      '-f',
+      'x11grab',
+      '-framerate',
+      framerate,
+      '-probesize',
+      '10M',
+      '-y',
+      '-draw_mouse',
+      '0',
+      '-i',
+      `:${display}.${screen}+${origin}`,
+      '-codec:v',
+      'libx264rgb',
+      '-crf',
+      0,
+      '-preset',
+      'ultrafast',
+      '-vf',
+      'pad=ceil(iw/2)*2:ceil(ih/2)*2',
+      filePath
+    ];
 }
 
 async function startRecording(ffmpegArgs, nice, filePath) {
@@ -103,7 +126,8 @@ module.exports = {
       size: withoutTopBar,
       filePath,
       framerate,
-      crf
+      crf,
+      offset
     });
     return startRecording(ffmpegArgs, nice, filePath);
   },

--- a/lib/video/screenRecording/desktop/x11recorder.js
+++ b/lib/video/screenRecording/desktop/x11recorder.js
@@ -8,11 +8,18 @@ const ffmpegRecorder = require('./ffmpegRecorder');
 const convert = require('./convert');
 const defaults = require('../../defaults');
 const getViewPort = require('../../../support/getViewPort');
-
-const originFirefox = '0,71';
-const originChrome = '0,66';
-const offsetFirefox = { x: 0, y: 168 };
-const offsetChrome = { x: 0, y: 66 };
+const screenOffsets = {
+  linux: {
+    firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
+    chrome: { origin: '0,66', offset: { x: 0, y: 66 } }
+  },
+  darwin: {
+    firefox: { origin: '0,71', offset: { x: 0, y: 80 } },
+    chrome: { origin: '0,66', offset: { x: 0, y: 80 } },
+    edge: { origin: '0,66', offset: { x: 0, y: 84 } },
+    safari: { origin: '0,66', offset: { x: 0, y: 66 } }
+  }
+};
 const unlink = util.promisify(fs.unlink);
 
 module.exports = class X11Recorder {
@@ -22,8 +29,8 @@ module.exports = class X11Recorder {
     this.nice = get(options, 'videoParams.nice', 0);
     this.crf = get(options, 'videoParams.crf', defaults.crf);
     this.viewPort = getViewPort(options);
-    this.origin = options.browser === 'firefox' ? originFirefox : originChrome;
-    this.offset = options.browser === 'firefox' ? offsetFirefox : offsetChrome;
+    this.origin = screenOffsets[process.platform][options.browser].origin;
+    this.offset = screenOffsets[process.platform][options.browser].offset;
     this.options = options;
   }
 


### PR DESCRIPTION
We had support for OS X in old (version 2?) versions of Browsertime
and now when we support Safari and Edge its interesting to add it
again.