### PR TITLE
Closes #1448: fix process ID fetch for Galaxy S5

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -272,6 +272,7 @@ class Android {
   }
 
   async _pidofWithPidof(packageName) {
+    // This method is expected to work on the Moto G5 and the Pixel 2.
     const cmd1 = `pidof ${packageName}`;
     log.debug(`pidof ${cmd1}`);
     const proc1 = await this._runCommand(cmd1);
@@ -279,8 +280,13 @@ class Android {
     const ps = ps1.toString();
     log.debug(`pidof ${ps}`);
 
-    if (ps && !Number.isNaN(Number.parseInt(ps.trim()))) {
-      console.log(Number.parseInt(ps.trim()));
+    if (ps &&
+        // On some devices such as the Galaxy S5, pidof returns all active
+        // pids (even with arguments) and isn't useful to us: we don't use
+        // pidof in this case which we detect if there's a space (i.e. more
+        // than one pid was returned).
+        !ps.trim().includes(' ') &&
+        !Number.isNaN(Number.parseInt(ps.trim()))) {
       return Number.parseInt(ps.trim());
     }
 

--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -294,21 +294,48 @@ class Android {
   }
 
   async _pidofWithPs(packageName) {
-    const cmd2 = `ps -o PID,NAME | grep ' ${packageName}$'`;
-    log.debug(`pidof ${cmd2}`);
-    const proc2 = await this._runCommand(cmd2);
-    const ps2 = await adb.util.readAll(proc2);
-    const ps = ps2.toString();
+    // The ps output and accepted arguments change across devices so we work
+    // with the most generic version of it by calling it without arguments.
+    // We could also do the parsing more simply with shell commands but we
+    // avoid them because they can have different behavior across devices.
+    //
+    // This method was tested on the Galaxy S5.
+    const cmd = `ps`;
+    log.debug(`pidof ${cmd}`);
+    const proc = await this._runCommand(cmd);
+    const psTemp = await adb.util.readAll(proc);
+    const ps = psTemp.toString();
     log.debug(`pidof ${ps}`);
 
-    for (const line in ps.split(/[\r\n]+/)) {
-      const parts = line.trim().split(' ');
-      if (
-        parts.length == 2 &&
-        parts[0] === packageName &&
-        !Number.isNaN(Number.parseInt(parts[1].trim()))
-      ) {
-        return Number.parseInt(parts[1].trim());
+    const lines = ps.split(/[\r\n]+/);
+
+    // Galaxy S5 example:
+    // USER      PID   PPID  VSIZE  RSS   WCHAN            PC  NAME
+    // root      1     0     3396   868   sys_epoll_ 00000000 S /init
+    // ...
+    const header = lines[0];
+    const headerParts = header.split(/\s+/);
+    const pidIndex = headerParts.indexOf('PID');
+
+    // On the Galaxy S5, the process state column ("S" in the example above) is
+    // unlabeled and comes before the package name. As such, we add one to the
+    // index. However, on other devices such as the Pixel 2, this column is
+    // labeled so we should not add 1. However, my hope is that simpler
+    // methodologies like pidof work so we don't need to handle that here.
+    const packageNameIndex = headerParts.indexOf('NAME') + 1;
+
+    for (const line of ps.split(/[\r\n]+/)) {
+      const lineParts = line.split(/\s+/);
+      const processPackage = lineParts[packageNameIndex];
+      const processPid = lineParts[pidIndex];
+      if (processPackage !== packageName) {
+        continue;
+      }
+
+      log.debug(`pidof ${line}`);
+      const pid = Number.parseInt(processPid);
+      if (pid && !Number.isNaN(pid)) {
+        return pid;
       }
     }
 

--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -257,16 +257,13 @@ class Android {
   async pidof(packageName) {
     // The same shell command on different devices may have different behaviors.
     // Therefore, if one command isn't working as expected, we try another one.
-    for (const pidofMethodology of [
-      this._pidofWithPidof,
-      this._pidofWithPs,
-    ]) {
+    for (const pidofMethodology of [this._pidofWithPidof, this._pidofWithPs]) {
       const pidofMethodologyWithThis = pidofMethodology.bind(this);
       const pid = await pidofMethodologyWithThis(packageName);
       if (pid) {
-        return pid
+        return pid;
       }
-    };
+    }
 
     return null;
   }
@@ -280,13 +277,15 @@ class Android {
     const ps = ps1.toString();
     log.debug(`pidof ${ps}`);
 
-    if (ps &&
-        // On some devices such as the Galaxy S5, pidof returns all active
-        // pids (even with arguments) and isn't useful to us: we don't use
-        // pidof in this case which we detect if there's a space (i.e. more
-        // than one pid was returned).
-        !ps.trim().includes(' ') &&
-        !Number.isNaN(Number.parseInt(ps.trim()))) {
+    if (
+      ps &&
+      // On some devices such as the Galaxy S5, pidof returns all active
+      // pids (even with arguments) and isn't useful to us: we don't use
+      // pidof in this case which we detect if there's a space (i.e. more
+      // than one pid was returned).
+      !ps.trim().includes(' ') &&
+      !Number.isNaN(Number.parseInt(ps.trim()))
+    ) {
       return Number.parseInt(ps.trim());
     }
 

--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -255,22 +255,44 @@ class Android {
   }
 
   async pidof(packageName) {
+    // The same shell command on different devices may have different behaviors.
+    // Therefore, if one command isn't working as expected, we try another one.
+    for (const pidofMethodology of [
+      this._pidofWithPidof,
+      this._pidofWithPs,
+    ]) {
+      const pidofMethodologyWithThis = pidofMethodology.bind(this);
+      const pid = await pidofMethodologyWithThis(packageName);
+      if (pid) {
+        return pid
+      }
+    };
+
+    return null;
+  }
+
+  async _pidofWithPidof(packageName) {
     const cmd1 = `pidof ${packageName}`;
     log.debug(`pidof ${cmd1}`);
     const proc1 = await this._runCommand(cmd1);
     const ps1 = await adb.util.readAll(proc1);
-    let ps = ps1.toString();
+    const ps = ps1.toString();
     log.debug(`pidof ${ps}`);
 
     if (ps && !Number.isNaN(Number.parseInt(ps.trim()))) {
+      console.log(Number.parseInt(ps.trim()));
       return Number.parseInt(ps.trim());
     }
 
+    return null;
+  }
+
+  async _pidofWithPs(packageName) {
     const cmd2 = `ps -o PID,NAME | grep ' ${packageName}$'`;
     log.debug(`pidof ${cmd2}`);
     const proc2 = await this._runCommand(cmd2);
     const ps2 = await adb.util.readAll(proc2);
-    ps = ps2.toString();
+    const ps = ps2.toString();
     log.debug(`pidof ${ps}`);
 
     for (const line in ps.split(/[\r\n]+/)) {


### PR DESCRIPTION
This fixes the process ID issue on the Galaxy S5 described in #1448. I was unable to run browsertime standalone but it fixes the issue within Mozilla's `./mach perftest` harness on this device.

Unfortunately, the perftest harness is currently broken on my Pixel 2 (https://bugzilla.mozilla.org/show_bug.cgi?id=1667224) so I'm unable to test on other devices. In particular, I'm concerned that the one non-trivial line I added, `!ps.trim().includes(' ') &&` will go untested (at least until I can fix our test harness for P2 or figure out how to run browsertime standalone). Otherwise, I didn't modify the codepath much I expect it to use (using `pidof`) so I think it should work correctly. I similarly confirmed the Moto G5 returns the expected output from pidof and should work correctly.

I don't know how to run the tests so I didn't run them. It doesn't look like a unit test harness is set up for these classes so I didn't write new tests.

Sorry for the lackluster testing and reproducible test case story but hopefully I've been descriptive enough to help out. :)