### PR TITLE
Exit after maxLoadTime if the loadEventEnd do not happen.

### DIFF
--- a/lib/core/pageCompleteChecks/defaultPageCompleteCheck.js
+++ b/lib/core/pageCompleteChecks/defaultPageCompleteCheck.js
@@ -1,10 +1,16 @@
 'use strict';
 module.exports = `
-return (function(waitTime) {
+return (function(options) {
     try { 
-            var end = window.performance.timing.loadEventEnd;
-            var start= window.performance.timing.navigationStart;
-            return (end > 0) && (performance.now() > end - start + waitTime);
+            const end = window.performance.timing.loadEventEnd;
+            const start = window.performance.timing.navigationStart;
+            const maxLoadTime = options.maxLoadTime || 60 * 1000;
+            const waitTime = options.waitTime || 5 * 1000;
+            if (performance.now() > maxLoadTime) {
+                return true;
+            } else {
+                return (end > 0) && (performance.now() > end - start + waitTime);
+            }
     } 
     catch(e) {
         return true;

--- a/lib/core/pageCompleteChecks/pageCompleteCheckByInactivity.js
+++ b/lib/core/pageCompleteChecks/pageCompleteCheckByInactivity.js
@@ -1,10 +1,10 @@
 'use strict';
 
 module.exports = `
-return (function(waitTime) {
+return (function(options) {
   const timing = window.performance.timing;
   const p = window.performance;
-  const limit = waitTime;
+  const limit = options.waitTime;
 
   if (timing.loadEventEnd === 0) {
     return false;

--- a/lib/core/pageCompleteChecks/spaInactivity.js
+++ b/lib/core/pageCompleteChecks/spaInactivity.js
@@ -1,13 +1,13 @@
 'use strict';
 
 module.exports = `
-return (function(waitTime) {
+return (function(options) {
   const timing = window.performance.timing;
   const p = window.performance;
   const resourceTimings = p.getEntriesByType('resource');
   if (resourceTimings.length > 0) {
     const lastEntry = resourceTimings.pop();
-    const stop = p.now() - lastEntry.responseEnd > waitTime;
+    const stop = p.now() - lastEntry.responseEnd > options.waitTime;
     if (stop) {
       // empty resource timings for the next run
       p.clearResourceTimings();

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -143,6 +143,7 @@ class SeleniumRunner {
    */
   async wait(pageCompleteCheck, url) {
     const waitTime = this.options.pageCompleteWaitTime || 5000;
+    const maxLoadTime = this.options.pageMaxLoadTime || 2 * 60 * 1000;
     if (!pageCompleteCheck) {
       pageCompleteCheck = this.options.pageCompleteCheckInactivity
         ? pageCompleteCheckByInactivity
@@ -160,7 +161,7 @@ class SeleniumRunner {
         'for page complete check script to return true',
         function (d) {
           return d
-            .executeScript(pageCompleteCheck, waitTime)
+            .executeScript(pageCompleteCheck, { waitTime, maxLoadTime })
             .then(function (t) {
               log.verbose('PageCompleteCheck returned %s', t);
               return t === true;


### PR DESCRIPTION
We got users (and I've seen this myself on the test server) that for some URLs we hit the max timeout time configured for the pageCompleteCheck (5 minutes), that means we get an error and the test fails. However it seems that some sites never fires the loadEventEnd, so this fix ends the tests after 2 minutes (or configurable) if loadEventEnd do not happen.

@gmierz I don't think this will have any effect on your tests, but wanted to verify that I'm on the right path. I do wanna cleanup with with all those timouts but I'll save that for after the summer.
