### PR TITLE
Add CLI argument to control ffmpeg thread count

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -556,6 +556,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
         'Convert the original video to a viewable format (for most video players). Turn that off to make a faster run.',
       group: 'video'
     })
+    .option('videoParams.threads', {
+      default: videoDefaults.threads,
+      describe:
+        'Number of threads to use for video recording. Default is determined by ffmpeg.',
+      group: 'video'
+    })
     .option('visualMetrics', {
       type: 'boolean',
       describe:

--- a/lib/video/defaults.js
+++ b/lib/video/defaults.js
@@ -5,5 +5,6 @@ module.exports = {
   crf: 23,
   xvfbDisplay: 99,
   addTimer: true,
-  convert: true
+  convert: true,
+  threads: 0
 };

--- a/lib/video/screenRecording/desktop/convert.js
+++ b/lib/video/screenRecording/desktop/convert.js
@@ -3,13 +3,15 @@
 const execa = require('execa');
 const log = require('intel').getLogger('browsertime.video');
 
-module.exports = async function convert(src, dest, crf) {
+module.exports = async function convert(src, dest, crf, threads) {
   const scriptArgs = [
     '-nostdin',
     '-i',
     src,
     '-c:v',
     'libx264',
+    '-threads',
+    threads,
     '-crf',
     crf,
     '-preset',

--- a/lib/video/screenRecording/desktop/desktopRecorder.js
+++ b/lib/video/screenRecording/desktop/desktopRecorder.js
@@ -18,6 +18,7 @@ module.exports = class DesktopRecorder {
     this.nice = get(options, 'videoParams.nice', 0);
     this.crf = get(options, 'videoParams.crf', defaults.crf);
     this.convert = get(options, 'videoParams.convert', defaults.convert);
+    this.threads = get(options, 'videoParams.threads', defaults.threads);
     this.viewPort = getViewPort(options);
     this.origin = '0,0';
     this.offset = { x: 0, y: 0 };
@@ -35,7 +36,8 @@ module.exports = class DesktopRecorder {
       offset: this.offset,
       framerate: this.framerate,
       crf: this.crf,
-      nice: this.nice
+      nice: this.nice,
+      threads: this.threads
     });
 
     return this.recording;
@@ -56,7 +58,7 @@ module.exports = class DesktopRecorder {
     }
     try {
       if (this.convert) {
-        await convert(this.filePath, destination, this.crf);
+        await convert(this.filePath, destination, this.crf, this.threads);
         await unlink(this.filePath);
       } else {
         await rename(this.filePath, destination);

--- a/lib/video/screenRecording/desktop/ffmpegRecorder.js
+++ b/lib/video/screenRecording/desktop/ffmpegRecorder.js
@@ -11,7 +11,8 @@ async function buildX11FfmpegArgs({
   origin = '0,0',
   size,
   filePath,
-  offset
+  offset,
+  threads
 }) {
   if (process.platform === 'darwin') {
     const osXScreen = await getScreenOnOSX();
@@ -31,6 +32,8 @@ async function buildX11FfmpegArgs({
         devicePixelRatio}`,
       '-codec:v',
       'libx264rgb',
+      '-threads',
+      threads,
       '-crf',
       '0',
       '-preset',
@@ -58,6 +61,8 @@ async function buildX11FfmpegArgs({
         : `:${display}.${screen}+${origin}`,
       '-codec:v',
       'libx264rgb',
+      '-threads',
+      threads,
       '-crf',
       0,
       '-preset',
@@ -122,7 +127,8 @@ module.exports = {
     offset,
     framerate,
     crf,
-    nice
+    nice,
+    threads
   }) {
     const widthAndHeight = size.split('x');
     const withoutTopBar =
@@ -138,7 +144,8 @@ module.exports = {
       filePath,
       framerate,
       crf,
-      offset
+      offset,
+      threads
     });
     return startRecording(ffmpegArgs, nice, filePath);
   },


### PR DESCRIPTION
Hi! I'm running browsertime dockerized with a limited number of CPUs assigned to each container, but ffmpeg's default thread count seems to be based on the number of CPUs of the entire system. This PR adds a new `videoParams.threads` CLI argument to overwrite ffmpeg's thread count for this scenario. The behavior will be the same if the option is not specified, i.e., ffmpeg picks the number of threads.