### PR TITLE
If one "hero"-element fail, do not add it to the result.

### DIFF
--- a/browsertime/visualmetrics-portable.py
+++ b/browsertime/visualmetrics-portable.py
@@ -1266,14 +1266,16 @@ def calculate_visual_metrics(
                     viewport = hero_data["viewport"]
                     hero_timings = []
                     for hero in hero_data["heroes"]:
-                        hero_timings.append(
-                            {
-                                "name": hero["name"],
-                                "value": calculate_hero_time(
+                        hero_time = calculate_hero_time(
                                     progress, dirs, hero, viewport
-                                ),
-                            }
-                        )
+                                )
+                        if hero_time is not None:
+                            hero_timings.append(
+                                {
+                                    "name": hero["name"],
+                                    "value": hero_time,
+                                }
+                            )
                     hero_timings_sorted = sorted(
                         hero_timings, key=lambda timing: timing["value"]
                     )


### PR DESCRIPTION
There's an example when a heading is just one pixel and fails in the script and then the rest of the metrics also fails. This fixes that.

https://github.com/sitespeedio/browsertime/issues/1784