### PR TITLE
Remove android-storage fix for Geckodriver.

### DIFF
--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -41,11 +41,6 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     for (let arg of geckodriverArgs) {
       serviceBuilder.addArguments(arg);
     }
-  } else if (options.android) {
-    // Hack to make sure it works with Geckodriver 28+
-    // See https://github.com/mozilla/geckodriver/issues/1808
-    // and https://bugzilla.mozilla.org/show_bug.cgi?id=1680407
-    serviceBuilder.addArguments('--android-storage', 'sdcard');
   }
 
   builder.setFirefoxService(serviceBuilder);


### PR DESCRIPTION
The root cause is being fixed in:
https://bugzilla.mozilla.org/show_bug.cgi?id=1680407