### PR TITLE
Ignore browsing context events without requests

### DIFF
--- a/lib/firefox/webdriver/harBuilder.js
+++ b/lib/firefox/webdriver/harBuilder.js
@@ -96,16 +96,20 @@ export class HarBuilder {
     const firstRequest = this.networkEntries.findLast(
       entry => entry.contextId === context && entry.request.url === url
     );
+    
+    if (!firstRequest) {
+      // Bail out if no request matches this event.
+      return;
+    }
 
     let relativeTime = +Number.POSITIVE_INFINITY,
       startedTime = -1;
-    if (firstRequest) {
-      const timings = firstRequest.request.timings;
-      startedTime = timings.requestTime / 1000;
-      relativeTime = timestamp - startedTime;
-      relativeTime = relativeTime.toFixed(1);
-      firstRequest.isFirstRequest = true;
-    }
+    
+    const timings = firstRequest.request.timings;
+    startedTime = timings.requestTime / 1000;
+    relativeTime = timestamp - startedTime;
+    relativeTime = relativeTime.toFixed(1);
+    firstRequest.isFirstRequest = true;
 
     this.pageTimings.push({
       contextId: context,


### PR DESCRIPTION
If no request can be found for a browsing context event, we can't compute the page timings and it will confuse our current HAR generation.

