### PR TITLE
Use %% for percentages in argparser help

### DIFF
--- a/browsertime/visualmetrics.py
+++ b/browsertime/visualmetrics.py
@@ -2069,14 +2069,14 @@ def main():
         "--findstart",
         type=int,
         default=0,
-        help="Find the start of activity by looking at the top X% "
+        help="Find the start of activity by looking at the top X%% "
         "of the video (like a browser address bar).",
     )
     parser.add_argument(
         "--renderignore",
         type=int,
         default=0,
-        help="Ignore the center X% of the frame when looking for "
+        help="Ignore the center X%% of the frame when looking for "
         "the first rendered frame (useful for Opera mini).",
     )
     parser.add_argument(


### PR DESCRIPTION
The help strings of `argparser.ArgumentParser` arguments are interpreted
as `%-formatting` strings so strings like "% o" are interpreted as "%o"
(i.e., format as octal). Help text has been corrected to use `%%`, which
generates a single `%` in output.