### PR TITLE
Use firefoxOptions for env settings on Android.

### DIFF
--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -178,10 +178,15 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   }
 
   const envs = util.toArray(firefoxConfig.env);
+  ffOptions.firefoxOptions_().env = ffOptions.firefoxOptions_().env || {};
   for (const env of envs) {
     const name = env.substr(0, env.indexOf('='));
     const value = env.substr(env.indexOf('=') + 1);
-    process.env[name] = value;
+    if (options.android) {
+      ffOptions.firefoxOptions_().env[name] = value;
+    } else {
+      process.env[name] = value;
+    }
   }
 
   if (options.headless) {


### PR DESCRIPTION
This patch fixes how environment variables are set on Android. Instead of using the `process.env` we use the `firefoxOptions.env`.