### PR TITLE
Remove all forwards to devtools for one device.

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -8,6 +8,7 @@ const execa = require('execa');
 const log = require('intel').getLogger('browsertime.android');
 const mkdir = promisify(fs.mkdir);
 const path = require('path');
+const endOfLine = require('os').EOL;
 
 class Android {
   constructor(options) {
@@ -138,15 +139,29 @@ class Android {
   }
 
   async removeFw() {
+    // We leak port forwards to devtools or rather Selenium/Chromedriver
+    // So to handle that we need to remove them all for the running device
+    // indstead of the one that we setup
+    const { stdout } = await execa('adb', ['forward', '--list']);
+    const allForwards = stdout.split(
+      ' localabstract:chrome_devtools_remote' + endOfLine
+    );
+
+    const regex = /(tcp:\d)\w+/g;
+    const closeThemAll = [];
+    for (let fw of allForwards) {
+      if (fw.indexOf(this.id) > -1) {
+        const f = fw.match(regex);
+        if (f.length > 0) {
+          closeThemAll.push(
+            execa('adb', ['-s', this.id, 'forward', '--remove', f[0]])
+          );
+        }
+      }
+    }
     this.forward = undefined;
     // Remove forwards are missing in the adbkit
-    return execa('adb', [
-      '-s',
-      this.id,
-      'forward',
-      '--remove',
-      'tcp:' + this.port
-    ]);
+    return Promise.all(closeThemAll);
   }
 
   async startVideo() {


### PR DESCRIPTION
Somehow we leak forwards for devtools, or rather Selenium/Chromedriver do,
so let us just remove them all instead of just the one we setup.

https://github.com/sitespeedio/browsertime/issues/1242