### PR TITLE
Fixed bad merge - window.location navigation left in clearOrange

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -218,11 +218,6 @@ class SeleniumRunner {
       if (orange) {
         orange.parentNode.removeChild(orange);
       }
-      window.requestAnimationFrame(function(){
-        window.requestAnimationFrame(function(){
-          window.location="${url}";
-        });
-      });
     })();`;
     await driver.executeScript(clearOrange);
 


### PR DESCRIPTION
The clearOrange function now only does that.