### PR TITLE
Hide the pretest power button click behind an option.

### DIFF
--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -85,7 +85,9 @@ class Engine {
         throw Error(message);
       }
 
-      await android.clickPowerButton();
+      if (this.options.androidPretestPowerClick) {
+        await android.clickPowerButton();
+      }
 
       if (this.options.androidVerifyNetwork) {
         const pingAddress = get(this.options, 'androidPingAddress', '8.8.8.8');

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -85,7 +85,7 @@ class Engine {
         throw Error(message);
       }
 
-      if (this.options.androidPretestPowerClick) {
+      if (this.options.androidPretestPowerPress) {
         await android.clickPowerButton();
       }
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -612,6 +612,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'If your phone does not get the minimum temperature aftet the wait time, reboot the phone.'
     })
+    .option('androidPretestPowerPress', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Press the power button on the phone before a test starts.'
+    })
     .option('androidVerifyNetwork', {
       type: 'boolean',
       default: false,

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -615,8 +615,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .option('androidPretestPowerPress', {
       type: 'boolean',
       default: false,
-      describe:
-        'Press the power button on the phone before a test starts.'
+      describe: 'Press the power button on the phone before a test starts.'
     })
     .option('androidVerifyNetwork', {
       type: 'boolean',


### PR DESCRIPTION
This patch hides the android power button click behind a flag since it might be causing the screen to get turned off on some phone models (Moto G5). I'm running some tests here to see: https://treeherder.mozilla.org/jobs?repo=try&revision=1cc159b1660fbe658d768169fba2a87d954adb46

You can see the bug we have about this here: https://bugzilla.mozilla.org/show_bug.cgi?id=1680998
The screen recordings are black, and the android logs also mention that the phone was going to sleep. This started after we updated to version 11.