### PR TITLE
Use Python3 as default

### DIFF
--- a/lib/video/postprocessing/visualmetrics/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/visualMetrics.js
@@ -37,7 +37,10 @@ function getScript(options) {
 }
 
 export async function checkDependencies(options) {
-  return execa(process.env.PYTHON || 'python', [getScript(options), '--check']);
+  return execa(process.env.PYTHON || 'python3', [
+    getScript(options),
+    '--check'
+  ]);
 }
 export async function run(
   videoPath,
@@ -126,7 +129,10 @@ export async function run(
   log.debug('Running visualmetrics.py ' + scriptArguments.join(' '));
   log.info('Get visual metrics from the video');
   try {
-    const result = await execa(process.env.PYTHON || 'python', scriptArguments);
+    const result = await execa(
+      process.env.PYTHON || 'python3',
+      scriptArguments
+    );
     log.debug('visualmetrics.py output:' + result.stdout);
     if (options.verbose < 1) {
       try {


### PR DESCRIPTION
Since visualmetrics-portable have` #!/usr/bin/env python3` I'm thinking maybe we should use python3 as default or how do others treat python/python3, @gmierz do you know what's best practice?