### PR TITLE
Add extra delay when Firefox Window recorder stops

### DIFF
--- a/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
+++ b/lib/video/screenRecording/firefox/firefoxWindowRecorder.js
@@ -7,6 +7,7 @@ const path = require('path');
 const execa = require('execa');
 const { removeDirAndFiles } = require('../../../support/fileUtil');
 const { Android } = require('../../../android');
+const delay = ms => new Promise(res => setTimeout(res, ms));
 
 const unlink = util.promisify(fs.unlink);
 
@@ -173,6 +174,9 @@ module.exports = class FirefoxWindowRecorder {
   async stop(destination) {
     log.info('Stop firefox window recorder.');
     await enableWindowRecorder(false, this.browser);
+
+    // Add some extra delay to make sure the recording is finished.
+    await delay(this.options.firefox.windowRecorderStopDelay || 1000);
 
     if (this.options.android) {
       const fullPathOnSdCard = this.android.getFullPathOnSdCard(


### PR DESCRIPTION
If the Firefox Window recorder is used in https://bugzilla.mozilla.org/show_bug.cgi?id=1773127 this could potentially fix that. If that's the case, there's something in the code in the window recorder that do not work as it should, since the video should stop before we start to collect metrics.