### PR TITLE
Create data dir for a URL before we run afterPageCompleteCheck.

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -199,6 +199,10 @@ class Measure {
       try {
         await this.engineDelegate.beforeEachURL(this.browser, url);
         await this.browser.loadAndWait(url, this.pageCompleteCheck);
+        // We have the URL, create the data dir
+        await this.storageManager.createSubDataDir(
+          path.join(pathToFolder(url, this.options))
+        );
         // We want to stop the video direct after the page completed
         // to make Visual Metrics faster and independent of what happens later
         if (this.recordVideo && !this.options.videoParams.debug) {
@@ -237,6 +241,10 @@ class Measure {
   async stop() {
     log.debug('Stop measuring');
     const url = await this.browser.runScript('return document.URL', 'PAGE_URL');
+    // We have the URL, create the data dir
+    await this.storageManager.createSubDataDir(
+      path.join(pathToFolder(url, this.options))
+    );
     if (this.recordVideo && !this.options.videoParams.debug) {
       await this.video.stop(url);
       this.videos.push(this.video);
@@ -294,11 +302,6 @@ class Measure {
     let url =
       testedStartUrl ||
       (await this.browser.runScript('return document.URL', 'PAGE_URL'));
-
-    // We have the URL, create the data dir
-    await this.storageManager.createSubDataDir(
-      path.join(pathToFolder(url, this.options))
-    );
 
     // If we have an alias for the URL, use that URL
     if (


### PR DESCRIPTION
This fixes so we can store files direct after page complete check as in  https://github.com/sitespeedio/browsertime/pull/1387