### PR TITLE
Add timeout for getting Geckoprofile data.

### DIFF
--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -4,7 +4,29 @@ const geckoProfilerDefaults = require('./settings/geckoProfilerDefaults');
 const { isAndroidConfigured, Android } = require('../android');
 const path = require('path');
 const pathToFolder = require('../support/pathToFolder');
+const { BrowserError } = require('../support/errors');
 
+/**
+ * Timeout a promise after ms. Use promise.race to compete
+ * about the timeout and the promise.
+ * @param {promise} promise - The promise to wait for
+ * @param {int} ms - how long in ms to wait for the promise to fininsh
+ * @param {string} errorMessage - the error message in the Error if we timeouts
+ */
+async function timeout(promise, ms, errorMessage) {
+  let timer = null;
+
+  return Promise.race([
+    new Promise((resolve, reject) => {
+      timer = setTimeout(reject, ms, new BrowserError(errorMessage));
+      return timer;
+    }),
+    promise.then(value => {
+      clearTimeout(timer);
+      return value;
+    })
+  ]);
+}
 class GeckoProfiler {
   constructor(runner, storageManager, firefoxConfig, options) {
     this.runner = runner;
@@ -91,24 +113,32 @@ class GeckoProfiler {
         .then(callback)
         .catch((e) => callback({'error' : e}));
        `;
-    await runner.runPrivilegedAsyncScript(script, 'Collect GeckoProfiler');
-    log.info('Stop GeckoProfiler.');
-    await runner.runPrivilegedScript(
-      'Services.profiler.StopProfiler();',
-      'Stop GeckoProfiler'
-    );
+    try {
+      await timeout(
+        runner.runPrivilegedAsyncScript(script, 'Collect GeckoProfiler'),
+        1200000,
+        'Could not get the Geckoprofiler log'
+      );
+      log.info('Stop GeckoProfiler.');
+      await runner.runPrivilegedScript(
+        'Services.profiler.StopProfiler();',
+        'Stop GeckoProfiler'
+      );
 
-    if (isAndroidConfigured(options)) {
-      const android = new Android(options);
-      await android._downloadFile(deviceProfileFilename, destinationFilename);
+      if (isAndroidConfigured(options)) {
+        const android = new Android(options);
+        await android._downloadFile(deviceProfileFilename, destinationFilename);
+      }
+
+      // GZIP the profile and remove the old file
+      return storageManager.gzip(
+        destinationFilename,
+        path.join(profileDir, `geckoProfile-${index}.json.gz`),
+        true
+      );
+    } catch (e) {
+      log.error(e.message);
     }
-
-    // GZIP the profile and remove the old file
-    return storageManager.gzip(
-      destinationFilename,
-      path.join(profileDir, `geckoProfile-${index}.json.gz`),
-      true
-    );
   }
 
   addMetaData() {}


### PR DESCRIPTION
On one of the phones where I run tests I've seen that getting the
Geckoprofile data can freeze the tests forever.