### PR TITLE
Move the MOZ_LOG collection to afterEachURL

### DIFF
--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -136,15 +136,7 @@ class Firefox {
             this.baseDir,
             pathToFolder(result.url, this.options),
             `${file}-${index}.txt`
-          ),
-          (error) => {
-            if (error) {
-              log.info(error);
-            }
-            else {
-              log.info("renamed");
-            }
-          }
+          )
         );
       }
     }

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -83,19 +83,6 @@ class Firefox {
    */
   async afterPageCompleteCheck(runner, index, url) {
     const result = { url };
-    if (this.firefoxConfig.collectMozLog) {
-      const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
-      for (const file of files) {
-        await rename(
-          `${this.baseDir}/${file}`,
-          path.join(
-            this.baseDir,
-            pathToFolder(result.url, this.options),
-            `${file}-${index}.txt`
-          )
-        );
-      }
-    }
 
     if (this.android && this.options.androidPower) {
       result.power = await this.android.measurePowerUsage(
@@ -136,6 +123,31 @@ class Firefox {
       'firefox.appconstants',
       false
     );
+
+    if (this.firefoxConfig.collectMozLog) {
+      const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
+      log.info(files)
+      for (const file of files) {
+        log.info("renaming:")
+        log.info(file)
+        await rename(
+          `${this.baseDir}/${file}`,
+          path.join(
+            this.baseDir,
+            pathToFolder(result.url, this.options),
+            `${file}-${index}.txt`
+          ),
+          (error) => {
+            if (error) {
+              log.info(error);
+            }
+            else {
+              log.info("renamed");
+            }
+          }
+        );
+      }
+    }
 
     for (let i = 0; i < result.length; i++) {
       if (!useFirefoxAppConstants) {

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -126,10 +126,7 @@ class Firefox {
 
     if (this.firefoxConfig.collectMozLog) {
       const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
-      log.info(files)
       for (const file of files) {
-        log.info("renaming:")
-        log.info(file)
         await rename(
           `${this.baseDir}/${file}`,
           path.join(


### PR DESCRIPTION
I was hitting some issues in our CI environment because of where the MOZ_LOG collection currently takes place. This patch moves the collection to the afterEachURL function to fix those issues.