### PR TITLE
Run Firefox and Chrome tests on Mac.

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,34 @@
+name: OSX Chrome and Firefox
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+jobs:
+  build:
+    runs-on: macos-13
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+    - name: Install browsertime
+      run: npm ci
+    - name: Install python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11' 
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install google-chrome
+        brew install --cask firefox
+    - name: Test Chrome 
+      run: ./bin/browsertime.js -b chrome -n 1 https://www.sitespeed.io/
+    - name: Test Firefox
+      run: ./bin/browsertime.js -b firefox -n 1 https://www.sitespeed.io/
+  

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,4 +1,4 @@
-name: OSX Chrome and Firefox
+name: OSX Chrome, Firefox and Edge
 on:
   push:
     branches:
@@ -27,8 +27,11 @@ jobs:
         brew update
         brew install google-chrome
         brew install --cask firefox
+        brew install --cask microsoft-edge
     - name: Test Chrome 
       run: ./bin/browsertime.js -b chrome -n 1 https://www.sitespeed.io/
     - name: Test Firefox
       run: ./bin/browsertime.js -b firefox -n 1 https://www.sitespeed.io/
+    - name: Test Edge
+      run: ./bin/browsertime.js -b edge -n 1 https://www.sitespeed.io/
   


### PR DESCRIPTION
It turns out the Chrome team didn't test the new Chrome/Chromedriver 115 setup so I guess it's best we do it for them.

https://github.com/sitespeedio/browsertime/issues/1968