### PR TITLE
Add an option for webdriver navigation (instead of window.location writes)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ jobs:
     # - run: VTENV_OPTS="-p python3" make test
     - name: Test Firefox with throttle
       run: ./bin/browsertime.js -b firefox -n 1 https://www.sitespeed.io --connectivity.profile cable --connectivity.engine throttle --xvfb --firefox.collectMozLog
-    - name: TestChrome with CPU throttle and preURL
+    - name: Test Chrome with CPU throttle and preURL
       run: ./bin/browsertime.js -b chrome --skipHar -n 1 --preURL https://www.sitespeed.io/ -r header:value --chrome.CPUThrottlingRate 2 --chrome.cdp.performance --xvfb --chrome.enableChromeDriverLog --chrome.collectConsoleLog https://www.sitespeed.io/documentation/
     - name: Test video and visual metrics
       run: ./bin/browsertime.js -b chrome -vv --viewPort=640x480 --video --screenshot --connectivity.engine tsproxy -c cable --visualMetrics -n 1 --chrome.timeline --visualElements --cookie test=true --xvfb https://www.sitespeed.io/
@@ -57,3 +57,7 @@ jobs:
       run: ./bin/browsertime.js -b firefox test/unifiedscripts/sample.js --xvfb
     - name: Test Chrome with emulated mobile
       run: ./bin/browsertime.js -b chrome --chrome.mobileEmulation.deviceName 'iPhone 6' https://www.sitespeed.io --xvfb
+    - name: Test Firefox with web driver nagivation
+      run: ./bin/browsertime.js -b firefox -n 1 https://www.sitespeed.io/ --webdriverPageload --xvfb
+    - name: Test Chrome with web driver nagivation
+      run: ./bin/browsertime.js -b chrome -n 1 https://www.sitespeed.io/ --webdriverPageload --xvfb

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -213,23 +213,37 @@ class SeleniumRunner {
     // To learn more about the event loop and request animation frame
     // watch Jake Archibald on ‘The Event Loop’ https://vimeo.com/254947206
     // TODO do we only want to do this when we record a video?
-    const navigate = `(function() {
-          const orange = document.getElementById('browsertime-orange');
-          if (orange) {
-            orange.parentNode.removeChild(orange);
-          }
+    const clearOrange = `(function() {
+      const orange = document.getElementById('browsertime-orange');
+      if (orange) {
+        orange.parentNode.removeChild(orange);
+      }
+      window.requestAnimationFrame(function(){
+        window.requestAnimationFrame(function(){
+          window.location="${url}";
+        });
+      });
+    })();`;
+    await driver.executeScript(clearOrange);
+
+    if (this.options.webdriverPageload) {
+      log.debug('Using webdriver.get to navigate');
+      await driver.get(url);
+    } else {
+      const navigate = `(function() {
+        window.requestAnimationFrame(function(){
           window.requestAnimationFrame(function(){
-            window.requestAnimationFrame(function(){
-              window.location="${url}";
-            });
+            window.location="${url}";
           });
-        })();`;
-    // Navigate to the page
-    await driver.executeScript(navigate);
+        });
+      })();`;
+      log.debug('Using window.location to navigate');
+      await driver.executeScript(navigate);
+    }
 
     // If you run with default settings, the webdriver will give back
-    // control ASAP. Therefore you wanna wait some extra time
-    // befor you start to run your page complete check
+    // control ASAP. Therefore you want to wait some extra time
+    // before you start to run your page complete check
     if (this.options.pageLoadStrategy === 'none') {
       await delay(this.options.pageCompleteCheckStartWait || 5000);
     } else {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -736,6 +736,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'Extra time added for the browser to settle before starting to test a URL. This delay happens after the browser was opened and before the navigation to the URL'
     })
+    .option('webdriverPageload', {
+      type: 'boolean',
+      describe:
+        'Use webdriver.get to initialize the page load instead of window.location.',
+      default: false
+    })
     .option('proxy.http', {
       type: 'string',
       describe: 'Http proxy (host:port)',


### PR DESCRIPTION
The option, `webdriverPageload`, is defaulted off.
When enabled, pageload navigation will be started with `webdriver.get({url})`.