### PR TITLE
Add scripting screenshots to result JSON #1056.

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -111,6 +111,16 @@ class Collector {
       results.info.description = allData.description;
       results.info.title = allData.title;
 
+      if (allData.screenshots.length > 0) {
+        for (let screenshotName of allData.screenshots) {
+          results.files.screenshot.push(
+            `${pathToFolder(url, this.options)}screenshots/${screenshotName}.${
+              this.options.screenshotParams.type
+            }`
+          );
+        }
+      }
+
       const statistics = this.allStats[url]
         ? this.allStats[url]
         : new Statistics();
@@ -244,14 +254,7 @@ class Collector {
           )
         );
       }
-      // Add path to files
-      if (this.options.screenshot) {
-        results.files.screenshot.push(
-          `${pathToFolder(url, this.options)}screenshots/${index}.${
-            this.options.screenshotParams.type
-          }`
-        );
-      }
+
       if (this.options.video) {
         results.files.video.push(
           `${pathToFolder(url, this.options)}video/${index}.mp4`

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -62,7 +62,6 @@ class Iteration {
     this.engineDelegate = engineDelegate;
     this.scriptsByCategory = scriptsByCategory;
     this.asyncScriptsByCategory = asyncScriptsByCategory;
-    this.screenshotManager = new ScreenshotManager(storageManager, options);
   }
 
   /**
@@ -72,6 +71,10 @@ class Iteration {
    * @param {*} index - Which iteration it is
    */
   async run(navigationScript, index) {
+    const screenshotManager = new ScreenshotManager(
+      this.storageManager,
+      this.options
+    );
     const options = this.options;
     const browser = new SeleniumRunner(
       this.storageManager.directory,
@@ -120,7 +123,7 @@ class Iteration {
         this.asyncScriptsByCategory,
         this.postURLScripts,
         context,
-        this.screenshotManager,
+        screenshotManager,
         options
       );
 
@@ -140,7 +143,7 @@ class Iteration {
         set: new Set(browser),
         cache: new Cache(browser, options.browser, extensionServer, cdp),
         meta: new Meta(),
-        screenshot: new Screenshot(this.screenshotManager, browser, index),
+        screenshot: new Screenshot(screenshotManager, browser, index),
         cdp,
         android: new Android(options)
       };
@@ -242,6 +245,8 @@ class Iteration {
           }
         }
       }
+
+      result.screenshots = screenshotManager.getSaved();
 
       await this.engineDelegate.afterCollect(index, result);
 

--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -17,9 +17,11 @@ class ScreenshotManager {
     this.storageManager = storageManager;
     this.config = merge({}, defaultConfig, options.screenshotParams);
     this.options = options;
+    this.savedScreenshots = [];
   }
 
   async save(name, data, url) {
+    this.savedScreenshots.push(name);
     if (!jimp) {
       if (this.config.type === 'jpg') {
         log.info(
@@ -56,6 +58,10 @@ class ScreenshotManager {
         this.options
       );
     }
+  }
+
+  getSaved() {
+    return this.savedScreenshots;
   }
 }
 


### PR DESCRIPTION
Adding screenshots in scripting is a great feature and one thing that
was missing was that the result JSON do not include any references to
the screenshots, so tools that uses browsertime, didn't know that they
exist. In sitespeed.ios case the screenshots are stored to disk but now shown.

This fix makes it possible to get the references from the JSON. In future
(next major) we should rename the screenshot files, they are now named:
name + "-index"

But it would have been more sane to have it the other way around (index first)
but don't want to potentially break any functionality so let us keep it for
now.