### PR TITLE
Add a hidden option to store url as hash.

### DIFF
--- a/lib/support/pathToFolder.js
+++ b/lib/support/pathToFolder.js
@@ -42,9 +42,11 @@ module.exports = function (url, options) {
       }
 
       // This is used from sitespeed.io to match URLs on Graphite
-      if (!options.storeURLsAsFlatPageOnDisk) {
-        pathSegments.push(...urlSegments);
-      } else {
+      if (options.storeURLsAsHash) {
+        const md5 = crypto.createHash('md5')
+        const hash = md5.update(url).digest('hex').substring(0, 8);
+        pathSegments.push(hash);
+      } else if (options.storeURLsAsFlatPageOnDisk) {
         const folder = toSafeKey(urlSegments.join('_').concat('_'));
         if (folder.length > 255) {
           log.info(
@@ -54,6 +56,8 @@ module.exports = function (url, options) {
         } else {
           pathSegments.push(folder);
         }
+      } else {
+        pathSegments.push(...urlSegments);
       }
     }
 


### PR DESCRIPTION
This patch adds an option to use the hash of the url as the folder path instead of the url itself. This helps with an issue we are having on Windows where the path-character limit is being exceeded and the work-arounds offered by Microsoft don't fix it.