### PR TITLE
Save gecko profile locations in the browsertime results.

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -28,7 +28,8 @@ function getNewResult(url, options) {
       timeline: [],
       consoleLog: [],
       netLog: [],
-      perfLog: []
+      perfLog: [],
+      geckoProfiles: []
     },
     cdp: { performance: [] },
     android: { batteryTemperature: [], power: [] },
@@ -363,6 +364,12 @@ class Collector {
       if (this.options.chrome && this.options.chrome.collectPerfLog) {
         results.files.perfLog.push(
           `${pathToFolder(url, this.options)}chromePerflog-${index}.json.gz`
+        );
+      }
+
+      if (this.options.firefox && this.options.firefox.geckoProfiler) {
+        results.files.geckoProfiles.push(
+          `${pathToFolder(url, this.options)}geckoProfile-${index}.json.gz`
         );
       }
 


### PR DESCRIPTION
This patch is for storing the gecko profile paths in the browsertime results. This makes it easier to figure out which gecko profiles go with which tests.