### PR TITLE
Provide active tab id to gecko profiler StartProfiler API

### DIFF
--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -73,14 +73,38 @@ class GeckoProfiler {
     );
 
     let script;
-    if (parameterLength === 7) {
-      script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
-        ${chosenFeatures.length},${threadString},${chosenThreads.length});`;
-    } else if (parameterLength === 5 || parameterLength === 6) {
-      script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},${threadString});`;
-    } else {
-      log.error('Unknown Gecko Profiler API');
-      throw new Error('Unknown Gecko Profiler API');
+    switch (parameterLength) {
+      case 7: {
+        // Oldest profiler API. It was deprecated in Firefox 69.
+        script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
+          ${chosenFeatures.length},${threadString},${chosenThreads.length});`;
+        break;
+      }
+      case 6: {
+        // Newest profiler API. It's being used since Firefox 72.
+        // `activeBrowserId` is useful for distinguishing browser tabs in the profiler UI.
+        const activeBrowserIdScript = `
+          const win = Services.wm.getMostRecentWindow("navigator:browser");
+          return win?.gBrowser?.selectedBrowser?.browsingContext?.browserId ?? 0;
+      `;
+        const activeBrowserId = await runner.runPrivilegedScript(
+          activeBrowserIdScript,
+          'Get activeBrowserId'
+        );
+        script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
+          ${threadString},${activeBrowserId});`;
+        break;
+      }
+      case 5: {
+        // The profiler API that was used between Firefox 69 and 72.
+        script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
+          ${threadString});`;
+        break;
+      }
+      default: {
+        log.error('Unknown Gecko Profiler API');
+        throw new Error('Unknown Gecko Profiler API');
+      }
     }
 
     log.info(


### PR DESCRIPTION
In the `Services.profiler.StartProfiler` API we have an optional parameter to pass the active tab id. It is the identifier for browser's active tab so the profiler can determine which website was inside the browser's active tab during the profiling session.

This is optional because it's not a crucial profiler feature, but it's useful to provide this.
You can see the code similar to this inside Firefox: https://searchfox.org/mozilla-central/rev/d7d2cc647772de15c4c5aa47f74d25d0e379e404/devtools/client/performance-new/popup/background.jsm.js#382-393 and
https://searchfox.org/mozilla-central/rev/d7d2cc647772de15c4c5aa47f74d25d0e379e404/devtools/shared/performance-new/recording-utils.js#16-34

While I was changing this part, I also added some more context in the commments for the API changes that we've done in the past. Hope it's useful!

To test this change locally, you can run it with:
```
node bin/browsertime.js https://sitespeed.io -b firefox --firefox.geckoProfiler --iterations 1
```
and it should produce the profile data inside `<browsetime-results-dir>/pages/sitespeed_io/data/geckoProfile-1.json.gz`.
If you search for `activeTabID` field inside that json, you should see a non-zero value. Previously this field was always zero.