### PR TITLE
Add perf stats support to browsertime

### DIFF
--- a/lib/firefox/perfStats.js
+++ b/lib/firefox/perfStats.js
@@ -1,0 +1,70 @@
+'use strict';
+const fs = require('fs');
+const log = require('intel').getLogger('browsertime.firefox');
+const path = require('path');
+const pathToFolder = require('../support/pathToFolder');
+
+class PerfStats {
+  constructor(runner, storageManager, firefoxConfig, options) {
+    this.runner = runner;
+    this.storageManager = storageManager;
+    this.firefoxConfig = firefoxConfig;
+    this.options = options;
+  }
+
+  async start() {
+    const runner = this.runner;
+    const featureMask = this.firefoxConfig.perfStatsParams.mask;
+    const script = `ChromeUtils.setPerfStatsCollectionMask(${featureMask});`;
+    return runner.runPrivilegedScript(script, 'Start PerfStats Measurement');
+  }
+
+  async stop() {
+    const runner = this.runner;
+    const script = `ChromeUtils.setPerfStatsCollectionMask(0);`;
+    return runner.runPrivilegedScript(script, 'Stop PerfStats Measurement');
+  }
+
+  async collect(index, url) {
+    const runner = this.runner;
+    const storageManager = this.storageManager;
+    const options = this.options;
+
+    const script = `
+    const callback = arguments[arguments.length - 1];
+    async function collectPerfStats() {
+      try {
+        const result = await ChromeUtils.collectPerfStats();
+        return callback(result);
+      }
+      catch(e) {
+        return callback({'error': e});
+      }
+    };
+    return collectPerfStats();
+    `;
+
+    try {
+      const perfStatsResult = await runner.runPrivilegedAsyncScript(
+        script,
+        'Collect PerfStats'
+      );
+
+      if (perfStatsResult) {
+        let profileDir = await storageManager.createSubDataDir(
+          path.join(pathToFolder(url, options))
+        );
+        let destinationFilename = path.join(
+          profileDir,
+          `perfStats-${index}.json`
+        );
+
+        fs.writeFileSync(destinationFilename, perfStatsResult);
+      }
+    } catch (e) {
+      log.error('Could not collect perf stats', e);
+    }
+  }
+}
+
+module.exports = PerfStats;

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -13,6 +13,7 @@ const util = require('../../support/util.js');
 const fileUtil = require('../../support/fileUtil.js');
 const getHAR = require('../getHAR');
 const GeckoProfiler = require('../geckoProfiler');
+const PerfStats = require('../perfStats.js');
 
 class Firefox {
   constructor(storageManager, options) {
@@ -71,7 +72,18 @@ class Firefox {
         this.options
       );
 
-      return this.geckoProfiler.start();
+      await this.geckoProfiler.start();
+    }
+
+    if (this.firefoxConfig.perfStats) {
+      this.perfStats = new PerfStats(
+        runner,
+        this.storageManager,
+        this.firefoxConfig,
+        this.options
+      );
+
+      return this.perfStats.start();
     }
   }
 
@@ -105,6 +117,11 @@ class Firefox {
 
     if (this.firefoxConfig.geckoProfiler) {
       await this.geckoProfiler.stop(index, url);
+    }
+
+    if (this.firefoxConfig.perfStats) {
+      await this.perfStats.collect(index, url);
+      await this.perfStats.stop();
     }
 
     if (this.skipHar || this.options.android) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -426,6 +426,19 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'number',
       group: 'firefox'
     })
+    .option('firefox.perfStats', {
+      describe:
+        'Collect gecko performance statistics as measured internally by the firefox browser.',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
+    .option('firefox.perfStatsParams.mask', {
+      describe: 'Mask to decide which features to enable',
+      default: 0xffffffff,
+      type: 'number',
+      group: 'firefox'
+    })
     .option('firefox.collectMozLog', {
       type: 'boolean',
       describe:


### PR DESCRIPTION
Firefox has an infrastructure to provide internal micro timings and emit the output as a JSON.  We'd like to extend browsertime to automatically measure and collect this data when requested.  