### PR TITLE
Add an acceptable error of 5 pixels to last frame matches.

### DIFF
--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -1129,7 +1129,7 @@ def eliminate_duplicate_frames(directory, cropped, is_mobile):
                 baseline = files[0]
                 previous_frame = baseline
                 for i in range(1, count):
-                    if frames_match(baseline, files[i], 15, 0, crop, None):
+                    if frames_match(baseline, files[i], 15, 5, crop, None):
                         if previous_frame is baseline:
                             duplicates.append(previous_frame)
                         else:


### PR DESCRIPTION
This patch adds an extra 5 pixel buffer to the last frame matches to handle an issue where the frames previously matched but are currently mismatched by a few pixels which causes regressions in the LastVisualChange metric.