### PR TITLE
Issue #1753: Handle negative x/y offsets when cropping images.

### DIFF
--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -108,6 +108,11 @@ def crop_im(img, crop_x, crop_y, crop_x_offset, crop_y_offset, gravity=None):
         base_x += crop_x_offset
         base_y += crop_y_offset
 
+        # Take the maximum in case the offset was negative, and
+        # smaller than the base position
+        base_x = max(base_x, 0)
+        base_y = max(base_y, 0)
+
         return Image.fromarray(
             img[base_y : base_y + crop_y, base_x : base_x + crop_x, :]
         )


### PR DESCRIPTION
This patch fixes an issue where the hero element has a negative x/y offset that was not being handled correctly. With this change, when a negative offset causes the starting indices to go negative we set the base position to 0.