### PR TITLE
Instead of log "browser" log the browser name.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -70,20 +70,22 @@ class SeleniumRunner {
         this.driver = await timeout(
           builder.createWebDriver(this.baseDir, this.options),
           this.options.timeouts.browserStart,
-          `Failed to start browser in ${this.options.timeouts.browserStart /
-            1000} seconds.`
+          `Failed to start ${this.options.browser} in ${this.options.timeouts
+            .browserStart / 1000} seconds.`
         );
         break;
       } catch (e) {
         log.info(
-          `Browser failed to start, trying ${tries - i - 1} more time(s): ${
-            e.message
-          }`
+          `${this.options.browser} failed to start, trying ${tries -
+            i -
+            1} more time(s): ${e.message}`
         );
       }
     }
     if (!this.driver) {
-      throw new BrowserError(`Could not start the browser with ${tries} tries`);
+      throw new BrowserError(
+        `Could not start the ${this.options.browser} with ${tries} tries`
+      );
     }
 
     try {
@@ -278,7 +280,9 @@ class SeleniumRunner {
           const waitTime = (this.options.retryWaitTime || 10000) * (i + 1);
           totalWaitTime += waitTime;
           log.info(
-            `URL ${url} failed to load, the browser are still on ${startURI} , trying ${tries -
+            `URL ${url} failed to load, the ${
+              this.options.browser
+            } are still on ${startURI} , trying ${tries -
               i -
               1} more time(s) but first wait for ${waitTime} ms.`
           );
@@ -459,8 +463,8 @@ class SeleniumRunner {
         .logs()
         .get(logType),
       this.options.timeouts.logs,
-      `Extracting logs from browser took more than ${this.options.timeouts
-        .logs / 1000} seconds.`
+      `Extracting logs from ${this.options.browser} took more than ${this
+        .options.timeouts.logs / 1000} seconds.`
     );
   }
 


### PR DESCRIPTION
This makes it easier to understand which browser that has a problem
when going throug 1000-lines of logs.