### PR TITLE
Add support for Android power testing

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -314,8 +314,74 @@ class Android {
   }
 }
 
+async function parsePowerMetrics(batterystats, packageName) {
+  const reUid = new RegExp(`.+proc=([^:]+):"${packageName}".*`);
+  const reEstimations = new RegExp(`.+Estimated power use [(]mAh[)].*`);
+  const reScreen = new RegExp(`.+Screen: ([0-9.]+).*`);
+  const reWifi = new RegExp(`.+Wifi: ([0-9.]+).*`);
+
+  let uid = null;
+  let foundEstimations = false;
+  let rePower = null;
+  let found = false;
+  let powerData = {};
+
+  batterystats.split(/\r?\n/).forEach(line => {
+    if (!uid) {
+      let match = line.match(reUid);
+      if (match) {
+        uid = match[1];
+        rePower = new RegExp(`.+Uid ${uid}: ([0-9.]+)(.*)`);
+      }
+      return;
+    }
+    if (!foundEstimations) {
+      let match = line.match(reEstimations);
+      if (match) {
+        foundEstimations = true;
+      }
+      return;
+    }
+    if (!("full-screen" in powerData)) {
+      let match = line.match(reScreen);
+      if (match){
+        powerData["full-screen"] = parseFloat(match[1]);
+      }
+    }
+    if (!("full-wifi" in powerData)) {
+      let match = line.match(reWifi);
+      if (match){
+        powerData["full-wifi"] = parseFloat(match[1]);
+      }
+    }
+    if (rePower && !found) {
+      let match = line.match(rePower);
+      if (!match) {
+        return;
+      }
+      found = true;
+      powerData["total"] = parseFloat(match[1]);
+
+      let breakdown = match[2];
+      if (breakdown) {
+        match = breakdown.match(/([a-zA-Z]+)=([0-9.]+)/g);
+        if (!match) {
+          return;
+        }
+        match.forEach(category => {
+          let [name, value] = category.split("=");
+          powerData[name] = parseFloat(value);
+        })
+      }
+    }
+  })
+
+  return powerData;
+}
+
 module.exports = {
   Android,
+  parsePowerMetrics,
   isAndroidConfigured(options) {
     if (options.android === true) {
       return true;

--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -342,16 +342,16 @@ async function parsePowerMetrics(batterystats, packageName) {
       }
       return;
     }
-    if (!("full-screen" in powerData)) {
+    if (!('full-screen' in powerData)) {
       let match = line.match(reScreen);
-      if (match){
-        powerData["full-screen"] = parseFloat(match[1]);
+      if (match) {
+        powerData['full-screen'] = parseFloat(match[1]);
       }
     }
-    if (!("full-wifi" in powerData)) {
+    if (!('full-wifi' in powerData)) {
       let match = line.match(reWifi);
-      if (match){
-        powerData["full-wifi"] = parseFloat(match[1]);
+      if (match) {
+        powerData['full-wifi'] = parseFloat(match[1]);
       }
     }
     if (rePower && !found) {
@@ -360,7 +360,7 @@ async function parsePowerMetrics(batterystats, packageName) {
         return;
       }
       found = true;
-      powerData["total"] = parseFloat(match[1]);
+      powerData['total'] = parseFloat(match[1]);
 
       let breakdown = match[2];
       if (breakdown) {
@@ -369,12 +369,12 @@ async function parsePowerMetrics(batterystats, packageName) {
           return;
         }
         match.forEach(category => {
-          let [name, value] = category.split("=");
+          let [name, value] = category.split('=');
           powerData[name] = parseFloat(value);
-        })
+        });
       }
     }
-  })
+  });
 
   return powerData;
 }

--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -27,6 +27,11 @@ class Android {
       get(options, 'firefox.android.deviceSerial')
     );
     this.port = options.devToolsPort;
+
+    // Variables for android power testing
+    this.screenBrightnessMode = 0;
+    this.screenBrightness = 127;
+
     return this;
   }
 
@@ -312,6 +317,43 @@ class Android {
     }
     return Math.round(total / count);
   }
