### PR TITLE
Bugfix: Set cookies for Chrome when navigating.

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -444,6 +444,10 @@ class Chromium {
       return { har: harBuilder.mergeHars(this.hars) };
     } else return {};
   }
+
+  async setCookies(url, cookies) {
+    return this.cdpClient.setCookies(url, cookies);
+  }
 }
 
 module.exports = Chromium;

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -141,6 +141,15 @@ class Measure {
     log.info('Navigating to url %s iteration %s', url, this.index);
     if (this.numberOfVisitedPages === 0) {
       await this.extensionServer.setup(url, this.browser, this.options);
+
+      // There's a bug that we introduced when moving cookie handling to CDP
+      // and this is the hack to fix that.
+      if (
+        (this.options.cookie && this.options.browser === 'chrome') ||
+        this.options.browser === 'edge'
+      ) {
+        await this.engineDelegate.setCookies(url, this.options.cookie);
+      }
     }
     if (this.numberOfVisitedPages === 0) {
       await this.engineDelegate.beforeStartIteration(this.browser, this.index);


### PR DESCRIPTION
Before this fix cookies (if you set cookies) wasn't
set on navigate command when using Chrome/Edge.