### PR TITLE
Use the viewport to determine if more cropping is needed.

### DIFF
--- a/browsertime/visualmetrics.py
+++ b/browsertime/visualmetrics.py
@@ -466,7 +466,6 @@ def find_video_viewport(
                     viewport = find_image_viewport(frame)
                 else:
                     viewport = {"x": 0, "y": 0, "width": width, "height": height}
-                    cropped = False
 
                 os.remove(frame)
 

--- a/browsertime/visualmetrics.py
+++ b/browsertime/visualmetrics.py
@@ -752,6 +752,7 @@ def eliminate_duplicate_frames(directory, cropped):
                 height = im_height - bottom_margin
 
             crop = "{0:d}x{1:d}+{2:d}+{3:d}".format(width, height, left, top)
+            logging.debug("Viewport cropping set to " + crop)
 
             # Do a pass looking for the first non-blank frame with an allowance
             # for up to a 10% per-pixel difference for noise in the white


### PR DESCRIPTION
This patch adds a new variable as output from the `find_video_viewport` function that can be used to determine if the frames will be cropped or not. This is then used in the frame de-duplication, and render-start functions to prevent the top of the frame from being cropped out. Before this patch, the top of the test page was being removed and this had caused issues in tests which first showed a banner on the top of the page.

See here for conversations about this issue: https://github.com/sitespeedio/browsertime/commit/cee2030d1ae5a5d354b41fdfa0f61b53ce36b25c