### PR TITLE
Get Largest Contentful Paint from the video if the browser supports the API

### DIFF
--- a/browserscripts/pageinfo/visualElements.js
+++ b/browserscripts/pageinfo/visualElements.js
@@ -125,6 +125,21 @@
     }
   });
 
+  // If the browser support largest contentful paint, get that element as well
+  const supported = PerformanceObserver.supportedEntryTypes;
+  if (supported && supported.indexOf('largest-contentful-paint') > -1) {
+    const observer = new PerformanceObserver(list => {});
+    observer.observe({ type: 'largest-contentful-paint', buffered: true });
+    const entries = observer.takeRecords();
+    if (entries.length > 0) {
+      const largestEntry = entries[entries.length - 1];
+      if (isElementPartlyInViewportAndVisible(largestEntry.element)) { 
+        keepLargestElementByType('largestContentfulPaint', largestEntry.element);
+      }
+    }
+  }
+
+
   // We need to follow the standard for VisualMetrics
   return {
     viewport: {

--- a/browserscripts/pageinfo/visualElements.js
+++ b/browserscripts/pageinfo/visualElements.js
@@ -134,7 +134,7 @@
     if (entries.length > 0) {
       const largestEntry = entries[entries.length - 1];
       if (isElementPartlyInViewportAndVisible(largestEntry.element)) { 
-        keepLargestElementByType('largestContentfulPaint', largestEntry.element);
+        keepLargestElementByType('LargestContentfulPaint', largestEntry.element);
       }
     }
   }


### PR DESCRIPTION
This will be an extra bonus for the Chrome team to be able to verify that the Largest Contentful Paint is correct. You can thank me by supporting https://opencollective.com/sitespeedio

See https://bugs.chromium.org/p/chromium/issues/detail?id=1291502