### PR TITLE
Remove Firefox preferences that disables the speculative connection pool

### DIFF
--- a/lib/firefox/settings/firefoxPreferences.js
+++ b/lib/firefox/settings/firefoxPreferences.js
@@ -135,8 +135,6 @@ module.exports = {
   'media.navigator.enabled': true,
   'media.navigator.permission.disabled': true,
   'media.peerconnection.enabled': true,
-  // Disable speculative connections so they aren't reported as leaking when they're hanging around.
-  'network.http.speculative-parallel-limit': 0,
   // Set places maintenance far in the future (the maximum time possible in an
   // int32_t) to avoid it kicking in during tests. The maintenance can take a
   // relatively long time which may cause unnecessary intermittents and slow down


### PR DESCRIPTION
This is a preference inherited from a legacy testing suite.
We do want the speculative connection pool active as it plays a critical role in pageload performance.

Closes #1422.
