### PR TITLE
Increase default wait to 5s (from 2s) when click on element.

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -131,7 +131,7 @@ export class SeleniumRunner {
   }
 
   async extraWait(pageCompleteCheck) {
-    await delay(2000);
+    await delay(this.options.beforePageCompleteWaitTime || 5000);
     return this.wait(pageCompleteCheck);
   }
   /**


### PR DESCRIPTION
This wait is before we run the page complete check. You can configure this using --beforePageCompleteWaitTime