### PR TITLE
Increase gecko profiler buffer size from 1MB to 100MB.

### DIFF
--- a/lib/firefox/settings/geckoProfilerDefaults.js
+++ b/lib/firefox/settings/geckoProfilerDefaults.js
@@ -5,5 +5,5 @@ module.exports = {
   threads: 'GeckoMain,Compositor,Renderer',
   desktop_sampling_interval: 1,
   android_sampling_interval: 4,
-  bufferSize: 1000000
+  bufferSize: 104857600 // 100MB
 };


### PR DESCRIPTION
Fixes https://github.com/sitespeedio/browsertime/issues/1391.