### PR TITLE
Fix how MOZ_LOG collection works and allow custom MOZ_LOG settings.

### DIFF
--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -52,8 +52,7 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   }
 
   if (firefoxConfig.collectMozLog) {
-    process.env.MOZ_LOG =
-      'timestamp,nsHttp:5,cache2:5,nsSocketTransport:5,nsHostResolver:5';
+    process.env.MOZ_LOG = firefoxConfig.setMozLog;
     process.env.MOZ_LOG_FILE = `${baseDir}/moz_log.txt`;
   }
 

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -10,6 +10,7 @@ const rename = promisify(fs.rename);
 const get = require('lodash.get');
 const { isAndroidConfigured, Android } = require('../../android');
 const util = require('../../support/util.js');
+const fileUtil = require('../../support/fileUtil.js');
 const getHAR = require('../getHAR');
 const GeckoProfiler = require('../geckoProfiler');
 
@@ -83,15 +84,17 @@ class Firefox {
   async afterPageCompleteCheck(runner, index, url) {
     const result = { url };
     if (this.firefoxConfig.collectMozLog) {
-      await rename(
-        `${this.baseDir}/moz_log.txt`,
-        path.join(
-          this.baseDir,
-          pathToFolder(result.url, this.options),
-          `moz_log-${index}.txt`
-        )
-      );
-      // TODO clear the original log file!
+      const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
+      for (const file of files) {
+        await rename(
+          `${this.baseDir}/${file}`,
+          path.join(
+            this.baseDir,
+            pathToFolder(result.url, this.options),
+            `${file}-${index}.txt`
+          )
+        );
+      }
     }
 
     if (this.android && this.options.androidPower) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -413,7 +413,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'Use in conjunction with firefox.collectMozLog to set MOZ_LOG to something ' +
         'specific. Without this, the HTTP logs will be collected by default',
-      default: 'timestamp,nsHttp:5,cache2:5,nsSocketTransport:5,nsHostResolver:5',
+      default:
+        'timestamp,nsHttp:5,cache2:5,nsSocketTransport:5,nsHostResolver:5',
       group: 'firefox'
     })
     .option('firefox.disableBrowsertimeExtension', {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -404,7 +404,16 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('firefox.collectMozLog', {
       type: 'boolean',
-      describe: 'Collect the MOZ HTTP log',
+      describe:
+        'Collect the MOZ HTTP log (by default). See --firefox.setMozLog if you ' +
+        'need to specify the logs you wish to gather.',
+      group: 'firefox'
+    })
+    .option('firefox.setMozLog', {
+      describe:
+        'Use in conjunction with firefox.collectMozLog to set MOZ_LOG to something ' +
+        'specific. Without this, the HTTP logs will be collected by default',
+      default: 'timestamp,nsHttp:5,cache2:5,nsSocketTransport:5,nsHostResolver:5',
       group: 'firefox'
     })
     .option('firefox.disableBrowsertimeExtension', {

--- a/lib/support/fileUtil.js
+++ b/lib/support/fileUtil.js
@@ -57,5 +57,13 @@ module.exports = {
     for (const filePath of filePaths) {
       await unlink(filePath);
     }
+  },
+  async findFiles(dir, filter) {
+    const fileNames = await readdir(dir);
+    const filePaths = fileNames
+      .filter((fileName, index, arr) => {
+        return fileName.indexOf(filter) >= 0;
+      });
+    return filePaths;
   }
 };

--- a/lib/support/fileUtil.js
+++ b/lib/support/fileUtil.js
@@ -60,10 +60,9 @@ module.exports = {
   },
   async findFiles(dir, filter) {
     const fileNames = await readdir(dir);
-    const filePaths = fileNames
-      .filter((fileName, index, arr) => {
-        return fileName.indexOf(filter) >= 0;
-      });
+    const filePaths = fileNames.filter(fileName => {
+      return fileName.indexOf(filter) >= 0;
+    });
     return filePaths;
   }
 };


### PR DESCRIPTION
This patch fixes how MOZ_LOG collection works to handle multiple `moz_log.txt*` being created. It also adds a new option so that users can set MOZ_LOG to something custom.