### PR TITLE
Add firefox memory support to browsertime

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -32,7 +32,8 @@ function getNewResult(url, options) {
       consoleLog: [],
       netLog: [],
       perfLog: [],
-      geckoProfiles: []
+      geckoProfiles: [],
+      memoryReports: []
     },
     markedAsFailure: 0,
     failureMessages: [],
@@ -237,6 +238,7 @@ class Collector {
         );
         const cls = get(data, 'browserScripts.pageinfo.cumulativeLayoutShift');
         const tbt = get(data, 'cpu.longTasks.totalBlockingTime');
+        const mem = get(data, 'memory');
 
         log.info(
           `${url} ${ttfb ? formatMetric('TTFB', ttfb, false, true) + ' ' : ''}${
@@ -260,7 +262,17 @@ class Collector {
               : ''
           }${tbt ? formatMetric('TBT', tbt, false, true) + ' ' : ''}${
             cls ? 'CLS:' + cls.toFixed(4) : ''
-          }`
+          }${
+            mem
+              ? formatMetric(
+                  'Memory',
+                  Math.round(mem / 1024 / 1024),
+                  false,
+                  false
+                ) + 'mb '
+              : ''
+          }
+          `
         );
       }
 
@@ -389,6 +401,18 @@ class Collector {
         results.geckoPerfStats.push(data.perfStats);
       }
 
+      // Add total memory
+      if (this.options.firefox && this.options.firefox.memoryReport) {
+        statistics.addDeep({
+          memory: data.memory
+        });
+
+        if (!results.memory) {
+          results.memory = [];
+        }
+        results.memory.push(data.memory);
+      }
+
       // Add delta to TTFB
       const deltaToTTFB = {};
       const fcp = get(
@@ -460,6 +484,12 @@ class Collector {
       if (this.options.firefox && this.options.firefox.geckoProfiler) {
         results.files.geckoProfiles.push(
           `${pathToFolder(url, this.options)}geckoProfile-${index}.json.gz`
+        );
+      }
+
+      if (this.options.firefox && this.options.firefox.memoryReport) {
+        results.files.memoryReports.push(
+          `${pathToFolder(url, this.options)}memory-report-${index}.json.gz`
         );
       }
 

--- a/lib/firefox/memoryReport.js
+++ b/lib/firefox/memoryReport.js
@@ -1,0 +1,106 @@
+'use strict';
+const path = require('path');
+const pathToFolder = require('../support/pathToFolder');
+const { BrowserError } = require('../support/errors');
+const { isAndroidConfigured, Android } = require('../android');
+const delay = ms => new Promise(res => setTimeout(res, ms));
+
+/**
+ * Timeout a promise after ms. Use promise.race to compete
+ * about the timeout and the promise.
+ * @param {promise} promise - The promise to wait for
+ * @param {int} ms - how long in ms to wait for the promise to fininsh
+ * @param {string} errorMessage - the error message in the Error if we timeouts
+ */
+async function timeout(promise, ms, errorMessage) {
+  let timer = null;
+
+  return Promise.race([
+    new Promise((resolve, reject) => {
+      timer = setTimeout(reject, ms, new BrowserError(errorMessage));
+      return timer;
+    }),
+    promise.then(value => {
+      clearTimeout(timer);
+      return value;
+    })
+  ]);
+}
+
+class MemoryReport {
+  constructor(runner, storageManager, firefoxConfig, options) {
+    this.runner = runner;
+    this.storageManager = storageManager;
+    this.firefoxConfig = firefoxConfig;
+    this.options = options;
+  }
+
+  /**
+   * The memory report parser will measure the total resident memory of the
+   * entire firefox browser.  It does this by summing up the "resident" memory
+   * of the parent process together with the "resident-unique" memory for each
+   * subprocess.
+   */
+  async parse(reportFilename, subDir) {
+    const report = JSON.parse(
+      await this.storageManager.readData(reportFilename, subDir)
+    );
+
+    let memory = 0;
+
+    for (const entry of Object.values(report.reports)) {
+      if (entry.process.startsWith('Main Process')) {
+        if (entry.path === 'resident') {
+          memory += entry.amount;
+        }
+      } else {
+        if (entry.path === 'resident-unique') {
+          memory += entry.amount;
+        }
+      }
+    }
+
+    return memory;
+  }
+
+  async collect(index, url) {
+    const runner = this.runner;
+    const firefoxConfig = this.firefoxConfig;
+    const options = this.options;
+
+    let subDir = pathToFolder(url, options);
+    let profileDir = await this.storageManager.createSubDataDir(subDir);
+
+    let reportFilename = `memory-report-${index}.json.gz`;
+    let destinationFilename = path.join(profileDir, reportFilename);
+
+    let deviceReportFilename = destinationFilename;
+    if (isAndroidConfigured(options)) {
+      deviceReportFilename = `/sdcard/memoryReport-${index}.json`;
+    }
+
+    let minimizeFirst = 'false';
+    if (firefoxConfig.memoryReportParams.minizeFirst) {
+      minimizeFirst = 'true';
+    }
+
+    let script = `Cc['@mozilla.org/memory-info-dumper;1'].getService(Ci.nsIMemoryInfoDumper).dumpMemoryReportsToNamedFile(String.raw\`${deviceReportFilename}\`, null, null, false, ${minimizeFirst});`;
+    await timeout(
+      runner.runPrivilegedScript(script, 'Collecting memory report'),
+      1200000,
+      'Could not get memory report'
+    );
+
+    // Add a delay in case the memory report is still writing to disk.
+    await delay(3000);
+
+    if (isAndroidConfigured(options)) {
+      const android = new Android(options);
+      await android._downloadFile(deviceReportFilename, destinationFilename);
+    }
+
+    return this.parse(reportFilename, subDir);
+  }
+}
+
+module.exports = MemoryReport;

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -13,6 +13,7 @@ const util = require('../../support/util.js');
 const fileUtil = require('../../support/fileUtil.js');
 const getHAR = require('../getHAR');
 const GeckoProfiler = require('../geckoProfiler');
