### PR TITLE
Fix --host-resolver-rules=..

### DIFF
--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -8,15 +8,15 @@ import { isAndroidConfigured } from '../../android/index.js';
 const log = intel.getLogger('browsertime.chrome');
 
 const CHROME_AMD_EDGE_INTERNAL_PHONE_HOME = [
-  '"MAP cache.pack.google.com 127.0.0.1"',
-  '"MAP clients1.google.com 127.0.0.1"',
-  '"MAP update.googleapis.com 127.0.0.1"',
-  '"MAP content-autofill.googleapis.com 127.0.0.1"',
-  '"MAP redirector.gvt1.com 127.0.0.1"',
-  '"MAP laptop-updates.brave.com 127.0.0.1"',
-  '"MAP offlinepages-pa.googleapis.com 127.0.0.1"',
-  '"MAP edge.microsoft.com 127.0.0.1"',
-  '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"'
+  'MAP cache.pack.google.com 127.0.0.1',
+  'MAP clients1.google.com 127.0.0.1',
+  'MAP update.googleapis.com 127.0.0.1',
+  'MAP content-autofill.googleapis.com 127.0.0.1',
+  'MAP redirector.gvt1.com 127.0.0.1',
+  'MAP laptop-updates.brave.com 127.0.0.1',
+  'MAP offlinepages-pa.googleapis.com 127.0.0.1',
+  'MAP edge.microsoft.com 127.0.0.1',
+  'MAP optimizationguide-pa.googleapis.com 127.0.0.1'
 ];
 
 const CHROME_FEATURES_THAT_WE_DISABLES = [
@@ -107,7 +107,7 @@ export function setupChromiumOptions(
     );
     if (argumentsWithHostResolverRules.length === 0) {
       seleniumOptions.addArguments(
-        '--host-resolver-rules=' + CHROME_AMD_EDGE_INTERNAL_PHONE_HOME.join(',')
+        '--host-resolver-rules="' + CHROME_AMD_EDGE_INTERNAL_PHONE_HOME.join(',') + '"'
       );
     }
   }

--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -107,7 +107,7 @@ export function setupChromiumOptions(
     );
     if (argumentsWithHostResolverRules.length === 0) {
       seleniumOptions.addArguments(
-        '--host-resolver-rules="' + CHROME_AMD_EDGE_INTERNAL_PHONE_HOME.join(',') + '"'
+        `--host-resolver-rules="${CHROME_AMD_EDGE_INTERNAL_PHONE_HOME.join(',')}"`
       );
     }
   }


### PR DESCRIPTION
before (doesn't work):
```
--host-resolver-rules="MAP cache.pack.google.com 127.0.0.1","MAP clients1.google.com 127.0.0.1","MAP update.googleapis.com 127.0.0.1","MAP content-autofill.googleapis.com 127.0.0.1","MAP redirector.gvt1.com 127.0.0.1","MAP laptop-updates.brave.com 127.0.0.1","MAP offlinepages-pa.googleapis.com 127.0.0.1","MAP edge.microsoft.com 127.0.0.1","MAP optimizationguide-pa.googleapis.com 127.0.0.1"
```

after (OK):
```
--host-resolver-rules="MAP cache.pack.google.com 127.0.0.1,MAP clients1.google.com 127.0.0.1,MAP update.googleapis.com 127.0.0.1,MAP content-autofill.googleapis.com 127.0.0.1,MAP redirector.gvt1.com 127.0.0.1,MAP laptop-updates.brave.com 127.0.0.1,MAP offlinepages-pa.googleapis.com 127.0.0.1,MAP edge.microsoft.com 127.0.0.1,MAP optimizationguide-pa.googleapis.com 127.0.0.1"
```

The changes could be verified:
1. via chrome://version
2. visiting http://clients1.google.com/ or https://edge.microsoft.com and check that we get `ERR_CONNECTION_REFUSED`