### PR TITLE
Add an option to prevent browsertime from setting Firefox default preferences.

### DIFF
--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -83,9 +83,11 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     }
   }
 
-  Object.keys(defaultFirefoxPreferences).forEach(function(pref) {
-    ffOptions.setPreference(pref, defaultFirefoxPreferences[pref]);
-  });
+  if (!firefoxConfig.noPrefs) {
+    Object.keys(defaultFirefoxPreferences).forEach(function(pref) {
+      ffOptions.setPreference(pref, defaultFirefoxPreferences[pref]);
+    });
+  }
 
   if (firefoxConfig.disableSafeBrowsing) {
     Object.keys(disableSafeBrowsingPreferences).forEach(function(pref) {

--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -87,6 +87,8 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     Object.keys(defaultFirefoxPreferences).forEach(function(pref) {
       ffOptions.setPreference(pref, defaultFirefoxPreferences[pref]);
     });
+  } else {
+    log.info('Skip setting default preferences for Firefox');
   }
 
   if (firefoxConfig.disableSafeBrowsing) {

--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -83,7 +83,7 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     }
   }
 
-  if (!firefoxConfig.noPrefs) {
+  if (!firefoxConfig.noDefaultPrefs) {
     Object.keys(defaultFirefoxPreferences).forEach(function(pref) {
       ffOptions.setPreference(pref, defaultFirefoxPreferences[pref]);
     });

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -483,6 +483,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
+    .option('firefox.noPrefs', {
+      describe: 'Prevents browsertime from setting its default preferences.',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('firefox.disableSafeBrowsing', {
       describe: 'Disable safebrowsing.',
       default: true,

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -483,7 +483,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
-    .option('firefox.noPrefs', {
+    .option('firefox.noDefaultPrefs', {
       describe: 'Prevents browsertime from setting its default preferences.',
       default: false,
       type: 'boolean',


### PR DESCRIPTION
This patch adds an option (--firefox.noPrefs) that lets us prevent browsertime from setting default preferences. This solves an issue where settings in an existing profile get overriden by the preferences set in browsertime.