### PR TITLE
First go at adding failure state.

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -31,6 +31,8 @@ function getNewResult(url, options) {
       perfLog: [],
       geckoProfiles: []
     },
+    markedAsFailure: 0,
+    failureMessages: [],
     cdp: { performance: [] },
     android: { batteryTemperature: [], power: [] },
     timestamps: [],
@@ -147,6 +149,11 @@ class Collector {
         statistics.addDeep({
           android: { batteryTemperature: allData.batteryTemperature }
         });
+      }
+
+      if (allData.markedAsFailure) {
+        results.markedAsFailure = 1;
+        results.failureMessages = allData.failureMessages;
       }
 
       // If we don't have an error, use an empty array. In the future we want to push

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -117,6 +117,17 @@ class Measure {
       }
     }
   }
+
+  _failure(message) {
+    log.debug('Mark run as failure with message %s', message);
+    this.result.markedAsFailure = 1;
+    if (this.result.failureMessages) {
+      this.result.failureMessages.push(message);
+    } else {
+      this.result.failureMessages = [message];
+    }
+  }
+
   async _navigate(url) {
     log.info('Navigating to url %s iteration %s', url, this.index);
     if (this.numberOfVisitedPages === 0) {

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -295,7 +295,7 @@ class Engine {
     }
     util.logResultLogLine(totalResult);
 
-    if (failures.length > 0) {     
+    if (failures.length > 0) {
       // If we have a result
       if (totalResult[0]) {
         totalResult[0].markedAsFailure = 1;
@@ -304,7 +304,6 @@ class Engine {
         // If we didn't have a result, we still want the failure
         totalResult[0] = { markedAsFailure: 1, failureMessages: failures };
       }
-
     }
 
     if (errorsOutsideTheBrowser.length > 0) {

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -240,18 +240,27 @@ class Engine {
     );
 
     const errorsOutsideTheBrowser = [];
+    const failures = [];
     for (let index = 1; index < options.iterations + 1; index++) {
       const data = await iteration.run(navigationScript, index);
       // Only collect if it was succesful
       // Here we got room for improvements
       if (data && data[0] && data[0].url) {
         await collector.perIteration(data, index);
+        // If we have a failure from scripting
+        if (data.markedAsFailure) {
+          failures.push(...data.failureMessages);
+        }
       } else {
         log.error('No data to collect');
         // We can have errors that happend before we started to test the page
         // like starting the browser, missmatching WebDriver
         if (data.error) {
           errorsOutsideTheBrowser.push(...data.error);
+        }
+        // Catch failures like starting the browser
+        if (data.markedAsFailure) {
+          failures.push(...data.failureMessages);
         }
       }
       if (shouldDelay(index, options.iterations, options.delay)) {
@@ -278,6 +287,18 @@ class Engine {
       totalResult.har = extras.har;
     }
     util.logResultLogLine(totalResult);
+
+    if (failures.length > 0) {     
+      // If we have a result
+      if (totalResult[0]) {
+        totalResult[0].markedAsFailure = 1;
+        totalResult[0].failureMessages = failures;
+      } else {
+        // If we didn't have a result, we still want the failure
+        totalResult[0] = { markedAsFailure: 1, failureMessages: failures };
+      }
+
+    }
 
     if (errorsOutsideTheBrowser.length > 0) {
       if (totalResult[0]) {

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -140,6 +140,7 @@ class Iteration {
         measure: measure,
         navigate: measure._navigate.bind(measure),
         error: measure._error.bind(measure),
+        markAsFailure: measure._failure.bind(measure),
         js: new JavaScript(browser, this.pageCompleteCheck),
         switch: new Switch(browser),
         set: new Set(browser),
@@ -191,6 +192,7 @@ class Iteration {
         await navigationScript(context, commands, this.postURLScripts);
       } catch (e) {
         commands.error(e.message);
+        commands.markAsFailure(e.message);
         throw e;
       }
       if (commands.measure.areWeMeasuring === true) {
@@ -287,6 +289,8 @@ class Iteration {
         await stop('ffmpeg');
       }
       result.error = [e.name];
+      result.markedAsFailure = 1;
+      result.failureMessages = [e.message];
       return result;
     } finally {
       // Here we should also make sure FFMPEG is really killed/stopped


### PR DESCRIPTION
This will add a new command: `markAsFailure(message)` where you can mark a test as a failure. If one run fails, all tests are marked as failed. The JSON from Browsertime (that is used in sitespeed.io) gets a failure filed and an array of failure messages (potentially you can mark a run as failed multiple times).

If we get an uncaught error when we run a tests (for example we couldn't start the browser at all), we automatically mark the test as a failure.

See https://github.com/sitespeedio/sitespeed.io/issues/3262