### PR TITLE
Add --firefox.appconstants flag to obtain AppConstants information.

### DIFF
--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -214,8 +214,13 @@ class FirefoxDelegate {
   }
 
   async afterCollect(index, result) {
-    if (this.firefoxConfig.geckoProfiler && this.options.visualMetrics) {
-      for (let i = 0; i < result.length; i++) {
+    for (let i = 0; i < result.length; i++) {
+      if (!this.options.firefox.appconstants) {
+        delete result[i].browserScripts.browser.appConstants;
+        delete result[i].browserScripts.browser.asyncAppConstants;
+      }
+
+      if (this.firefoxConfig.geckoProfiler && this.options.visualMetrics) {
         const profileFilename = `geckoProfile-${index}.json.gz`;
         const profileSubdir = pathToFolder(result[i].url, this.options);
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -352,6 +352,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       choices: ['none', 'all', 'html'],
       group: 'firefox'
     })
+    .option('firefox.appconstants', {
+      describe: 'Include Firefox AppConstants information in the results',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('firefox.acceptInsecureCerts', {
       describe: 'Accept insecure certs',
       type: 'boolean',


### PR DESCRIPTION
This patch removes the AppConstants/asyncAppConstants from the results JSON. They can still be obtained by supplying the  `--firefox.appconstants` option.