### PR TITLE
Pause the gecko profiler before starting to collect the profile data

### DIFF
--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -115,6 +115,12 @@ class GeckoProfiler {
     log.info(
       `Collecting Gecko profile from ${deviceProfileFilename} to ${destinationFilename}`
     );
+    // Pause profiler before we collect the profile, so that we don't capture
+    // more samples while the parent process waits for subprocess profiles.
+    await runner.runPrivilegedScript(
+      'Services.profiler.Pause();',
+      'Pause GeckoProfiler.'
+    );
     const script = `
       var callback = arguments[arguments.length - 1];
        Services.profiler.dumpProfileToFileAsync(String.raw\`${deviceProfileFilename}\`)


### PR DESCRIPTION
Hey from the Firefox Profiler team! 👋 I was looking on some browsertime related improvements and saw that we are not pausing the profiler during the collection time. Sending a small PR for it.
 
This is essentially needed so we properly pause the profiler and not save anything else to the profiler buffer while the profiler is collecting the data. Profile collection happens asynchronously in Firefox for all the processes. This means that some processes might still continue to sample while the parent process is stopped and capturing the profile json. This improves two things:
- Performance: Profiler has some overhead while running, this could shorten the profile collection time.
- Unneeded data: Since we are here in the code path, it means that we are done capturing the test case. The data we will capture after this point is just unneeded.

Also we have a similar logic in Firefox for reference: https://searchfox.org/mozilla-central/rev/0a2eba79c24300ce0539f91c1bebac2e75264e58/devtools/client/performance-new/popup/background.jsm.js#329-331