### PR TITLE
Use --firefox.profileTemplate setting when it's provided.

### DIFF
--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -41,7 +41,9 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     'firefox-profile'
   );
 
-  ffOptions.setProfile(profileTemplatePath);
+  ffOptions.setProfile(
+    get(firefoxConfig, 'profileTemplate') || profileTemplatePath
+  )
 
   if (options.userAgent) {
     ffOptions.setPreference('general.useragent.override', options.userAgent);


### PR DESCRIPTION
This patch fixes an issue where the profile that is provided to `--firefox.profileTemplate` is not used. With this change, if there exists a setting for `--firefox.profileTemplate` it will be used, otherwise it defaults to the profile in `browsertime/browsersupport/firefox-profile`.