### PR TITLE
Navigate to the same URL should generate multiple tests.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,3 +61,7 @@ jobs:
       run: ./bin/browsertime.js -b firefox -n 1 https://www.sitespeed.io/ --webdriverPageload --xvfb
     - name: Test Chrome with web driver nagivation
       run: ./bin/browsertime.js -b chrome -n 1 https://www.sitespeed.io/ --webdriverPageload --xvfb
+    - name: Test navigate to the same URL twice
+      run: ./bin/browsertime.js -b chrome test/navigationscript/sameURLTwice.js -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
+    - name: Test navigate to the same URL twice by clicking on a link
+      run: ./bin/browsertime.js -b chrome test/navigationscript/sameURLTwiceWithClick.js -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -199,25 +199,7 @@ class Measure {
       try {
         await this.engineDelegate.beforeEachURL(this.browser, url);
         await this.browser.loadAndWait(url, this.pageCompleteCheck);
-        // We have the URL, create the data dir
-        await this.storageManager.createSubDataDir(
-          path.join(pathToFolder(url, this.options))
-        );
-        // We want to stop the video direct after the page completed
-        // to make Visual Metrics faster and independent of what happens later
-        if (this.recordVideo && !this.options.videoParams.debug) {
-          await this.video.stop(url);
-          this.videos.push(this.video);
-        }
-        const res = await this.engineDelegate.afterPageCompleteCheck(
-          this.browser,
-          this.index,
-          url
-        );
-        this.result[this.numberOfMeasuredPages] = merge(
-          this.result[this.numberOfMeasuredPages],
-          res
-        );
+        return this.stop(url);
       } catch (e) {
         this.result[this.numberOfMeasuredPages].error = [e.name];
         // The page failed loading but make sure we keep track of
@@ -227,7 +209,6 @@ class Measure {
         this.engineDelegate.failing(url);
         throw e;
       }
-      return this.collect(url);
     } else {
       this.areWeMeasuring = true;
       return this.engineDelegate.beforeEachURL(this.browser);
@@ -238,9 +219,28 @@ class Measure {
    * Stop measuring and collect all the metrics.
    * @returns {Promise} Promise object represents all the metrics has been collected.
    */
-  async stop() {
+  async stop(testedStartUrl) {
     log.debug('Stop measuring');
-    const url = await this.browser.runScript('return document.URL', 'PAGE_URL');
+    // If we don't have a URL (tested using clicking on link etc) get the URL from the browser
+    let url =
+      testedStartUrl ||
+      (await this.browser.runScript('return document.URL', 'PAGE_URL'));
+
+    if (this.testedURLs[url]) {
+      log.info(
+        '%s has been tested before within the same run, it will get an extra query parameter named browsertime_run. Make sure to use alias to keep track of the URLs',
+        url
+      );
+      this.testedURLs[url] = this.testedURLs[url] + 1;
+      if (url.indexOf('?') > -1) {
+        url = url + '&browsertime_run=' + this.testedURLs[url];
+      } else {
+        url = url + '?browsertime_run=' + this.testedURLs[url];
+      }
+    } else {
+      this.testedURLs[url] = 1;
+    }
+
     // We have the URL, create the data dir
     await this.storageManager.createSubDataDir(
       path.join(pathToFolder(url, this.options))
@@ -258,7 +258,7 @@ class Measure {
       this.result[this.numberOfMeasuredPages],
       res
     );
-    return this.collect();
+    return this.collect(url);
   }
 
   /**
@@ -289,7 +289,7 @@ class Measure {
       );
   }
 
-  async collect(testedStartUrl) {
+  async collect(url) {
     if (this.options.tcpdump) {
       await this.tcpDump.stop();
     }
@@ -297,11 +297,6 @@ class Measure {
     // await this.engineDelegate.beforeCollect();
 
     log.verbose('Collecting metrics');
-    // Collect all the metrics through JavaScript
-    // If we don't have a URL (tested using clicking on link etc) get the URL from the browser
-    let url =
-      testedStartUrl ||
-      (await this.browser.runScript('return document.URL', 'PAGE_URL'));
 
     // If we have an alias for the URL, use that URL
     if (
@@ -316,20 +311,6 @@ class Measure {
       }
     }
 
-    if (this.testedURLs[url]) {
-      log.info(
-        '%s has been tested before within the same run, it will get an extra query parameter named browsertime_run. Make sure to use alias to keep track of the URLs',
-        url
-      );
-      this.testedURLs[url] = this.testedURLs[url] + 1;
-      if (url.indexOf('?') > -1) {
-        url = url + '&browsertime_run=' + this.testedURLs[url];
-      } else {
-        url = url + '?browsertime_run=' + this.testedURLs[url];
-      }
-    } else {
-      this.testedURLs[url] = 1;
-    }
     this.result[this.numberOfMeasuredPages].url = url;
 
     // when we have the URL we can use that to stop the video and put it where we want it

--- a/test/navigationscript/sameURLTwice.js
+++ b/test/navigationscript/sameURLTwice.js
@@ -1,0 +1,5 @@
+module.exports = async function(context, commands) {
+  await commands.measure.start('https://www.sitespeed.io');
+  await commands.navigate('about:blank');
+  return commands.measure.start('https://www.sitespeed.io');
+};

--- a/test/navigationscript/sameURLTwiceWithClick.js
+++ b/test/navigationscript/sameURLTwiceWithClick.js
@@ -1,0 +1,17 @@
+module.exports = async function(context, commands) {
+  await commands.measure.start('https://www.sitespeed.io/documentation/');
+  await commands.measure.start('https://www.sitespeed.io');
+  // Hide everything
+  // We do not hide the body since the body needs to be visible when we do the magic to find the staret of the
+  // navigation by adding a layer of orange on top of the page
+  await commands.js.run(
+    'for (let node of document.body.childNodes) { if (node.style) node.style.display = "none";}'
+  );
+  // Start measurning
+  await commands.measure.start();
+  // Click on the link for /documentation/ and wait on navigation to happen
+  await commands.click.bySelectorAndWait(
+    'body > nav > div > div > div > ul > li:nth-child(2) > a'
+  );
+  return commands.measure.stop();
+};


### PR DESCRIPTION
In 10 testing the same page twice in a script was broken as reported
in #1419 and also reported in https://github.com/sitespeedio/sitespeed.io/issues/3164.

The problem was that when we stop the video, we didn't know the correct URL,
that is fixed with this commit (+code cleanup to make it easier to follow).