+
+  async startPowerTesting() {
+    log.info('Initializing power testing');
+
+    // Disable adaptive brightness
+    this.screenBrightnessMode = await this._runCommandAndGet(
+      'settings get system screen_brightness_mode'
+    );
+    await this._runCommand('settings put system screen_brightness_mode 0');
+
+    // Set screen brightness to 50%
+    this.screenBrightness = await this._runCommandAndGet(
+      'settings get system screen_brightness'
+    );
+    await this._runCommand('settings put system screen_brightness 127');
+  }
+
+  async stopPowerTesting() {
+    log.info('Finalizing power testing');
+    await this._runCommand(
+      `settings put system screen_brightness ${this.screenBrightness}`
+    );
+    await this._runCommand(
+      `settings put system screen_brightness_mode ${this.screenBrightnessMode}`
+    );
+  }
+
+  async resetPowerUsage() {
+    log.info('Resetting power information');
+    await this._runCommand('dumpsys batterystats --reset');
+    await this._runCommand('dumpsys batterystats --enable full-wake-history');
+  }
+
+  async measurePowerUsage(packageName) {
+    const batterystats = await this._runCommandAndGet('dumpsys batterystats');
+    return parsePowerMetrics(batterystats, packageName);
+  }
 }
 
 async function parsePowerMetrics(batterystats, packageName) {
@@ -320,14 +362,15 @@ async function parsePowerMetrics(batterystats, packageName) {
   const reScreen = new RegExp(`.+Screen: ([0-9.]+).*`);
   const reWifi = new RegExp(`.+Wifi: ([0-9.]+).*`);
 
-  let uid = null;
-  let foundEstimations = false;
-  let rePower = null;
-  let found = false;
+  let uid;
+  let foundEstimations;
+  let rePower;
+  let found;
   let powerData = {};
 
   batterystats.split(/\r?\n/).forEach(line => {
     if (!uid) {
+      // Find the applications UID first
       let match = line.match(reUid);
       if (match) {
         uid = match[1];
@@ -336,6 +379,7 @@ async function parsePowerMetrics(batterystats, packageName) {
       return;
     }
     if (!foundEstimations) {
+      // Ignore all lines until we find the estimation section
       let match = line.match(reEstimations);
       if (match) {
         foundEstimations = true;
@@ -343,25 +387,33 @@ async function parsePowerMetrics(batterystats, packageName) {
       return;
     }
     if (!('full-screen' in powerData)) {
+      // Measures the full power used by the screen (not app-specific)
       let match = line.match(reScreen);
       if (match) {
         powerData['full-screen'] = parseFloat(match[1]);
       }
     }
     if (!('full-wifi' in powerData)) {
+      // Measures the full power used by the wifi (not app-specific)
       let match = line.match(reWifi);
       if (match) {
         powerData['full-wifi'] = parseFloat(match[1]);
       }
     }
     if (rePower && !found) {
+      // Searches for and parses an app-specific power usage line such as:
+      // Uid u0a120: 0.826 ( cpu=0.826, wifi=99 )
       let match = line.match(rePower);
       if (!match) {
         return;
       }
       found = true;
+
+      // First value is the total used by the app
       powerData['total'] = parseFloat(match[1]);
 
+      // Gather the breakdown of the total value from
+      // the "name=val" entries in the line
       let breakdown = match[2];
       if (breakdown) {
         match = breakdown.match(/([a-zA-Z]+)=([0-9.]+)/g);
@@ -381,7 +433,6 @@ async function parsePowerMetrics(batterystats, packageName) {
 
 module.exports = {
   Android,
-  parsePowerMetrics,
   isAndroidConfigured(options) {
     if (options.android === true) {
       return true;

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -31,7 +31,7 @@ function getNewResult(url, options) {
       perfLog: []
     },
     cdp: { performance: [] },
-    android: { batteryTemperature: [] },
+    android: { batteryTemperature: [], power: [] },
     timestamps: [],
     browserScripts: [],
     visualMetrics: [],
@@ -315,6 +315,14 @@ class Collector {
             }
           });
         }
+      }
+
+      // Add power data (if we have it)
+      if (data.power) {
+        results.android.power.push(data.power);
+        statistics.addDeep({
+          android: {power: data.power}
+        });
       }
 
       // Store all extra JSON metrics

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -321,7 +321,7 @@ class Collector {
       if (data.power) {
         results.android.power.push(data.power);
         statistics.addDeep({
-          android: {power: data.power}
+          android: { power: data.power }
         });
       }
 

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -8,7 +8,11 @@ const harBuilder = require('../../support/har/');
 const pathToFolder = require('../../support/pathToFolder');
 const rename = promisify(fs.rename);
 const get = require('lodash.get');
-const { isAndroidConfigured, Android, parsePowerMetrics } = require('../../android');
+const {
+  isAndroidConfigured,
+  Android,
+  parsePowerMetrics
+} = require('../../android');
 const geckoProfilerDefaults = require('../geckoProfilerDefaults');
 const util = require('../../support/util.js');
 
@@ -38,19 +42,23 @@ class FirefoxDelegate {
     }
 
     if (this.android && this.options.androidPower) {
-      log.info("Initializing power testing");
+      log.info('Initializing power testing');
 
       // Disable adaptive brightness
       this.screenBrightnessMode = await this.android._runCommandAndGet(
-        "settings get system screen_brightness_mode"
+        'settings get system screen_brightness_mode'
       );
-      await this.android._runCommand("settings put system screen_brightness_mode 0");
+      await this.android._runCommand(
+        'settings put system screen_brightness_mode 0'
+      );
 
       // Set screen brightness to 50%
       this.screenBrightness = await this.android._runCommandAndGet(
-        "settings get system screen_brightness"
+        'settings get system screen_brightness'
       );
-      await this.android._runCommand("settings put system screen_brightness 127");
+      await this.android._runCommand(
+        'settings put system screen_brightness 127'
+      );
     }
   }
 
@@ -62,9 +70,11 @@ class FirefoxDelegate {
 
   async beforeEachURL(runner) {
     if (this.android && this.options.androidPower) {
-      log.info("Resetting power information");
-      await this.android._runCommand("dumpsys batterystats --reset");
-      await this.android._runCommand("dumpsys batterystats --enable full-wake-history");
+      log.info('Resetting power information');
+      await this.android._runCommand('dumpsys batterystats --reset');
+      await this.android._runCommand(
+        'dumpsys batterystats --enable full-wake-history'
+      );
     }
 
     if (this.firefoxConfig.geckoProfiler) {
@@ -137,9 +147,12 @@ class FirefoxDelegate {
     }
 
     if (this.android && this.options.androidPower) {
-      const batterystats = await this.android._runCommandAndGet("dumpsys batterystats");
+      const batterystats = await this.android._runCommandAndGet(
+        'dumpsys batterystats'
+      );
       result.power = await parsePowerMetrics(
-        batterystats, this.firefoxConfig.android.package
+        batterystats,
+        this.firefoxConfig.android.package
       );
     }
 
@@ -334,7 +347,7 @@ class FirefoxDelegate {
 
   async onStop() {
     if (this.android && this.options.androidPower) {
-      log.info("Finalizing power testing");
+      log.info('Finalizing power testing');
       await this.android._runCommand(
         `settings put system screen_brightness ${this.screenBrightness}`
       );

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -8,11 +8,7 @@ const harBuilder = require('../../support/har/');
 const pathToFolder = require('../../support/pathToFolder');
 const rename = promisify(fs.rename);
 const get = require('lodash.get');
-const {
-  isAndroidConfigured,
-  Android,
-  parsePowerMetrics
-} = require('../../android');
+const { isAndroidConfigured, Android } = require('../../android');
 const geckoProfilerDefaults = require('../geckoProfilerDefaults');
 const util = require('../../support/util.js');
 
@@ -27,12 +23,8 @@ class FirefoxDelegate {
       : 'none';
     this.firefoxConfig = options.firefox || {};
     this.options = options;
-    this.android = null;
     // We keep track of all alias and URLs
     this.aliasAndUrl = {};
-    // Variables for android power testing
-    this.screenBrightnessMode = 0;
-    this.screenBrightness = 127;
   }
 
   async onStart() {
@@ -42,23 +34,7 @@ class FirefoxDelegate {
     }
 
     if (this.android && this.options.androidPower) {
-      log.info('Initializing power testing');
-
-      // Disable adaptive brightness
-      this.screenBrightnessMode = await this.android._runCommandAndGet(
-        'settings get system screen_brightness_mode'
-      );
-      await this.android._runCommand(
-        'settings put system screen_brightness_mode 0'
-      );
-
-      // Set screen brightness to 50%
-      this.screenBrightness = await this.android._runCommandAndGet(
-        'settings get system screen_brightness'
-      );
-      await this.android._runCommand(
-        'settings put system screen_brightness 127'
-      );
+      await this.android.startPowerTesting();
     }
   }
 
@@ -70,11 +46,7 @@ class FirefoxDelegate {
 
   async beforeEachURL(runner) {
     if (this.android && this.options.androidPower) {
-      log.info('Resetting power information');
-      await this.android._runCommand('dumpsys batterystats --reset');
-      await this.android._runCommand(
-        'dumpsys batterystats --enable full-wake-history'
-      );
+      await this.android.resetPowerUsage();
     }
 
     if (this.firefoxConfig.geckoProfiler) {
@@ -147,11 +119,7 @@ class FirefoxDelegate {
     }
 
     if (this.android && this.options.androidPower) {
-      const batterystats = await this.android._runCommandAndGet(
-        'dumpsys batterystats'
-      );
-      result.power = await parsePowerMetrics(
-        batterystats,
+      result.power = await this.android.measurePowerUsage(
         this.firefoxConfig.android.package
       );
     }
@@ -347,13 +315,7 @@ class FirefoxDelegate {
 
   async onStop() {
     if (this.android && this.options.androidPower) {
-      log.info('Finalizing power testing');
-      await this.android._runCommand(
-        `settings put system screen_brightness ${this.screenBrightness}`
-      );
-      await this.android._runCommand(
-        `settings put system screen_brightness_mode ${this.screenBrightnessMode}`
-      );
+      await this.android.stopPowerTesting();
     }
     if (!this.skipHar && this.hars.length > 0) {
       return { har: harBuilder.mergeHars(this.hars) };

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -8,7 +8,7 @@ const harBuilder = require('../../support/har/');
 const pathToFolder = require('../../support/pathToFolder');
 const rename = promisify(fs.rename);
 const get = require('lodash.get');
-const { isAndroidConfigured, Android } = require('../../android');
+const { isAndroidConfigured, Android, parsePowerMetrics } = require('../../android');
 const geckoProfilerDefaults = require('../geckoProfilerDefaults');
 const util = require('../../support/util.js');
 
@@ -23,12 +23,35 @@ class FirefoxDelegate {
       : 'none';
     this.firefoxConfig = options.firefox || {};
     this.options = options;
+    this.android = null;
     // We keep track of all alias and URLs
     this.aliasAndUrl = {};
+    // Variables for android power testing
+    this.screenBrightnessMode = 0;
+    this.screenBrightness = 127;
   }
 
   async onStart() {
     this.hars = [];
+    if (isAndroidConfigured(this.options)) {
+      this.android = new Android(this.options);
+    }
+
+    if (this.android && this.options.androidPower) {
+      log.info("Initializing power testing");
+
+      // Disable adaptive brightness
+      this.screenBrightnessMode = await this.android._runCommandAndGet(
+        "settings get system screen_brightness_mode"
+      );
+      await this.android._runCommand("settings put system screen_brightness_mode 0");
+
+      // Set screen brightness to 50%
+      this.screenBrightness = await this.android._runCommandAndGet(
+        "settings get system screen_brightness"
+      );
+      await this.android._runCommand("settings put system screen_brightness 127");
+    }
   }
 
   async afterBrowserStart() {}
@@ -38,6 +61,12 @@ class FirefoxDelegate {
   async onStopIteration() {}
 
   async beforeEachURL(runner) {
+    if (this.android && this.options.androidPower) {
+      log.info("Resetting power information");
+      await this.android._runCommand("dumpsys batterystats --reset");
+      await this.android._runCommand("dumpsys batterystats --enable full-wake-history");
+    }
+
     if (this.firefoxConfig.geckoProfiler) {
       const chosenFeatures = this.firefoxConfig.geckoProfilerParams.features.split(
         ','
@@ -105,6 +134,13 @@ class FirefoxDelegate {
         )
       );
       // TODO clear the original log file!
+    }
+
+    if (this.android && this.options.androidPower) {
+      const batterystats = await this.android._runCommandAndGet("dumpsys batterystats");
+      result.power = await parsePowerMetrics(
+        batterystats, this.firefoxConfig.android.package
+      );
     }
 
     if (this.firefoxConfig.geckoProfiler) {
@@ -297,6 +333,15 @@ class FirefoxDelegate {
   }
 
   async onStop() {
+    if (this.android && this.options.androidPower) {
+      log.info("Finalizing power testing");
+      await this.android._runCommand(
+        `settings put system screen_brightness ${this.screenBrightness}`
+      );
+      await this.android._runCommand(
+        `settings put system screen_brightness_mode ${this.screenBrightnessMode}`
+      );
+    }
     if (!this.skipHar && this.hars.length > 0) {
       return { har: harBuilder.mergeHars(this.hars) };
     } else {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -264,6 +264,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'Easy way to enable both chrome.timeline and CPU long tasks for Chrome and geckoProfile for Firefox'
     })
+    .option('androidPower', {
+      type: 'boolean',
+      describe:
+        'Enables android power testing - charging must be disabled for this.' +
+        '(You have to disable charging yourself for this - it depends on the phone model).'
+    })
     .option('chrome.CPUThrottlingRate', {
       type: 'number',
       describe:


### PR DESCRIPTION
This patch adds the ability to perform power usage testing with Firefox on Android phones.

@soulgalore this code is very similar to what we use in the mozilla-central tree but fine-tuned for browsertime. :)

I'm not entirely sure about the structure or how we should organize all of this within browsertime - the big thing I am wondering about is where should `parsePowerMetrics` go?

I've only enabled power testing with Firefox for the time being (but other browsers will be easy to add in the future).