### PR TITLE
Increased default pageCompleteWaitTime to 8 seconds (from 5)

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -749,7 +749,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .option('pageCompleteWaitTime', {
       describe:
         'How long time you want to wait for your pageComplteteCheck to finish, after it is signaled to closed. Extra parameter passed on to your pageCompleteCheck.',
-      default: 5000
+      default: 8000
     })
     .option('pageCompleteCheckInactivity', {
       describe:


### PR DESCRIPTION
 https://github.com/sitespeedio/browsertime/issues/1486