### PR TITLE
Make it possible to enable Safe Browsing and Tracking protection.

### DIFF
--- a/lib/firefox/webdriver/disableTrackingProtectionPreferences.js
+++ b/lib/firefox/webdriver/disableTrackingProtectionPreferences.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  'privacy.trackingprotection.annotate_channels': false,
+  'privacy.trackingprotection.enabled': false,
+  'privacy.trackingprotection.introURL':
+    'http://127.0.0.1/trackingprotection/tour',
+  'privacy.trackingprotection.pbmode.enabled': false
+};

--- a/lib/firefox/webdriver/firefoxPreferences.js
+++ b/lib/firefox/webdriver/firefoxPreferences.js
@@ -88,25 +88,6 @@ module.exports = {
   'browser.newtabpage.activity-stream.default.sites': '',
   'browser.newtabpage.activity-stream.telemetry': false,
   'browser.reader.detectedFirstArticle': true,
-  'browser.safebrowsing.blockedURIs.enabled': false,
-  'browser.safebrowsing.downloads.enabled': false,
-  'browser.safebrowsing.downloads.remote.url':
-    'http://127.0.0.1/safebrowsing-dummy/downloads',
-  'browser.safebrowsing.malware.enabled': false,
-  'browser.safebrowsing.passwords.enabled': false,
-  'browser.safebrowsing.phishing.enabled': false,
-  'browser.safebrowsing.provider.google.gethashURL':
-    'http://127.0.0.1/safebrowsing-dummy/gethash',
-  'browser.safebrowsing.provider.google.updateURL':
-    'http://127.0.0.1/safebrowsing-dummy/update',
-  'browser.safebrowsing.provider.google4.gethashURL':
-    'http://127.0.0.1/safebrowsing4-dummy/gethash',
-  'browser.safebrowsing.provider.google4.updateURL':
-    'http://127.0.0.1/safebrowsing4-dummy/update',
-  'browser.safebrowsing.provider.mozilla.gethashURL':
-    'http://127.0.0.1/safebrowsing-dummy/gethash',
-  'browser.safebrowsing.provider.mozilla.updateURL':
-    'http://127.0.0.1/safebrowsing-dummy/update',
   'browser.search.geoip.url': '',
   'browser.shell.checkDefaultBrowser': false,
   'browser.tabs.remote.autostart': true,
@@ -164,11 +145,6 @@ module.exports = {
   'plugin.state.flash': 0,
   'plugins.flashBlock.enabled': false,
   'privacy.reduceTimerPrecision': false, // Bug 1445243 - reduces precision of tests
-  'privacy.trackingprotection.annotate_channels': false,
-  'privacy.trackingprotection.enabled': false,
-  'privacy.trackingprotection.introURL':
-    'http://127.0.0.1/trackingprotection/tour',
-  'privacy.trackingprotection.pbmode.enabled': false,
   'security.enable_java': false,
   'security.fileuri.strict_origin_policy': false,
   'toolkit.telemetry.server': 'https://127.0.0.1/telemetry-dummy/',

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -9,6 +9,7 @@ const isEmpty = require('lodash.isempty');
 const get = require('lodash.get');
 const defaultFirefoxPreferences = require('./firefoxPreferences');
 const disableSafeBrowsingPreferences = require('./disableSafeBrowsingPreferences');
+const disableTrackingProtectionPreferences = require('./disableTrackingProtectionPreferences');
 const util = require('../../support/util');
 const { Android } = require('../../android');
 
@@ -79,6 +80,12 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   if (firefoxConfig.disableSafeBrowsing) {
     Object.keys(disableSafeBrowsingPreferences).forEach(function(pref) {
       ffOptions.setPreference(pref, disableSafeBrowsingPreferences[pref]);
+    });
+  }
+
+  if (firefoxConfig.disableTrackingProtection) {
+    Object.keys(disableTrackingProtectionPreferences).forEach(function(pref) {
+      ffOptions.setPreference(pref, disableTrackingProtectionPreferences[pref]);
     });
   }
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -417,6 +417,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
+    .option('firefox.disableTrackingProtection', {
+      describe: 'Disable Tracking Protection.',
+      default: true,
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('firefox.android.package', {
       describe:
         'Run Firefox or a GeckoView-consuming App on your Android device. Set to org.mozilla.geckoview_example for default Firefox version. You need to have adb installed to make this work.',


### PR DESCRIPTION
Lets do this in multiple steps. First make it possible to enable them, then
create a profile where all lists are already downloaded and then in next
major enable it by default.

https://github.com/sitespeedio/browsertime/issues/1211 and @acreskeyMoz