### PR TITLE
Add support to get the raw CDP client

### DIFF
--- a/lib/chrome/chromeDevtoolsProtocol.js
+++ b/lib/chrome/chromeDevtoolsProtocol.js
@@ -157,6 +157,10 @@ export class ChromeDevtoolsProtocol {
     });
   }
 
+  getRawClient() {
+    return this.cdpClient;
+  }
+
   async setRequestHeaders(requestHeaders) {
     // Our cli don't validate parameters
     // so -run will become -r etc

--- a/lib/core/engine/command/chromeDevToolsProtocol.js
+++ b/lib/core/engine/command/chromeDevToolsProtocol.js
@@ -51,6 +51,14 @@ export class ChromeDevelopmentToolsProtocol {
     }
   }
 
+  getRawClient() {
+    if (this.browserName === 'chrome' || this.browserName === 'edge') {
+      return this.engineDelegate.getCDPClient().getRawClient();
+    } else {
+      throw new Error('DevToolsProtocol only supported in Chrome and Edge');
+    }
+  }
+
   async send(command, arguments_) {
     if (this.browserName === 'chrome' || this.browserName === 'edge') {
       try {


### PR DESCRIPTION
Expose chrome-remote-interface client to scripting. This makes it easy to do exactly whatever you want to do in your script.

Enables things like:
```
export default async function (context, commands) {
  const cdpClient = commands.cdp.getRawClient();
  await cdpClient.Fetch.enable({
    patterns: [
      {
        urlPattern: '*',
        requestStage: 'Response'
      }
    ]
  });

  cdpClient.Fetch.requestPaused(async reqEvent => {
    const { requestId } = reqEvent;
    let responseHeaders = reqEvent.responseHeaders || [];

    const newServerHeader = { name: 'server', value: 'Haxxor' };
    const foundHeaderIndex = responseHeaders.findIndex(
      h => h.name === 'server'
    );
    if (foundHeaderIndex) {
      responseHeaders[foundHeaderIndex] = newServerHeader;
    } else {
      responseHeaders.push(newServerHeader);
    }

    return cdpClient.Fetch.continueResponse({
      requestId,
      responseCode: 200,
      responseHeaders
    });
  });

  await commands.measure.start('https://www.sitespeed.io/search/');
}

```