### PR TITLE
Fix to firefox for android profile and memory report serialization

### DIFF
--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -103,11 +103,13 @@ class GeckoProfiler {
 
     let deviceProfileFilename = destinationFilename;
     if (isAndroidConfigured(options)) {
-      deviceProfileFilename = `/sdcard/geckoProfile-${index}.json`;
+      deviceProfileFilename = `/sdcard/Android/data/${this.firefoxConfig.android.package}/files/geckoProfile-${index}.json`;
     }
 
     // Must use String.raw or else the backslashes on Windows will be escapes.
-    log.info(`Collecting Gecko profile in ${destinationFilename}`);
+    log.info(
+      `Collecting Gecko profile from ${deviceProfileFilename} to ${destinationFilename}`
+    );
     const script = `
       var callback = arguments[arguments.length - 1];
        Services.profiler.dumpProfileToFileAsync(String.raw\`${deviceProfileFilename}\`)

--- a/lib/firefox/memoryReport.js
+++ b/lib/firefox/memoryReport.js
@@ -1,4 +1,5 @@
 'use strict';
+const log = require('intel').getLogger('browsertime.firefox');
 const path = require('path');
 const pathToFolder = require('../support/pathToFolder');
 const { BrowserError } = require('../support/errors');
@@ -76,7 +77,7 @@ class MemoryReport {
 
     let deviceReportFilename = destinationFilename;
     if (isAndroidConfigured(options)) {
-      deviceReportFilename = `/sdcard/memoryReport-${index}.json`;
+      deviceReportFilename = `/sdcard/Android/data/${firefoxConfig.android.package}/files/memoryReport-${index}.json`;
     }
 
     let minimizeFirst = 'false';
@@ -84,6 +85,9 @@ class MemoryReport {
       minimizeFirst = 'true';
     }
 
+    log.info(
+      `Collecting memory report from ${deviceReportFilename} to ${destinationFilename}`
+    );
     let script = `Cc['@mozilla.org/memory-info-dumper;1'].getService(Ci.nsIMemoryInfoDumper).dumpMemoryReportsToNamedFile(String.raw\`${deviceReportFilename}\`, null, null, false, ${minimizeFirst});`;
     await timeout(
       runner.runPrivilegedScript(script, 'Collecting memory report'),


### PR DESCRIPTION
On unrooted devices running Android 10 and later, we do no longer have access to the root of `/sdcard`

https://github.com/sitespeedio/browsertime/issues/1662