### PR TITLE
Fix backfilling fullyLoaded.

### DIFF
--- a/lib/chrome/har.js
+++ b/lib/chrome/har.js
@@ -15,7 +15,8 @@ module.exports = async function(
   mobileEmulation,
   androidClient,
   chrome,
-  aliasAndUrl
+  aliasAndUrl,
+  alias
 ) {
   log.debug('Getting performance logs from Chrome');
 
@@ -56,6 +57,9 @@ module.exports = async function(
   if (har.log.pages.length > 0) {
     har.log.pages[0].title = `${result.url} run ${index}`;
     // Hack to add the URL from a SPA
+    if (alias) {
+      har.log.pages[0]._alias = alias;
+    }
     if (result.alias && !aliasAndUrl[result.alias]) {
       aliasAndUrl[result.alias] = result.url;
       har.log.pages[0]._url = result.url;

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -143,7 +143,7 @@ class Chromium {
    * stop trace logging, stop measuring etc.
    *
    */
-  async afterPageCompleteCheck(runner, index, url) {
+  async afterPageCompleteCheck(runner, index, url, alias) {
     const result = { url };
     if (this.collectTracingEvents && this.isTracing) {
       // We are ready and can stop collecting events
@@ -199,7 +199,8 @@ class Chromium {
           this.chrome.mobileEmulation,
           this.android,
           this.chrome,
-          this.aliasAndUrl
+          this.aliasAndUrl,
+          alias
         )
       );
     }

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -77,7 +77,10 @@ class Collector {
    * @param {*} url
    * @param {*} fullyLoaded
    */
-  addFullyLoaded(url, fullyLoaded) {
+  addFullyLoaded(url, fullyLoaded, alias) {
+    if (this.aliasAndUrl[alias]) {
+      url = this.aliasAndUrl[alias];
+    }
     const statistics = this.allStats[url];
     const results = this.allResults[url];
     if (results) {

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -243,16 +243,13 @@ class Measure {
 
     // There's a use case where you only add an alias in script, if that's the case
     // we also need to add that to the meta data so that the correct folder is created
-    if (this.result[this.numberOfMeasuredPages].alias) {
+    let alias = this.result[this.numberOfMeasuredPages].alias;
+    if (alias) {
       if (this.options.urlMetaData) {
-        this.options.urlMetaData[url] = this.result[
-          this.numberOfMeasuredPages
-        ].alias;
+        this.options.urlMetaData[url] = alias;
       } else {
         this.options.urlMetaData = {};
-        this.options.urlMetaData[url] = this.result[
-          this.numberOfMeasuredPages
-        ].alias;
+        this.options.urlMetaData[url] = alias;
       }
     }
 
@@ -267,7 +264,10 @@ class Measure {
     const res = await this.engineDelegate.afterPageCompleteCheck(
       this.browser,
       this.index,
-      url
+      url,
+      alias || (this.options.urlMetaData && this.options.urlMetaData[url])
+        ? this.options.urlMetaData[url]
+        : undefined
     );
 
     // Add the alias from the options to the result to follow the same pattern as if we have the alias in the script file

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -241,7 +241,7 @@ class Engine {
     if (!options.skipHar && extras.har) {
       const fullyLoadedPerUrl = harUtil.getFullyLoaded(extras.har);
       for (let data of fullyLoadedPerUrl) {
-        collector.addFullyLoaded(data.url, data.fullyLoaded);
+        collector.addFullyLoaded(data.url, data.fullyLoaded, data.alias);
       }
     }
 

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -81,7 +81,7 @@ class Firefox {
    * stop trace logging, stop measuring etc.
    *
    */
-  async afterPageCompleteCheck(runner, index, url) {
+  async afterPageCompleteCheck(runner, index, url, alias) {
     const result = { url };
     if (this.firefoxConfig.collectMozLog) {
       const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
@@ -112,6 +112,9 @@ class Firefox {
     } else {
       const har = await getHAR(runner, this.includeResponseBodies);
       if (har.log.pages.length > 0) {
+        if (alias) {
+          har.log.pages[0]._alias = alias;
+        }
         // Hack to add the URL from a SPA
         if (result.alias && !this.aliasAndUrl[result.alias]) {
           this.aliasAndUrl[result.alias] = result.url;

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -159,6 +159,7 @@ module.exports = {
       const pageStartDateTime = new Date(page.startedDateTime).getTime();
       const pageId = page.id;
       const url = page._url;
+      const alias = page._alias;
 
       let pageEntries = Array.from(entries);
       pageEntries = Array.from(
@@ -175,7 +176,7 @@ module.exports = {
           pageEnd = entryEnd;
         }
       }
-      fullyLoaded.push({ url, fullyLoaded: Number(pageEnd.toFixed(0)) });
+      fullyLoaded.push({ alias, url, fullyLoaded: Number(pageEnd.toFixed(0)) });
     }
     return fullyLoaded;
   },


### PR DESCRIPTION
If you use an alias and the URL change between runs, adding the
fullyLoaded metric breaks, because it tries to add stats to a
URL that do not exist. If the HAR file know the alias, we can
fix it. This is hacky and we should make a task to cleanup the
use of alias.