### PR TITLE
Fix INP error log messages.

### DIFF
--- a/browserscripts/pageinfo/interactionToNextPaintInfo.js
+++ b/browserscripts/pageinfo/interactionToNextPaintInfo.js
@@ -95,7 +95,7 @@
           const interaction = {
             id: entry.interactionId,
             latency: entry.duration,
-            entries: [entry]
+            name: entry.name
           };
           longestInteractionMap[interaction.id] = interaction;
           longestInteractionList.push(interaction);


### PR DESCRIPTION
I think Chrome started to ship more usable info in the INP event and my hack didn't handle that very well. Lets at least get the name for now and then we can add more meaningful info later.