### PR TITLE
Add a debug mode to browsertime with abitrary pausing.

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { hotkeys } = require('hotkeys-js');
+
 const webdriver = require('selenium-webdriver');
 const log = require('intel').getLogger('browsertime');
 const SeleniumRunner = require('../seleniumRunner');
@@ -244,7 +246,11 @@ class Iteration {
       }
 
       await engineDelegate.beforeBrowserStop(browser, index, result);
-      await browser.stop();
+
+      if (!options.debug) {
+        await browser.stop();
+      }
+
       // Give the browsers some time to stop
       await delay(2000);
       await engineDelegate.afterBrowserStopped();
@@ -329,7 +335,9 @@ class Iteration {
         if (options.connectivity.variance) {
           await removeConnectivity(options);
         }
-        await browser.stop();
+        if (!options.debug) {
+          await browser.stop();
+        }
       } catch (e) {
         // Most cases the browser been stopped already
       }

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -83,7 +83,7 @@ class Iteration {
     if (!this.pause) {
       return;
     }
-    log.info("Execution paused, press CTRL+SHIFT+G to continue...");
+    log.info("Execution paused, press CTRL+ALT+G to continue...");
     while (this.pause) {
       await commands.wait.byTime(2000);
     }

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { hotkeys } = require('hotkeys-js');
+const { uIOhook, UiohookKey } = require('uiohook-napi');
 
 const webdriver = require('selenium-webdriver');
 const log = require('intel').getLogger('browsertime');
@@ -76,6 +76,18 @@ class Iteration {
     this.engineDelegate = engineDelegate;
     this.scriptsByCategory = scriptsByCategory;
     this.asyncScriptsByCategory = asyncScriptsByCategory;
+    this.pause = false;
+  }
+
+  async pauseIteration(commands) {
+    if (!this.pause) {
+      return;
+    }
+    log.info("Execution paused, press CTRL+SHIFT+G to continue...");
+    while (this.pause) {
+      await commands.wait.byTime(2000);
+    }
+    log.info("Execution unpaused")
   }
 
   /**
@@ -102,6 +114,18 @@ class Iteration {
 
     const extensionServer = new ExtensionServer(options);
     const engineDelegate = this.engineDelegate;
+
+    // Add a CTRL+SHIFT+G hotkey to pause execution when in debug mode
+    uIOhook.on('keyup', (e) => {
+      if (!this.options.debug) {
+        return;
+      }
+      if (e.keycode === UiohookKey.G && e.altKey && e.ctrlKey) {
+        log.info("Pausing execution as soon as we can, press CTRL+ALT+G to continue...")
+        this.pause = !this.pause;
+      }
+    })
+    uIOhook.start()
 
     try {
       if (options.flushDNS) {
@@ -181,7 +205,8 @@ class Iteration {
           doubleClick: new DoubleClick(browser, this.pageCompleteCheck),
           clickAndHold: new ClickAndHold(browser)
         },
-        select: new Select(browser)
+        select: new Select(browser),
+        pauseIteration: this.pauseIteration.bind(this)
       };
 
       // Safari can't load data:text URLs at startup, so you can either choose
@@ -233,6 +258,9 @@ class Iteration {
         );
         await commands.measure.stop();
       }
+
+      // Pause the iteration if requested
+      await this.pauseIteration();
 
       for (const postScript of this.postScripts) {
         await postScript(context, commands);

--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -199,6 +199,11 @@ module.exports.configureBuilder = function (builder, baseDir, options) {
     }
   }
 
+  if (options.debug) {
+    ffOptions.addArguments("--devtools");
+    ffOptions.setPreference("detach", true);
+  }
+
   if (options.headless) {
     ffOptions.headless();
   }

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -1260,6 +1260,13 @@ module.exports.parseCommandLine = function parseCommandLine() {
     set(argv, 'visualMetrics', get(argv, 'visualMetrics', true));
   }
 
+  // Set the timeouts to a maximum while debugging
+  if (argv.debug) {
+    set(argv, 'timeouts.pageload', 2147483647);
+    set(argv, 'timeouts.script', 2147483647);
+    set(argv, 'timeouts.pageCompleteCheck', 2147483647);
+  }
+
   return {
     urls: argv._,
     options: argv

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -1159,6 +1159,13 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'The wait time before you start the real testing after your pre-cache request.'
     })
+    .option('debug', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'This will leave the browser open after the test finishes and enables the CTRL+SHIFT+D pause/resume mechanism.',
+      group: 'debug'
+    })
 
     .count('verbose')
     .config(config)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "find-up": "5.0.0",
         "get-port": "5.1.1",
         "hasbin": "1.2.3",
+        "hotkeys-js": "^3.9.3",
         "intel": "1.2.0",
         "lodash.get": "4.4.2",
         "lodash.groupby": "4.6.0",
@@ -2893,6 +2894,11 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "node_modules/hotkeys-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.3.tgz",
+      "integrity": "sha512-s+f0xyvDmf6+DyrFQ2SY+eA7lbvMbjqkqi0I0SpMgnN5tZx7DeH8nsWhkJR4KEq3pxDPHJppDUhdt1rZFW5LeQ=="
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -7301,6 +7307,11 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
+    },
+    "hotkeys-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.3.tgz",
+      "integrity": "sha512-s+f0xyvDmf6+DyrFQ2SY+eA7lbvMbjqkqi0I0SpMgnN5tZx7DeH8nsWhkJR4KEq3pxDPHJppDUhdt1rZFW5LeQ=="
     },
     "human-signals": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "find-up": "5.0.0",
         "get-port": "5.1.1",
         "hasbin": "1.2.3",
-        "hotkeys-js": "^3.9.3",
         "intel": "1.2.0",
         "lodash.get": "4.4.2",
         "lodash.groupby": "4.6.0",
@@ -2895,11 +2894,6 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
-    "node_modules/hotkeys-js": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.3.tgz",
-      "integrity": "sha512-s+f0xyvDmf6+DyrFQ2SY+eA7lbvMbjqkqi0I0SpMgnN5tZx7DeH8nsWhkJR4KEq3pxDPHJppDUhdt1rZFW5LeQ=="
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -7330,11 +7324,6 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
-    },
-    "hotkeys-js": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.3.tgz",
-      "integrity": "sha512-s+f0xyvDmf6+DyrFQ2SY+eA7lbvMbjqkqi0I0SpMgnN5tZx7DeH8nsWhkJR4KEq3pxDPHJppDUhdt1rZFW5LeQ=="
     },
     "human-signals": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "lodash.pick": "4.4.0",
         "lodash.set": "4.3.2",
         "selenium-webdriver": "4.1.2",
+        "uiohook-napi": "^1.1.0",
         "yargs": "17.4.1"
       },
       "bin": {
@@ -3591,6 +3592,16 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
@@ -4890,6 +4901,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uiohook-napi": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.1.0.tgz",
+      "integrity": "sha512-wZUHje4BARjPnkNXic7yyBpIRfWSfxBLFnUXIdfFeHnA+YpWL97F0WsC/o9AlIJhJ9q16bWypeLNsfpI86K/rg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "4.x.x"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/universalify": {
@@ -7827,6 +7850,11 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
+    "node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
+    },
     "node-stream-zip": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
@@ -8754,6 +8782,14 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "uiohook-napi": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.1.0.tgz",
+      "integrity": "sha512-wZUHje4BARjPnkNXic7yyBpIRfWSfxBLFnUXIdfFeHnA+YpWL97F0WsC/o9AlIJhJ9q16bWypeLNsfpI86K/rg==",
+      "requires": {
+        "node-gyp-build": "4.x.x"
+      }
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash.pick": "4.4.0",
     "lodash.set": "4.3.2",
     "selenium-webdriver": "4.1.2",
+    "uiohook-napi": "^1.1.0",
     "yargs": "17.4.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "find-up": "5.0.0",
     "get-port": "5.1.1",
     "hasbin": "1.2.3",
-    "hotkeys-js": "^3.9.3",
     "intel": "1.2.0",
     "lodash.get": "4.4.2",
     "lodash.groupby": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "find-up": "5.0.0",
     "get-port": "5.1.1",
     "hasbin": "1.2.3",
+    "hotkeys-js": "^3.9.3",
     "intel": "1.2.0",
     "lodash.get": "4.4.2",
     "lodash.groupby": "4.6.0",
@@ -38,8 +39,8 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.6.2",
-    "serve-handler": "6.1.3",
-    "serve": "13.0.2"
+    "serve": "13.0.2",
+    "serve-handler": "6.1.3"
   },
   "engines": {
     "node": ">=14.19.1"


### PR DESCRIPTION
This patch adds a --debug flag that can be used to enter debug mode. This mode enables a hotkey `ctrl+alt+g` which can be used to pause execution after the iteration is complete. It's also exposed in the test script so it can be used by custom test scripts as they may perform their own iterations.

Furthermore, when in --debug mode the Firefox browser will be detached from the terminal and open the devtools panel by default.