### PR TITLE
Use visual metrics portable by default and updated container

### DIFF
--- a/.github/workflows/browser-dev.yml
+++ b/.github/workflows/browser-dev.yml
@@ -32,7 +32,7 @@ jobs:
         sudo snap alias ffmpeg.ffprobe ffprobe
         python -m pip install --upgrade --user pip
         python -m pip install --upgrade --user setuptools
-        python -m pip install --user pyssim
+        python -m pip install --user pyssim OpenCV-Python Numpy
         python -m pip --version
         python -m pip show Pillow
         python -m pip show pyssim

--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -18,6 +18,10 @@ jobs:
         node-version: '18.x'
     - name: Install browsertime
       run: npm ci
+    - name: Install python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10' 
     - name: Install dependencies
       run: |
         sudo safaridriver --enable

--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -8,7 +8,7 @@ on:
     - main
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -23,10 +23,10 @@ jobs:
         sudo safaridriver --enable
         sudo rm '/usr/local/bin/2to3'
         brew update
-        brew install ffmpeg imagemagick
+        brew install ffmpeg
         python -m pip install --upgrade --user pip
-        python -m pip install --upgrade --user setuptools
-        python -m pip install --user pyssim
+        python -m pip install --upgrade --user setuptools 
+        python -m pip install --user pyssim OpenCV-Python Numpy
         python -m pip --version
         python -m pip show Pillow
         python -m pip show pyssim

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,8 +31,6 @@ jobs:
         python -m pip --version
         python -m pip show Pillow
         python -m pip show pyssim
-    - name: Run Visual Metrics test
-      run: python ./browsertime/visualmetrics.py --check
       shell: cmd
     - name: Start local HTTP server
       run: (npm run start-server&)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,8 +19,7 @@ jobs:
       run: npm ci
     - name: Install dependencies
       run: |
-        choco install ffmpeg
-        choco install imagemagick.app --allow-downgrade --version=7.0.10.53 -PackageParameters LegacySupport=true 
+        choco install ffmpeg 
         choco outdated
         choco install python
         choco install microsoft-edge
@@ -28,7 +27,7 @@ jobs:
         choco install firefox
         python -m pip install --upgrade --user pip
         python -m pip install --upgrade --user setuptools
-        python -m pip install --user pyssim
+        python -m pip install --user pyssim OpenCV-Python Numpy
         python -m pip --version
         python -m pip show Pillow
         python -m pip show pyssim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sitespeedio/webbrowsers:chrome-106.0-firefox-105.0-edge-105.0
+FROM sitespeedio/webbrowsers:chrome-107.0-firefox-106.0-edge-106.0-b
 
 ARG TARGETPLATFORM=linux/amd64
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -670,6 +670,7 @@ export function parseCommandLine() {
     })
     .option('visualMetricsPortable', {
       type: 'boolean',
+      default: true,
       describe:
         'Use the portable visual-metrics processing script (no ImageMagick dependencies).'
     })


### PR DESCRIPTION
The container skips installing ImageMagick (and contains Chrome 107).