### PR TITLE
Revert the orange frame workaround we did for Firefox

### DIFF
--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -2,7 +2,7 @@
 
 const log = require('intel').getLogger('browsertime.video');
 const { until, By } = require('selenium-webdriver');
-module.exports = async function (driver, options) {
+module.exports = async function (driver) {
   log.debug('Add orange color');
   // We tried other ways for Android (access an orange page)
   // That works fine ... but break scripts

--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -7,44 +7,7 @@ module.exports = async function (driver, options) {
   // We tried other ways for Android (access an orange page)
   // That works fine ... but break scripts
   // https://github.com/sitespeedio/browsertime/issues/802
-
-  let orangeScript = '';
-
-  if (options.android && options.browser === 'firefox') {
-    orangeScript = `
-        (function() {
-          // Adding this extra layer of white frame fixes
-          // https://bugzilla.mozilla.org/show_bug.cgi?id=1606365
-          // Not clear why it fixes this bug, looks like when
-          // WebRender is enabled, orange frame isn't being
-          // removed correctly if it's the only element
-          // in the document.
-          const white = document.createElement('div');
-          white.id = 'browsertime-white';
-          white.style.position = 'absolute';
-          white.style.top = '0';
-          white.style.left = '0';
-          white.style.width = Math.max(document.documentElement.clientWidth, document.body.clientWidth) + 'px';
-          white.style.height = Math.max(document.documentElement.clientHeight,document.body.clientHeight) + 'px';
-          white.style.backgroundColor = 'white';
-          white.style.zIndex = '2147483647';
-          document.body.appendChild(white);
-          document.body.style.display = '';
-
-          const orange = document.createElement('div');
-          orange.id = 'browsertime-orange';
-          orange.style.position = 'absolute';
-          orange.style.top = '0';
-          orange.style.left = '0';
-          orange.style.width = Math.max(document.documentElement.clientWidth, document.body.clientWidth) + 'px';
-          orange.style.height = Math.max(document.documentElement.clientHeight,document.body.clientHeight) + 'px';
-          orange.style.backgroundColor = '#DE640D';
-          orange.style.zIndex = '2147483647';
-          document.body.appendChild(orange);
-          document.body.style.display = '';
-        })();`;
-  } else {
-    orangeScript = `
+  const orangeScript = `
         (function() {
           const orange = document.createElement('div');
           orange.id = 'browsertime-orange';
@@ -59,7 +22,6 @@ module.exports = async function (driver, options) {
           document.body.appendChild(orange);
           document.body.style.display = '';
         })();`;
-  }
 
   await driver.executeScript(orangeScript);
   // It seems that in some cases the video do not have any orange at the start, so make sure we


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1606365,
we did a workaround to fix a Firefox issue, and
this issue is no longer persist, so we can remove this changes.