### PR TITLE
Fix getting Chrome netlog on Android

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -31,6 +31,7 @@ class Android {
     // Variables for android power testing
     this.screenBrightnessMode = 0;
     this.screenBrightness = 127;
+    this.tmpDir = '/data/local/tmp/';
 
     return this;
   }
@@ -168,7 +169,7 @@ class Android {
   }
 
   async pullNetLog(destination) {
-    const sourcePath = `${this.sdcard}/chromeNetlog.json`;
+    const sourcePath = `${this.tmpDir}netlog.json`;
     log.info(`Pulling netlog from ${this.id}`);
 
     return this._downloadFile(sourcePath, destination);

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -48,7 +48,9 @@ class Chromium {
 
       if (this.chrome.collectNetLog) {
         // The file needs to exist for netlog to work
-        await this.android._runCommand(`touch ${this.androidTmpDir}netlog.json`);
+        await this.android._runCommand(
+          `touch ${this.androidTmpDir}netlog.json`
+        );
       }
     }
   }
@@ -254,11 +256,9 @@ class Chromium {
         pathToFolder(result.url, this.options),
         `chromeNetlog-${index}.json.gz`
       );
-      await this.android.pullNetLog(
-        filename
-      );
+      await this.android.pullNetLog(filename);
 
-      await this.storageManager.gzip(filename, gzFilename, true); 
+      await this.storageManager.gzip(filename, gzFilename, true);
     }
 
     if (this.collectTracingEvents) {

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -32,6 +32,7 @@ class Chromium {
     this.isTracing = false;
     // Keep the HAR file for all runs
     this.hars = [];
+    this.androidTmpDir = '/data/local/tmp/';
   }
 
   /**
@@ -43,6 +44,11 @@ class Chromium {
       this.android = new Android(this.options);
       if (this.options.androidPower) {
         await this.android.startPowerTesting();
+      }
+
+      if (this.chrome.collectNetLog) {
+        // The file needs to exist for netlog to work
+        await this.android._runCommand(`touch ${this.androidTmpDir}netlog.json`);
       }
     }
   }
@@ -237,13 +243,22 @@ class Chromium {
   async afterEachURL(runner, index, result) {
     if (this.chrome.collectNetLog && this.chrome.android) {
       // THIS needs to be unique per page
-      await this.android.pullNetLog(
-        path.join(
-          this.baseDir,
-          pathToFolder(result.url, this.options),
-          `chromeNetlog-${index}.json.gz`
-        )
+      const filename = path.join(
+        this.baseDir,
+        pathToFolder(result.url, this.options),
+        `chromeNetlog-${index}.json`
       );
+
+      const gzFilename = path.join(
+        this.baseDir,
+        pathToFolder(result.url, this.options),
+        `chromeNetlog-${index}.json.gz`
+      );
+      await this.android.pullNetLog(
+        filename
+      );
+
+      await this.storageManager.gzip(filename, gzFilename, true); 
     }
 
     if (this.collectTracingEvents) {

--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -67,10 +67,9 @@ module.exports = function(seleniumOptions, browserOptions, options, baseDir) {
   }
 
   if (browserOptions.collectNetLog) {
-    // FIXME this shouldn't hard code path to external storage
-    const dir = !browserOptions.android ? baseDir : '/sdcard';
-    seleniumOptions.addArguments(`--log-net-log=${dir}/chromeNetlog.json`);
-    seleniumOptions.addArguments('--net-log-capture-mode=0');
+    const dir = !browserOptions.android ? baseDir : '/data/local/tmp';
+    seleniumOptions.addArguments(`--log-net-log=${dir}/netlog.json`);
+    seleniumOptions.addArguments(`--net-log-capture-mode=IncludeSensitive`);
   }
 
   if (browserOptions.android) {


### PR DESCRIPTION
There where a couple of problems:
* storing the net log on the sdcard (move to the tmp data dir)
* if the net log file do not exist when the browser start, Chrome bails out (this must be a Chrome bug on Android, I will create an upstream bug)
* When the file was moved to desktop, it had .gz file ending but was not compressed.