### PR TITLE
Add win32 to x11recorder.js origin/offset options.

### DIFF
--- a/lib/video/screenRecording/desktop/x11recorder.js
+++ b/lib/video/screenRecording/desktop/x11recorder.js
@@ -16,7 +16,7 @@ const screenOffsets = {
   windows: {
     firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
     chrome: { origin: '0,66', offset: { x: 0, y: 66 } } 
-  }
+  },
   darwin: {
     firefox: { origin: '0,71', offset: { x: 0, y: 80 } },
     chrome: { origin: '0,66', offset: { x: 0, y: 80 } },

--- a/lib/video/screenRecording/desktop/x11recorder.js
+++ b/lib/video/screenRecording/desktop/x11recorder.js
@@ -13,7 +13,7 @@ const screenOffsets = {
     firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
     chrome: { origin: '0,66', offset: { x: 0, y: 66 } }
   },
-  windows: {
+  win32: {
     firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
     chrome: { origin: '0,66', offset: { x: 0, y: 66 } } 
   },

--- a/lib/video/screenRecording/desktop/x11recorder.js
+++ b/lib/video/screenRecording/desktop/x11recorder.js
@@ -13,6 +13,10 @@ const screenOffsets = {
     firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
     chrome: { origin: '0,66', offset: { x: 0, y: 66 } }
   },
+  windows: {
+    firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
+    chrome: { origin: '0,66', offset: { x: 0, y: 66 } } 
+  }
   darwin: {
     firefox: { origin: '0,71', offset: { x: 0, y: 80 } },
     chrome: { origin: '0,66', offset: { x: 0, y: 80 } },

--- a/lib/video/screenRecording/desktop/x11recorder.js
+++ b/lib/video/screenRecording/desktop/x11recorder.js
@@ -15,7 +15,7 @@ const screenOffsets = {
   },
   win32: {
     firefox: { origin: '0,71', offset: { x: 0, y: 168 } },
-    chrome: { origin: '0,66', offset: { x: 0, y: 66 } } 
+    chrome: { origin: '0,66', offset: { x: 0, y: 66 } }
   },
   darwin: {
     firefox: { origin: '0,71', offset: { x: 0, y: 80 } },


### PR DESCRIPTION
This patch fixes an issue where the origin and offset for the `x11recorder` are undefined on windows machines. Note that `process.platform` returns win32 for any type of windows machine.