### PR TITLE
Check if pathname contains a path before splitting it.

### DIFF
--- a/lib/support/pathToFolder.js
+++ b/lib/support/pathToFolder.js
@@ -9,8 +9,12 @@ module.exports = function(url, options) {
     return '';
   } else {
     const useHash = options.useHash;
-    const parsedUrl = urlParser.parse(decodeURIComponent(url)),
+    const parsedUrl = urlParser.parse(decodeURIComponent(url));
+
+    let pathSegments = [url];
+    if (parsedUrl && !isEmpty(parsedUrl.pathname)){
       pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
+    }
 
     if (useHash && !isEmpty(parsedUrl.hash)) {
       const md5 = crypto.createHash('md5'),

--- a/lib/support/pathToFolder.js
+++ b/lib/support/pathToFolder.js
@@ -12,7 +12,7 @@ module.exports = function(url, options) {
     const parsedUrl = urlParser.parse(decodeURIComponent(url));
 
     let pathSegments = [url];
-    if (parsedUrl && !isEmpty(parsedUrl.pathname)){
+    if (parsedUrl && !isEmpty(parsedUrl.pathname)) {
       pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
     }
 


### PR DESCRIPTION
This patch fixes an issue in `pathToFolder` that occurs when `parsedUrl.pathname` is empty. It falls back to using the given `url` as the first entry in the `pathSegments` variable when this error occurs.

I hit this issue when trying to make a measurement on `about:blank` since this url doesn't have a non-null pathname when parsed through the url module.

Peter, what do you think about this issue and solution?