### PR TITLE
Issue #1958 - Check for android.enabled when checking debug mode.

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -63,6 +63,11 @@ function validateInput(argv) {
     }
   }
 
+  // hack to keep backward compability to --android
+  if (argv.android[0] === true) {
+    set(argv, 'android.enabled', true);
+  }
+
   if (argv.chrome && argv.chrome.mobileEmulation) {
     const m = argv.chrome.mobileEmulation;
     if (!(m.deviceName || (m.height && m.width && m.pixelRatio))) {
@@ -82,7 +87,7 @@ function validateInput(argv) {
     return 'Debug mode do not work in Safari. Please try with Firefox/Chrome or Edge';
   }
 
-  if (argv.debug && argv.android) {
+  if (argv.debug && argv.android.enabled) {
     return 'Debug mode do not work on Android. Please run debug mode on Desktop.';
   }
 
@@ -1262,10 +1267,6 @@ export function parseCommandLine() {
 
   let argv = validated.argv;
 
-  // hack to keep backward compability to --android
-  if (argv.android[0] === true) {
-    set(argv, 'android.enabled', true);
-  }
   if (
     argv.firefox &&
     (argv.firefox.nightly || argv.firefox.beta || argv.firefox.developer)


### PR DESCRIPTION
This patch fixes an issue with --debug mode on desktop (see issue). The hack for backwards compatibility is moved into the verification part of arg parsing code instead of after it.