### PR TITLE
Fix bufferSize to proper 100MB default size.

### DIFF
--- a/lib/firefox/settings/geckoProfilerDefaults.js
+++ b/lib/firefox/settings/geckoProfilerDefaults.js
@@ -5,5 +5,5 @@ module.exports = {
   threads: 'GeckoMain,Compositor,Renderer',
   desktop_sampling_interval: 1,
   android_sampling_interval: 4,
-  bufferSize: 104857600 // 100MB
+  bufferSize: 13107200 // 100MB
 };


### PR DESCRIPTION
Sorry @soulgalore, I misread the bug.  It will eventually be changed to take bytes, but currently takes the number of entries which are 8 bytes each.  So the real value to get 100MB should be 13107200.  Sorry about that.