### PR TITLE
Combine the gecko perfstats from each process

### DIFF
--- a/lib/firefox/perfStats.js
+++ b/lib/firefox/perfStats.js
@@ -43,7 +43,19 @@ class PerfStats {
         'Collect PerfStats'
       );
 
-      return JSON.parse(perfStatsResult);
+      // Combine the perf stats from the eacj processes
+      const combinedPerfStats = {};
+      const perfStats = JSON.parse(perfStatsResult);
+      for (const process of perfStats.processes) {
+        for (const metric of process.perfstats.metrics) {
+          const metricName = metric.metric;
+          if (!(metricName in combinedPerfStats)) {
+            combinedPerfStats[metricName] = 0;
+          }
+          combinedPerfStats[metricName] += Math.round(metric.time);
+        }
+      }
+      return combinedPerfStats;
     } catch (e) {
       log.error('Could not collect perf stats', e);
     }


### PR DESCRIPTION
The perfstats are collected for each process.

In this PR I accumulate the timings in such a structure:

```
"geckoPerfStats": [
      {
        "DisplayList Building": 61,
        "Rasterizing": 255,
        "LayerBuilding": 27,
        "Layer Transactions": 70,
        "Compositing": 2014,
        "Reflowing": 52,
        "Styling": 78,
        "HttpChannelCompletion_Network": 279599,
        "HttpChannelCompletion_Cache": 705
      }
    ],
    
```