### PR TITLE
Add Python 3.6+ requirement to visualmetrics-portable.py.

### DIFF
--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -137,7 +137,7 @@ def resize(img, width, height):
 def scale(img, maxsize):
     """Scale an image to the given max size."""
     width, height = img.size
-    ratio = min(maxsize / width, maxsize / height)
+    ratio = min(float(maxsize) / width, float(maxsize) / height)
     return resize(img, int(width * ratio), int(height * ratio))
 
 

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -2293,6 +2293,13 @@ def check_config():
         print("FAIL")
         ok = False
 
+    print("Python 3.6+:  ")
+    if sys.version_info >= (3, 6):
+        print("OK")
+    else:
+        print("FAIL")
+        ok = False
+
     print("Numpy:  ")
     try:
         import numpy as np


### PR DESCRIPTION
This patch adds a python 3.6+ requirement to the new `visualmetrics-portable.py` script (it doesn't work with Python 2, and has only been tested in 3.6+). It also fixes a small bug that can happen when `maxsize` is an Integer in the scale method (only used when `--contentful-video` is provided).