### PR TITLE
It makes more sense to have the screenshots as an array

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -114,9 +114,7 @@ class Collector {
       results.info.title = allData.title;
 
       if (allData.screenshots.length > 0) {
-        for (let screenshotName of allData.screenshots) {
-          results.files.screenshot.push(screenshotName);
-        }
+        results.files.screenshot.push(allData.screenshots);
       }
 
       const statistics = this.allStats[url]

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -316,7 +316,12 @@ class Measure {
     if (this.options.screenshot) {
       try {
         const screenshot = await this.browser.takeScreenshot(url);
-        await this.screenshotManager.save(`${this.index}`, screenshot, url);
+        await this.screenshotManager.save(
+          'afterPageCompleteCheck',
+          screenshot,
+          url,
+          this.index
+        );
       } catch (e) {
         // not getting screenshots shouldn't result in a failed test.
       }

--- a/lib/core/engine/command/screenshot.js
+++ b/lib/core/engine/command/screenshot.js
@@ -12,11 +12,7 @@ class Screenshot {
       .getDriver()
       .executeScript('return document.documentURI;');
     const screenshot = await this.browser.takeScreenshot();
-    return this.screenshotManager.save(
-      name + '-' + this.index,
-      screenshot,
-      url
-    );
+    return this.screenshotManager.save(name, screenshot, url, this.index);
   }
 }
 module.exports = Screenshot;

--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const merge = require('lodash.merge');
 const defaultConfig = require('./defaults');
+const path = require('path');
 const SCREENSHOT_DIR = 'screenshots';
 const images = require('../support/images');
 const log = require('intel').getLogger('browsertime.screenshot');
@@ -20,7 +21,7 @@ class ScreenshotManager {
     this.savedScreenshots = [];
   }
 
-  async save(name, data, url) {
+  async save(name, data, url, index) {
     if (!jimp) {
       if (this.config.type === 'jpg') {
         log.info(
@@ -32,11 +33,11 @@ class ScreenshotManager {
         data,
         url,
         this.storageManager,
-        SCREENSHOT_DIR,
+        path.join(SCREENSHOT_DIR, `${index}`),
         this.options
       );
       this.savedScreenshots.push(
-        pathAndName.replace(this.storageManager.directory, '')
+        pathAndName.replace(this.storageManager.directory + '/', '')
       );
     }
     if (this.config.type === 'png') {
@@ -46,11 +47,11 @@ class ScreenshotManager {
         url,
         this.storageManager,
         this.config,
-        SCREENSHOT_DIR,
+        path.join(SCREENSHOT_DIR, `${index}`),
         this.options
       );
       this.savedScreenshots.push(
-        pathAndName.replace(this.storageManager.directory, '')
+        pathAndName.replace(this.storageManager.directory + '/', '')
       );
     } else {
       const pathAndName = await images.saveJpg(
@@ -59,11 +60,11 @@ class ScreenshotManager {
         url,
         this.storageManager,
         this.config,
-        SCREENSHOT_DIR,
+        path.join(SCREENSHOT_DIR, `${index}`),
         this.options
       );
       this.savedScreenshots.push(
-        pathAndName.replace(this.storageManager.directory, '')
+        pathAndName.replace(this.storageManager.directory + '/', '')
       );
     }
   }

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -90,7 +90,9 @@ function addMetaToHAR(index, harPage, url, options) {
       _meta.screenshot = `${base}${pathToFolder(
         url,
         options
-      )}screenshots/${index + 1}.${options.screenshotParams.type}`;
+      )}screenshots/${index + 1}/afterPageCompleteCheck.${
+        options.screenshotParams.type
+      }`;
     }
     if (options.video) {
       _meta.video = `${base}${pathToFolder(url, options)}video/${index +


### PR DESCRIPTION
Lets release this in the next major + remove the naming with numbers per run. 

* Screenshots per run is an array (support multiple screenshots in scripting)
* Store screenshots per folder per run: `screenshoots/1/`
* Name the default screenshot to afterPageCompleteCheck