### PR TITLE
Fix missing SpeedIndex in HAR

### DIFF
--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -43,7 +43,7 @@ function addTimingsToHAR(harPage, visualMetricsData, timings, cpu) {
         harPageTimings['_' + key.charAt(0).toLowerCase() + key.slice(1)] =
           visualMetricsData[key];
         _visualMetrics[key] = visualMetricsData[key];
-      } else if (key.indexOf('Progress') === 0) {
+      } else if (!key.endsWith('Progress')) {
         _visualMetrics[key] = visualMetricsData[key];
       }
     }


### PR DESCRIPTION
## Overview

Commit 206afb39332c2b0d10ed209568b610b9784ced0d introduced a bug where the SpeedIndex and PerceptualSpeedIndex metrics are no longer added to the HAR under `har.log.pages[]._visualMetrics`. This is causing problems with Sitespeed.io Compare, since it now can't find the SpeedIndex.

## Reproduction Steps
Command to reproduce this:
```
rm -rf browsertime-results \ 
&& ./bin/browsertime.js -n1 --chrome.visualMetricsUsingTrace --chrome.enableTraceScreenshots --cpu https://sitespeed.io \
&& jq '.log.pages[0]._visualMetrics' browsertime-results/sitespeed.io/*/browsertime.har
```

Expected result:
```
{
  "FirstVisualChange": 212,
  "LastVisualChange": 212,
  "SpeedIndex": 212,
  "PerceptualSpeedIndex": 212,
  "VisualReadiness": 0,
  "VisualComplete85": 212,
  "VisualComplete95": 212,
  "VisualComplete99": 212,
  "VisualProgress": {}
}

```

Actual result:
```
{
  "FirstVisualChange": 131,
  "LastVisualChange": 131,
  "VisualComplete85": 131,
  "VisualComplete95": 131,
  "VisualComplete99": 131,
  "VisualProgress": {}
}
```


## Fix
I'm not 100% sure why 206afb39332c2b0d10ed209568b610b9784ced0d changed the condition to `key.indexOf('Progress') === 0`, since there aren't any metrics that start with "Progress". I'm guessing the intent was to check if the metric name ends with "Progress", so I changed it do that. I also added tests.