### PR TITLE
Disable password popup on Android.

### DIFF
--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -17,14 +17,12 @@ const CHROME_AMD_EDGE_INTERNAL_PHONE_HOME = [
 ];
 
 module.exports = function (seleniumOptions, browserOptions, options, baseDir) {
-  // Fixing save password popup, only on Desktop
-  if (!options.android) {
-    seleniumOptions.setUserPreferences({
-      'profile.password_manager_enable': false,
-      'profile.default_content_setting_values.notifications': 2,
-      credentials_enable_service: false
-    });
-  }
+  // Fixing save password popup
+  seleniumOptions.setUserPreferences({
+    'profile.password_manager_enable': false,
+    'profile.default_content_setting_values.notifications': 2,
+    credentials_enable_service: false
+  });
 
   if (options.headless) {
     seleniumOptions.headless();


### PR DESCRIPTION
There was an old comment that this only work on Desktop but is that really the case? Lets try it out because the password popup is annoying.

Let me test this when I get a hold of a phone :)