### PR TITLE
Stop recording the video direct after pageCompleteCheck.

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -199,6 +199,12 @@ class Measure {
       try {
         await this.engineDelegate.beforeEachURL(this.browser, url);
         await this.browser.loadAndWait(url, this.pageCompleteCheck);
+        // We want to stop the video direct after the page completed
+        // to make Visual Metrics faster and independent of what happens later
+        if (this.recordVideo && !this.options.videoParams.debug) {
+          await this.video.stop(url);
+          this.videos.push(this.video);
+        }
         const res = await this.engineDelegate.afterPageCompleteCheck(
           this.browser,
           this.index,
@@ -320,7 +326,6 @@ class Measure {
 
     // when we have the URL we can use that to stop the video and put it where we want it
     if (this.recordVideo && !this.options.videoParams.debug) {
-      await this.video.stop(url);
       this.result[this.numberOfMeasuredPages].recordingStartTime = parseFloat(
         this.video.getRecordingStartTime()
       );
@@ -328,7 +333,6 @@ class Measure {
         this.video.getTimeToFirstFrame(),
         10
       );
-      this.videos.push(this.video);
     }
 
     if (this.options.screenshot) {


### PR DESCRIPTION
https://github.com/sitespeedio/browsertime/issues/1352'