### PR TITLE
Move mozlog collection to postWork method.

### DIFF
--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -104,19 +104,6 @@ class Firefox {
    */
   async afterPageCompleteCheck(runner, index, url, alias) {
     const result = { url, alias };
-    if (this.firefoxConfig.collectMozLog) {
-      const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
-      for (const file of files) {
-        await rename(
-          `${this.baseDir}/${file}`,
-          path.join(
-            this.baseDir,
-            pathToFolder(result.url, this.options),
-            `${file}-${index}.txt`
-          )
-        );
-      }
-    }
 
     if (this.android && this.options.androidPower) {
       result.power = await this.android.measurePowerUsage(
@@ -192,6 +179,20 @@ class Firefox {
 
   async postWork(index, results) {
     for (let i = 0; i < results.length; i++) {
+      if (this.firefoxConfig.collectMozLog) {
+        const files = await fileUtil.findFiles(this.baseDir, 'moz_log.txt');
+        for (const file of files) {
+          await rename(
+            `${this.baseDir}/${file}`,
+            path.join(
+              this.baseDir,
+              pathToFolder(results[i].url, this.options),
+              `${file}-${index}.txt`
+            )
+          );
+        }
+      }
+
       if (this.firefoxConfig.geckoProfiler && this.options.visualMetrics) {
         const profileFilename = `geckoProfile-${index}.json.gz`;
         const profileSubdir = pathToFolder(results[i].url, this.options);


### PR DESCRIPTION
This patch moves the Firefox mozlog collection to the postWork method. This fixes an issue where we were trying to move the moz logs while they were still being written to. This issue exists on Linux, and Mac as well but we don't get an error there when we do the renaming/moving.

This fixes issue #1765.