### PR TITLE
Add max load time.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -5,7 +5,11 @@ const merge = require('lodash.merge');
 const get = require('lodash.get');
 const { Condition } = require('selenium-webdriver/lib/webdriver');
 const { isAndroidConfigured } = require('../android');
-const { UrlLoadError, BrowserError } = require('../support/errors');
+const {
+  UrlLoadError,
+  BrowserError,
+  TimeoutError
+} = require('../support/errors');
 const builder = require('./webdriver');
 const getViewPort = require('../support/getViewPort');
 const defaultPageCompleteCheck = require('./pageCompleteChecks/defaultPageCompleteCheck');
@@ -18,7 +22,7 @@ const defaults = {
     pageLoad: 300000,
     script: 120000,
     logs: 90000,
-    pageCompleteCheck: 300000
+    pageCompleteCheck: 60000
   },
   index: 0
 };
@@ -36,7 +40,7 @@ async function timeout(promise, ms, errorMessage) {
 
   return Promise.race([
     new Promise((resolve, reject) => {
-      timer = setTimeout(reject, ms, new BrowserError(errorMessage));
+      timer = setTimeout(reject, ms, new TimeoutError(errorMessage));
       return timer;
     }),
     promise.then(value => {
@@ -182,20 +186,26 @@ class SeleniumRunner {
         `Running page complete check ${pageCompleteCheck} took too long`
       );
     } catch (e) {
-      log.error(
-        `Failed waiting on page ${
-          url ? url : ''
-        } to finished loading, timed out after ${pageCompleteCheckTimeout} ms`,
-        e
-      );
-      throw new UrlLoadError(
-        `Failed waiting on page ${
-          url ? url : ''
-        }  to finished loading, timed out after ${pageCompleteCheckTimeout} ms `,
-        {
-          cause: e
-        }
-      );
+      if (e instanceof TimeoutError) {
+        log.info(
+          `The page did not finishied loading in ${pageCompleteCheckTimeout} ms. You can adjust the timeout by setting the --maxLoadTime option (in ms).`
+        );
+      } else {
+        log.error(
+          `Failed waiting on page ${
+            url ? url : ''
+          } to finished loading, timed out after ${pageCompleteCheckTimeout} ms`,
+          e
+        );
+        throw new UrlLoadError(
+          `Failed waiting on page ${
+            url ? url : ''
+          }  to finished loading, timed out after ${pageCompleteCheckTimeout} ms `,
+          {
+            cause: e
+          }
+        );
+      }
     }
   }
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -162,7 +162,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'timeouts'
     })
     .option('timeouts.pageCompleteCheck', {
-      default: 300000,
+      alias: 'maxLoadTime',
+      default: 120000,
       type: 'number',
       describe:
         'Timeout when waiting for page to complete loading, in milliseconds',

--- a/lib/support/errors.js
+++ b/lib/support/errors.js
@@ -21,8 +21,16 @@ class UrlLoadError extends BrowsertimeError {
   }
 }
 
+class TimeoutError extends BrowsertimeError {
+  constructor(message, url, extra) {
+    super(message, extra);
+    this.url = url;
+  }
+}
+
 module.exports = {
   BrowsertimeError,
   BrowserError,
-  UrlLoadError
+  UrlLoadError,
+  TimeoutError
 };


### PR DESCRIPTION
This fix makes sure that if the page complete check doesn't happen in 2 minutes (or what you configure) the tests will just move in instead of causing an error. It also introduce the new alias ```--maxLoadTime```.

 This is a better version than #1805, thank you @gmierz :) 