### PR TITLE
Fix correct path for all screenshots

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -115,11 +115,7 @@ class Collector {
 
       if (allData.screenshots.length > 0) {
         for (let screenshotName of allData.screenshots) {
-          results.files.screenshot.push(
-            `${pathToFolder(url, this.options)}screenshots/${screenshotName}.${
-              this.options.screenshotParams.type
-            }`
-          );
+          results.files.screenshot.push(screenshotName);
         }
       }
 

--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -21,24 +21,26 @@ class ScreenshotManager {
   }
 
   async save(name, data, url) {
-    this.savedScreenshots.push(name);
     if (!jimp) {
       if (this.config.type === 'jpg') {
         log.info(
           'Missing sharp dependency so you can only save images as png at viewport size'
         );
       }
-      return images.savePngWithoutResize(
+      const pathAndName = await images.savePngWithoutResize(
         name,
         data,
         url,
         this.storageManager,
         SCREENSHOT_DIR,
         this.options
+      );
+      this.savedScreenshots.push(
+        pathAndName.replace(this.storageManager.directory, '')
       );
     }
     if (this.config.type === 'png') {
-      return images.savePng(
+      const pathAndName = await images.savePng(
         name,
         data,
         url,
@@ -47,8 +49,11 @@ class ScreenshotManager {
         SCREENSHOT_DIR,
         this.options
       );
+      this.savedScreenshots.push(
+        pathAndName.replace(this.storageManager.directory, '')
+      );
     } else {
-      return images.saveJpg(
+      const pathAndName = await images.saveJpg(
         name,
         data,
         url,
@@ -56,6 +61,9 @@ class ScreenshotManager {
         this.config,
         SCREENSHOT_DIR,
         this.options
+      );
+      this.savedScreenshots.push(
+        pathAndName.replace(this.storageManager.directory, '')
       );
     }
   }

--- a/lib/support/images/index.js
+++ b/lib/support/images/index.js
@@ -40,7 +40,7 @@ module.exports = {
         .scaleToFit(config.maxSize, config.maxSize)
         .getBufferAsync('image/jpeg');
     });
-    storageManager.writeData(
+    return storageManager.writeData(
       `${name}.jpg`,
       buffer,
       path.join(pathToFolder(url, options), dir)

--- a/lib/support/storageManager.js
+++ b/lib/support/storageManager.js
@@ -80,8 +80,10 @@ class StorageManager {
     } else {
       dirPath = await this.createDataDir();
     }
-
-    return writeFile(path.join(dirPath, filename), data);
+    const fullPath = path.join(dirPath, filename);
+    return writeFile(fullPath, data).then(() => {
+      return fullPath;
+    });
   }
 
   async writeJson(filename, json, shouldGzip) {


### PR DESCRIPTION
The result.json didn't always have thee correct path to the screenshot file.

```
module.exports = async function(context, commands) {
  await commands.navigate('https://www.sitespeed.io');
  await commands.screenshot.take('help');
  return commands.measure.start('https://www.sitespeed.io/documentation/');
};
```
Had the path of the first screenshot under /documentation/ in the JSON.