### PR TITLE
Check for resultsDir cli option before creating default directory

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -44,9 +44,11 @@ async function preWarmServer(urls, options) {
 
 async function run(urls, options) {
   try {
-    let dir = 'browsertime-results';
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir);
+    if (!options.resultDir) {
+      let dir = 'browsertime-results';
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+      }
     }
 
     let engine = new Engine(options);


### PR DESCRIPTION
I've noticed that the `browsertime-results` directory gets created even if the resultsDir option is passed in the cli. 

So in this PR we check if we have that option before trying to create it. 

I'm even wondering if this creation needs to happen here as in lib/support/storageManager.js it calls mkdir from fs with recursive true so from hat I can see it would try to make it here again. If this is true lines 47 to 52 of browsertime.js can just be removed I guess :) 