### PR TITLE
Set firefox environment variables in process.env[...]

### DIFF
--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -167,15 +167,11 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     ffOptions.addArguments(firefoxConfig.args);
   }
 
-  const envMap = {}; // Map of string name to string value.
   const envs = util.toArray(firefoxConfig.env);
   for (const env of envs) {
     const name = env.substr(0, env.indexOf('='));
-    let value = env.substr(env.indexOf('=') + 1);
-    envMap[name] = value;
-  }
-  if (envs.length > 0) {
-    ffOptions.firefoxOptions_().env = envMap;
+    const value = env.substr(env.indexOf('=') + 1);
+    process.env[name] = value;
   }
 
   if (options.headless) {


### PR DESCRIPTION
Setting firefox environment variables that were passed using `--firefox.env` does not work completely as expected currently. 
Please refer to https://phabricator.services.mozilla.com/D95144.
@gmierz I'm setting the variables in `process.env[...]` as you suggested but I'm not sure about `ffOptions.firefoxOptions_().env`. I've currently left that as is. Setting the variables in both places might be redundant, but not a problem right?

Tagging @gmierz and @soulgalore for review.