### PR TITLE
Remove unused functionality from the visual metrics portable script

### DIFF
--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -405,9 +405,7 @@ def video_to_frames(
                     directories = [directory]
                     for dir in directories:
                         if orange_file is not None:
-                            remove_frames_before_orange(dir, orange_file)
                             remove_orange_frames(dir, orange_file)
-                        blank_first_frame(dir)
                         find_render_start(
                             dir, orange_file, cropped, is_mobile
                         )
@@ -512,32 +510,6 @@ def find_recording_platform(video):
             is_mobile = True
 
     return is_mobile
-
-def remove_frames_before_orange(directory, orange_file):
-    """Remove stray frames from the start of the video"""
-    frames = sorted(glob.glob(os.path.join(directory, "video-*.png")))
-    if len(frames):
-        # go through the first 20 frames and remove any that come before the first orange frame.
-        # iOS video capture starts with a blank white frame and then flips to
-        # orange before starting.
-        logging.debug("Scanning for non-orange frames...")
-        found_orange = False
-        remove_frames = []
-        frame_count = 0
-        for frame in frames:
-            frame_count += 1
-            if is_color_frame(frame, orange_file):
-                found_orange = True
-                break
-            if frame_count > 20:
-                break
-            remove_frames.append(frame)
-
-        if found_orange and len(remove_frames):
-            for frame in remove_frames:
-                logging.debug("Removing pre-orange frame %s", frame)
-                os.remove(frame)
-
 
 def remove_orange_frames(directory, orange_file):
     """Remove orange frames from the beginning of the video"""

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -987,19 +987,6 @@ def eliminate_similar_frames(directory):
     except BaseException:
         logging.exception("Error removing similar frames")
 
-
-def blank_first_frame(directory):
-    try:
-        if options.forceblank:
-            files = sorted(glob.glob(os.path.join(directory, "video-*.png")))
-            count = len(files)
-            if count > 1:
-                blank = blank_frame(files[0])
-                blank.save(files[0])
-    except BaseException:
-        logging.exception("Error blanking first frame")
-
-
 def crop_viewport(directory):
     if client_viewport is not None:
         try:
@@ -2086,12 +2073,6 @@ def main():
         default=0,
         help="Ignore the center X%% of the frame when looking for "
         "the first rendered frame (useful for Opera mini).",
-    )
-    parser.add_argument(
-        "--forceblank",
-        action="store_true",
-        default=False,
-        help="Force the first frame to be blank white.",
     )
     parser.add_argument(
         "--maxframes",

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -421,7 +421,6 @@ def video_to_frames(
                         find_render_start(
                             dir, orange_file, cropped, is_mobile
                         )
-                        find_last_frame(dir, white_file)
                         adjust_frame_times(dir)
                         eliminate_duplicate_frames(dir, cropped, is_mobile)
                         eliminate_similar_frames(dir)
@@ -887,32 +886,6 @@ def find_first_frame(directory, white_file):
                         break
     except BaseException:
         logging.exception("Error finding first frame")
-
-
-def find_last_frame(directory, white_file):
-    logging.debug("Finding Last Frame...")
-    try:
-        if options.endwhite:
-            files = sorted(glob.glob(os.path.join(directory, "video-*.png")))
-            count = len(files)
-            if count > 2:
-                found_end = False
-
-                for i in range(2, count):
-                    if found_end:
-                        logging.debug(
-                            "Removing frame {0} from the end".format(files[i])
-                        )
-                        os.remove(files[i])
-                    if is_white_frame(files[i], white_file):
-                        found_end = True
-                        logging.debug(
-                            "Removing ending white frame {0}".format(files[i])
-                        )
-                        os.remove(files[i])
-    except BaseException:
-        logging.exception("Error finding last frame")
-
 
 def find_render_start(directory, orange_file, cropped, is_mobile):
     logging.debug("Finding Render Start...")
@@ -2308,13 +2281,6 @@ def main():
         help="Find the first fully white frame as the start of the video.",
     )
     parser.add_argument(
-        "--endwhite",
-        action="store_true",
-        default=False,
-        help="Find the first fully white frame after render start as the "
-        "end of the video.",
-    )
-    parser.add_argument(
         "--forceblank",
         action="store_true",
         default=False,
@@ -2436,7 +2402,7 @@ def main():
                         orange_file = os.path.join(colors_temp_dir, "orange.png")
                         generate_orange_png(orange_file)
                 white_file = None
-                if options.white or options.startwhite or options.endwhite:
+                if options.white or options.startwhite:
                     white_file = os.path.join(
                         os.path.dirname(os.path.realpath(__file__)), "white.png"
                     )

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -406,6 +406,7 @@ def video_to_frames(
                     directories = [directory]
                     for dir in directories:
                         if orange_file is not None:
+                            remove_frames_before_orange(dir, orange_file)
                             remove_orange_frames(dir, orange_file)
                         find_render_start(
                             dir, orange_file, cropped, is_mobile
@@ -501,6 +502,31 @@ def find_recording_platform(video):
             is_mobile = True
 
     return is_mobile
+
+def remove_frames_before_orange(directory, orange_file):
+    """Remove stray frames from the start of the video"""
+    frames = sorted(glob.glob(os.path.join(directory, "video-*.png")))
+    if len(frames):
+        # go through the first 20 frames and remove any that come before the first orange frame.
+        # iOS video capture starts with a blank white frame and then flips to
+        # orange before starting.
+        logging.debug("Scanning for non-orange frames...")
+        found_orange = False
+        remove_frames = []
+        frame_count = 0
+        for frame in frames:
+            frame_count += 1
+            if is_color_frame(frame, orange_file):
+                found_orange = True
+                break
+            if frame_count > 20:
+                break
+            remove_frames.append(frame)
+
+        if found_orange and len(remove_frames):
+            for frame in remove_frames:
+                logging.debug("Removing pre-orange frame %s", frame)
+                os.remove(frame)
 
 def remove_orange_frames(directory, orange_file):
     """Remove orange frames from the beginning of the video"""

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -634,7 +634,6 @@ def find_video_viewport(
     video,
     directory,
     find_viewport,
-
     viewport_retries,
     viewport_min_height,
     viewport_min_width,

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -816,23 +816,7 @@ def adjust_frame_times(directory):
 def find_first_frame(directory, white_file):
     logging.debug("Finding First Frame...")
     try:
-        if options.startwhite:
-            files = sorted(glob.glob(os.path.join(directory, "video-*.png")))
-            count = len(files)
-            if count > 1:
-                from PIL import Image
-
-                for i in range(count):
-                    if is_white_frame(files[i], white_file):
-                        break
-                    else:
-                        logging.debug(
-                            "Removing non-white frame {0} from the beginning".format(
-                                files[i]
-                            )
-                        )
-                        os.remove(files[i])
-        elif options.findstart > 0 and options.findstart <= 100:
+        if options.findstart > 0 and options.findstart <= 100:
             files = sorted(glob.glob(os.path.join(directory, "video-*.png")))
             count = len(files)
             if count > 1:
@@ -2275,12 +2259,6 @@ def main():
         "the first rendered frame (useful for Opera mini).",
     )
     parser.add_argument(
-        "--startwhite",
-        action="store_true",
-        default=False,
-        help="Find the first fully white frame as the start of the video.",
-    )
-    parser.add_argument(
         "--forceblank",
         action="store_true",
         default=False,
@@ -2402,7 +2380,7 @@ def main():
                         orange_file = os.path.join(colors_temp_dir, "orange.png")
                         generate_orange_png(orange_file)
                 white_file = None
-                if options.white or options.startwhite:
+                if options.white:
                     white_file = os.path.join(
                         os.path.dirname(os.path.realpath(__file__)), "white.png"
                     )

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -37,19 +37,15 @@ import json
 import logging
 import math
 import os
-import platform
 import re
 import sys
 import shutil
 import subprocess
 import tempfile
 
-if sys.version_info > (3, 0):
-    GZIP_TEXT = "wt"
-    GZIP_READ_TEXT = "rt"
-else:
-    GZIP_TEXT = "w"
-    GZIP_READ_TEXT = "r"
+
+GZIP_TEXT = "wt"
+GZIP_READ_TEXT = "rt"
 
 # Globals
 options = None

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -1978,12 +1978,6 @@ def main():
         help="Save the last frame of video as an image to the path provided.",
     )
     parser.add_argument(
-        "-g",
-        "--histogram",
-        help="Histogram file (as input if exists or as output if "
-        "histograms need to be calculated).",
-    )
-    parser.add_argument(
         "-q",
         "--quality",
         type=int,
@@ -2114,7 +2108,6 @@ def main():
         not options.check
         and not options.dir
         and not options.video
-        and not options.histogram
     ):
         parser.error(
             "A video, Directory of images or histograms file needs to be provided.\n\n"
@@ -2133,10 +2126,7 @@ def main():
     directory = temp_dir
     if options.dir is not None:
         directory = options.dir
-    if options.histogram is not None:
-        histogram_file = options.histogram
-    else:
-        histogram_file = os.path.join(temp_dir, "histograms.json.gz")
+    histogram_file = os.path.join(temp_dir, "histograms.json.gz")
 
     # Set up logging
     log_level = logging.CRITICAL

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -363,7 +363,6 @@ def video_to_frames(
     force,
     orange_file,
     white_file,
-    gray_file,
     multiple,
     find_viewport,
     viewport_time,
@@ -425,7 +424,7 @@ def video_to_frames(
                         find_first_frame(dir, white_file)
                         blank_first_frame(dir)
                         find_render_start(
-                            dir, orange_file, gray_file, cropped, is_mobile
+                            dir, orange_file, cropped, is_mobile
                         )
                         find_last_frame(dir, white_file)
                         adjust_frame_times(dir)
@@ -967,7 +966,7 @@ def find_last_frame(directory, white_file):
         logging.exception("Error finding last frame")
 
 
-def find_render_start(directory, orange_file, gray_file, cropped, is_mobile):
+def find_render_start(directory, orange_file, cropped, is_mobile):
     logging.debug("Finding Render Start...")
     try:
         if (
@@ -1039,9 +1038,6 @@ def find_render_start(directory, orange_file, gray_file, cropped, is_mobile):
                         files[i], orange_file
                     ):
                         logging.debug("Removing orange frame %s", files[i])
-                        os.remove(files[i])
-                    elif gray_file is not None and is_color_frame(files[i], gray_file):
-                        logging.debug("Removing gray frame %s", files[i])
                         os.remove(files[i])
                     else:
                         break
@@ -1413,20 +1409,6 @@ def generate_orange_png(orange_file):
         im.save(orange_file, "PNG")
     except BaseException:
         logging.exception("Error generating orange png " + orange_file)
-
-
-def generate_gray_png(gray_file):
-    try:
-        from PIL import Image, ImageDraw
-
-        im = Image.new("RGB", (200, 200))
-        draw = ImageDraw.Draw(im)
-        draw.rectangle([0, 0, 200, 200], fill=(128, 128, 128))
-        del draw
-        im.save(gray_file, "PNG")
-    except BaseException:
-        logging.exception("Error generating gray png " + gray_file)
-
 
 def generate_white_png(white_file):
     try:
@@ -2447,12 +2429,6 @@ def main():
         help="Remove orange-colored frames from the beginning of the video.",
     )
     parser.add_argument(
-        "--gray",
-        action="store_true",
-        default=False,
-        help="Remove gray-colored frames from the beginning of the video.",
-    )
-    parser.add_argument(
         "-w",
         "--white",
         action="store_true",
@@ -2685,21 +2661,12 @@ def main():
                     if not os.path.isfile(white_file):
                         white_file = os.path.join(colors_temp_dir, "white.png")
                         generate_white_png(white_file)
-                gray_file = None
-                if options.gray:
-                    gray_file = os.path.join(
-                        os.path.dirname(os.path.realpath(__file__)), "gray.png"
-                    )
-                    if not os.path.isfile(gray_file):
-                        gray_file = os.path.join(colors_temp_dir, "gray.png")
-                        generate_gray_png(gray_file)
                 video_to_frames(
                     options.video,
                     directory,
                     options.force,
                     orange_file,
                     white_file,
-                    gray_file,
                     options.multiple,
                     options.viewport,
                     options.viewporttime,

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -364,7 +364,6 @@ def video_to_frames(
     orange_file,
     white_file,
     find_viewport,
-    viewport_time,
     viewport_retries,
     viewport_min_height,
     viewport_min_width,
@@ -391,7 +390,6 @@ def video_to_frames(
                     video,
                     directory,
                     find_viewport,
-                    viewport_time,
                     viewport_retries,
                     viewport_min_height,
                     viewport_min_width,
@@ -647,7 +645,7 @@ def find_video_viewport(
     video,
     directory,
     find_viewport,
-    viewport_time,
+
     viewport_retries,
     viewport_min_height,
     viewport_min_width,
@@ -691,8 +689,6 @@ def find_video_viewport(
                 os.remove(frame)
 
             command = ["ffmpeg", "-i", video]
-            if viewport_time:
-                command.extend(["-ss", viewport_time])
 
             # Pull one frame from the video starting with the frame at
             # the `retries` index
@@ -2115,12 +2111,6 @@ def main():
         help="Locate and use the viewport from the first video frame.",
     )
     parser.add_argument(
-        "-t",
-        "--viewporttime",
-        help="Time of the video frame to use for identifying the viewport "
-        "(in HH:MM:SS.xx format).",
-    )
-    parser.add_argument(
         "--viewportretries",
         type=int,
         default=5,
@@ -2293,7 +2283,6 @@ def main():
                     orange_file,
                     white_file,
                     options.viewport,
-                    options.viewporttime,
                     options.viewportretries,
                     options.viewportminheight,
                     options.viewportminwidth,

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -368,8 +368,7 @@ def video_to_frames(
     viewport_retries,
     viewport_min_height,
     viewport_min_width,
-    full_resolution,
-    trim_end,
+    full_resolution
 ):
     """Extract the video frames"""
     global client_viewport
@@ -412,7 +411,6 @@ def video_to_frames(
                         )
                     directories = [directory]
                     for dir in directories:
-                        trim_video_end(dir, trim_end)
                         if orange_file is not None:
                             remove_frames_before_orange(dir, orange_file)
                             remove_orange_frames(dir, orange_file)
@@ -765,32 +763,6 @@ def find_video_viewport(
         viewport = None
 
     return viewport, cropped
-
-
-def trim_video_end(directory, trim_time):
-    if trim_time > 0:
-        logging.debug(
-            "Trimming "
-            + str(trim_time)
-            + "ms from the end of the video in "
-            + directory
-        )
-        frames = sorted(glob.glob(os.path.join(directory, "video-*.png")))
-        if len(frames):
-            match = re.compile(r"video-(?P<ms>[0-9]+)\.png")
-            m = re.search(match, frames[-1])
-            if m is not None:
-                frame_time = int(m.groupdict().get("ms"))
-                end_time = frame_time - trim_time
-                logging.debug("Trimming frames before " + str(end_time) + "ms")
-                for frame in frames:
-                    m = re.search(match, frame)
-                    if m is not None:
-                        frame_time = int(m.groupdict().get("ms"))
-                        if frame_time > end_time:
-                            logging.debug("Trimming frame " + frame)
-                            os.remove(frame)
-
 
 def adjust_frame_times(directory):
     offset = None
@@ -2265,12 +2237,6 @@ def main():
         help="Force the first frame to be blank white.",
     )
     parser.add_argument(
-        "--trimend",
-        type=int,
-        default=0,
-        help="Time to trim from the end of the video (in milliseconds).",
-    )
-    parser.add_argument(
         "--maxframes",
         type=int,
         default=0,
@@ -2399,7 +2365,6 @@ def main():
                     options.viewportminheight,
                     options.viewportminwidth,
                     options.full,
-                    options.trimend,
                 )
             
             if options.render is not None:

--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -457,10 +457,8 @@ def extract_frames(video, directory, full_resolution, viewport):
         ]
         logging.debug(" ".join(command))
         lines = []
-        if sys.version_info > (3, 0):
-            proc = subprocess.Popen(command, stderr=subprocess.PIPE, encoding="UTF-8")
-        else:
-            proc = subprocess.Popen(command, stderr=subprocess.PIPE)
+
+        proc = subprocess.Popen(command, stderr=subprocess.PIPE, encoding="UTF-8")
         while proc.poll() is None:
             lines.extend(iter(proc.stderr.readline, ""))
 
@@ -491,10 +489,7 @@ def find_recording_platform(video):
     logging.debug(command)
 
     lines = []
-    if sys.version_info > (3, 0):
-        proc = subprocess.Popen(command, stderr=subprocess.PIPE, encoding="UTF-8")
-    else:
-        proc = subprocess.Popen(command, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(command, stderr=subprocess.PIPE, encoding="UTF-8")
 
     while proc.poll() is None:
         lines.extend(iter(proc.stderr.readline, ""))
@@ -977,14 +972,7 @@ def crop_viewport(directory):
 def get_decimate_filter():
     decimate = None
     try:
-        if sys.version_info > (3, 0):
-            filters = subprocess.check_output(
-                ["ffmpeg", "-filters"], stderr=subprocess.STDOUT, encoding="UTF-8"
-            )
-        else:
-            filters = subprocess.check_output(
-                ["ffmpeg", "-filters"], stderr=subprocess.STDOUT
-            )
+        filters = subprocess.check_output(["ffmpeg", "-filters"], stderr=subprocess.STDOUT, encoding="UTF-8")
         lines = filters.split("\n")
         match = re.compile(
             r"(?P<filter>[\w]*decimate).*V->V.*Remove near-duplicate frames"
@@ -1791,13 +1779,8 @@ def check_config():
 
 def check_process(command, output):
     ok = False
-    try:
-        if sys.version_info > (3, 0):
-            out = subprocess.check_output(
-                command, stderr=subprocess.STDOUT, shell=True, encoding="UTF-8"
-            )
-        else:
-            out = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
+    try:   
+        out = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True, encoding="UTF-8")
         if out.find(output) > -1:
             ok = True
     except BaseException:

--- a/lib/video/postprocessing/visualmetrics/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/visualMetrics.js
@@ -79,10 +79,6 @@ module.exports = {
       scriptArgs.push('--perceptual');
     }
 
-    if (options.visualMetricsNotification) {
-      scriptArgs.push('--notification');
-    }
-
     if (options.visualMetricsContentful) {
       scriptArgs.push('--contentful');
     }


### PR DESCRIPTION
Remove the following:
* --gray (remove gray frames that was an old fix for a Chrome bug)
* --timeline that synced with trace from Chrome
* The functionality to use a video with multiple navigations and split that
* Remove white frames at the end
* Remove that the navigation could start white
* Remove the possibility to trim the end of the video
*  --findstart
* --viewporttime
* --white option
* --forceblank
* Gzip option for Python 2
* --histogram option
* Removing remove frames before first orange
* --maxframes
* --notification
* functionality to generate a new video from the frames