### PR TITLE
fix #1577 issue with cookies containing equals sign in value

### DIFF
--- a/lib/chrome/chromeDevtoolsProtocol.js
+++ b/lib/chrome/chromeDevtoolsProtocol.js
@@ -131,7 +131,10 @@ class ChromeDevtoolsProtocol {
   async setCookies(url, cookie) {
     const cookies = util.toArray(cookie);
     for (let cookieParts of cookies) {
-      const parts = new Array(cookieParts.slice(0,cookieParts.indexOf("=")),cookieParts.slice(cookieParts.indexOf("=") + 1,cookieParts.length))
+      const parts = new Array(
+        cookieParts.slice(0, cookieParts.indexOf('=')),
+        cookieParts.slice(cookieParts.indexOf('=') + 1, cookieParts.length)
+      );
       await this.cdpClient.Network.setCookie({
         name: parts[0],
         value: parts[1],

--- a/lib/chrome/chromeDevtoolsProtocol.js
+++ b/lib/chrome/chromeDevtoolsProtocol.js
@@ -131,7 +131,7 @@ class ChromeDevtoolsProtocol {
   async setCookies(url, cookie) {
     const cookies = util.toArray(cookie);
     for (let cookieParts of cookies) {
-      const parts = cookieParts.split('=');
+      const parts = new Array(cookieParts.slice(0,cookieParts.indexOf("=")),cookieParts.slice(cookieParts.indexOf("=") + 1,cookieParts.length))
       await this.cdpClient.Network.setCookie({
         name: parts[0],
         value: parts[1],


### PR DESCRIPTION
Cookies with "=" in values are not correctly handled by split(), the following patch fixes #1577 