### PR TITLE
Timeout closing the browser after 2 minutes.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -478,8 +478,11 @@ class SeleniumRunner {
   async stop() {
     if (this.driver) {
       try {
-        await this.driver.quit();
-        log.debug('Closed the browser.');
+        return timeout(
+          this.driver.quit(),
+          120000,
+          'Could not close the browser using driver.quit'
+        );
       } catch (e) {
         throw new BrowserError(e.message, {
           cause: e


### PR DESCRIPTION
In #1413 it looks like the browser become unresponsive and we
just hang. Instead: timeout when we close the browser after failure
so we can move on.