### PR TITLE
Another fix to watch out for deleting the extra FF data.

### DIFF
--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -218,10 +218,16 @@ class FirefoxDelegate {
       if (!this.options.firefox.appconstants) {
         // We need to be extra careful here, see
         // https://github.com/sitespeedio/browsertime/issues/1261
-        if (result[i].browserScripts.browser.appConstants) {
+        if (
+          result[i].browserScripts.browser &&
+          result[i].browserScripts.browser.appConstants
+        ) {
           delete result[i].browserScripts.browser.appConstants;
         }
-        if (result[i].browserScripts.browser.asyncAppConstants) {
+        if (
+          result[i].browserScripts.browser &&
+          result[i].browserScripts.browser.asyncAppConstants
+        ) {
           delete result[i].browserScripts.browser.asyncAppConstants;
         }
       }


### PR DESCRIPTION
We still have cases with errors, so let us add more checks. It seems though that
sometimes we do not get the browser info from FF.

https://github.com/sitespeedio/browsertime/issues/1261#issuecomment-621696696