+const MemoryReport = require('../memoryReport');
 const PerfStats = require('../perfStats.js');
 
 class Firefox {
@@ -116,6 +117,16 @@ class Firefox {
     if (this.firefoxConfig.perfStats) {
       result.perfStats = await this.perfStats.collect();
       await this.perfStats.stop();
+    }
+
+    if (this.firefoxConfig.memoryReport) {
+      const memoryReport = new MemoryReport(
+        runner,
+        this.storageManager,
+        this.firefoxConfig,
+        this.options
+      );
+      result.memory = await memoryReport.collect(index, url);
     }
 
     if (this.skipHar || this.options.android) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -403,6 +403,19 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
+    .option('firefox.memoryReport', {
+      describe: 'Measure firefox resident memory after each iteration.',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
+    .option('firefox.memoryReportParams.minizeFirst', {
+      describe:
+        'Force a collection before dumping and measuring the memory report.',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('firefox.geckoProfiler', {
       describe: 'Collect a profile using the internal gecko profiler',
       default: false,

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -37,6 +37,7 @@ module.exports = {
         visualComplete85 = '',
         backEndTime = '',
         lastVisualChange = '',
+        memory = '',
         lcp = '',
         fcp = '',
         cls = '',
@@ -173,6 +174,16 @@ module.exports = {
         backEndTime = this.formatMetric('TTFB', pt.backEndTime, true, true, m);
       }
 
+      if (result.statistics.memory) {
+        let mem = result.statistics.memory;
+        for (let val in mem) {
+          mem[val] = Math.round(mem[val] / 1024 / 1024);
+        }
+
+        memory = this.formatMetric('Memory', mem, true, false, m);
+        memory = memory + 'mb';
+      }
+
       let lines = [
           `${requests}`,
           `${totalSize > 0 ? totalSize : ''}`,
@@ -185,6 +196,7 @@ module.exports = {
           cls,
           tbt,
           pageLoad,
+          memory,
           speedIndex,
           perceptualSpeedIndex,
           contentfulSpeedIndex,


### PR DESCRIPTION
Firefox is capable of dumping a memory report for all of it's processes.  This patch adds support to browsertime to do this after each iteration and then parse the report to measure the total resident memory of the browser.  The memory report is also saved if other details are required instead.  A new option "--firefox.memoryReport" will enable this feature.