### PR TITLE
set orange.style.pointerEvents = 'none' 

### DIFF
--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -55,6 +55,7 @@ module.exports = async function(driver, options) {
           orange.style.height = Math.max(document.documentElement.clientHeight,document.body.clientHeight) + 'px';
           orange.style.backgroundColor = '#DE640D';
           orange.style.zIndex = '2147483647';
+		  orange.style.pointerEvents = 'none';
           document.body.appendChild(orange);
           document.body.style.display = '';
         })();`;


### PR DESCRIPTION
Mouse focus on element won't be lost at script measurement start.
Relates to sitespeed.io issue
https://github.com/sitespeedio/sitespeed.io/issues/2956