### PR TITLE
Add a timeout to gecko profiler gzipping phase

### DIFF
--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -171,10 +171,14 @@ export class GeckoProfiler {
 
       // GZIP the profile and remove the old file
       log.info('Gzip file the profile.');
-      await storageManager.gzip(
-        destinationFilename,
-        join(profileDir, `geckoProfile-${index}.json.gz`),
-        true
+      await timeout(
+        storageManager.gzip(
+          destinationFilename,
+          join(profileDir, `geckoProfile-${index}.json.gz`),
+          true
+        ),
+        300_000, // 5 minutes
+        'Could not gzip the profile.'
       );
 
       log.info('Done stopping GeckoProfiler.');

--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -164,16 +164,20 @@ export class GeckoProfiler {
       );
 
       if (isAndroidConfigured(options)) {
+        log.info('Download profile file from Android.');
         const android = new Android(options);
         await android._downloadFile(deviceProfileFilename, destinationFilename);
       }
 
       // GZIP the profile and remove the old file
-      return storageManager.gzip(
+      log.info('Gzip file the profile.');
+      await storageManager.gzip(
         destinationFilename,
         join(profileDir, `geckoProfile-${index}.json.gz`),
         true
       );
+
+      log.info('Done stopping GeckoProfiler.');
     } catch (error) {
       log.error(error.message);
     }


### PR DESCRIPTION
In our performance testing CI in Firefox, it looks like browsertime is hanging right after the `"Stop GeckoProfiler."` log intermittently. We are not sure where exactly it's hanging but I strongly suspect that it's hanging at the `storageManager.gzip` line. 

So, I wanted to add both some logs here to get some more insight in our logs and also add a `timeout` for that gzipping phase so we don't spent too much time there unnecessarily. Tested locally and it works well on my machine.