### PR TITLE
Fix ContentfulSpeedIndex and VisualMetrics Tests 

### DIFF
--- a/browsertime/test_visualmetrics.py
+++ b/browsertime/test_visualmetrics.py
@@ -20,8 +20,10 @@ class TestVisualMetrics(unittest.TestCase):
             return p
 
         progress = [_p(image) for image in images if image.startswith("ms_")]
-        res = calculate_contentful_speed_index(progress, directory)
-        self.assertTrue(res[0], 5080)
+        res = calculate_contentful_speed_index(sorted(progress,
+                                                      key = lambda image: image['time']),
+                                               directory)
+        self.assertEqual(res[0], 5080)
 
     def test_calculate_perceptual_speed_index(self):
         directory = "test_data"
@@ -33,5 +35,7 @@ class TestVisualMetrics(unittest.TestCase):
             return p
 
         progress = [_p(image) for image in images if image.startswith("ms_")]
-        res = calculate_perceptual_speed_index(progress, directory)
-        self.assertTrue(res[0], 5080)
+        res = calculate_perceptual_speed_index(sorted(progress,
+                                                      key = lambda image: image['time']),
+                                               directory)
+        self.assertEqual(res[0], 946)

--- a/browsertime/test_visualmetrics.py
+++ b/browsertime/test_visualmetrics.py
@@ -10,9 +10,9 @@ HERE = os.path.dirname(__file__)
 
 
 class TestVisualMetrics(unittest.TestCase):
-    def test_calculate_contentful_speed_index(self):
-        directory = "test_data"
-        images = os.listdir(os.path.join(HERE, directory))
+    def setUp(self):
+        self.directory = "test_data"
+        images = os.listdir(os.path.join(HERE, self.directory))
 
         def _p(image):
             p = {}
@@ -20,22 +20,15 @@ class TestVisualMetrics(unittest.TestCase):
             return p
 
         progress = [_p(image) for image in images if image.startswith("ms_")]
-        res = calculate_contentful_speed_index(sorted(progress,
-                                                      key = lambda image: image['time']),
-                                               directory)
-        self.assertEqual(res[0], 5080)
+        self.sorted_progress = sorted(progress,
+                                      key = lambda image: image['time'])
+
+    def test_calculate_contentful_speed_index(self):
+        res = calculate_contentful_speed_index(self.sorted_progress,
+                                               self.directory)
+        self.assertEqual(res[0], 1188)
 
     def test_calculate_perceptual_speed_index(self):
-        directory = "test_data"
-        images = os.listdir(os.path.join(HERE, directory))
-
-        def _p(image):
-            p = {}
-            p["time"] = int(image.split(".")[0].split("ms_")[-1])
-            return p
-
-        progress = [_p(image) for image in images if image.startswith("ms_")]
-        res = calculate_perceptual_speed_index(sorted(progress,
-                                                      key = lambda image: image['time']),
-                                               directory)
+        res = calculate_perceptual_speed_index(self.sorted_progress,
+                                               self.directory)
         self.assertEqual(res[0], 946)

--- a/browsertime/visualmetrics.py
+++ b/browsertime/visualmetrics.py
@@ -1648,9 +1648,9 @@ def calculate_speed_index(progress):
 
 def calculate_contentful_speed_index(progress, directory):
     # convert output comes out with lines that have this format:
-    # <number>: <rgb color> #<hex color> <gray color>
+    # <pixel count>: <rgb color> #<hex color> <gray color>
     # This is CLI dependant and very fragile
-    matcher = re.compile(r"\d+: \S+ #[0-9A-F]+ (?:gray\((\d+)\)|(\d+)(?:))")
+    matcher = re.compile(r"(\d+?):")
 
     try:
         dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), directory)
@@ -1664,25 +1664,17 @@ def calculate_contentful_speed_index(progress, directory):
             command = "{0} {1} -canny 2x2+8%+8% -define histogram:unique-colors=true -format %c histogram:info:-".format(
                 image_magick["convert"], current_frame
             )
-            output = subprocess.check_output(command, shell=True)
+            output = subprocess.check_output(command, shell=True).decode('utf-8')
             logging.debug("Output %s" % output)
-            # take the last line of the convert call output
-            lines = [
-                line.strip().decode("utf8")
-                for line in output.split(b"\n")
-                if line.strip()
-            ]
-            if len(lines) == 0:
+
+            # Take the last matching pixel count, which is the pixel count from the last
+            # line
+            pixel_count = matcher.findall(output)[-1]
+            if not pixel_count:
                 logging.debug("Could not find the contentfulness value")
                 return None, None
 
-            # extract the value from the last line
-            match = [[v for v in el if v] for el in matcher.findall(lines[-1])]
-            if match == []:
-                logging.debug("Could not find the contentfulness value")
-                return None, None
-
-            value = int(match[0][0])
+            value = int(pixel_count)
             if value > maxContent:
                 maxContent = value
             content.append(value)


### PR DESCRIPTION
To fix #1178 

There are 2 issues in `test_visualmetrics.py`
1) `assertTrue` just verifies the trueness of the values, and we want to
   compare the values.
2) progress should be sorted based on the timestamps of the images.

I also modified the regex to get the digits before the `:`, and then we pick the last one as the value. I believe this is platform-independent. @tarekziade May I ask you to test on MacOS? I don't have a mac machine :)

Thanks!