### PR TITLE
Use HERMITE instead of default resize.

### DIFF
--- a/lib/support/images/index.js
+++ b/lib/support/images/index.js
@@ -32,12 +32,11 @@ export async function savePng(
   }
 
   if (jimp) {
-    const buffer = await jimp.default.read(data).then(image => {
-      return image
-        .deflateLevel(config.png.compressionLevel)
-        .scaleToFit(config.maxSize, config.maxSize)
-        .getBufferAsync('image/png');
-    });
+    const image = await jimp.default.read(data);
+    const buffer = await image
+      .deflateLevel(config.png.compressionLevel)
+      .scaleToFit(config.maxSize, config.maxSize, jimp.default.RESIZE_HERMITE)
+      .getBufferAsync('image/png');
 
     return storageManager.writeData(
       `${name}.png`,
@@ -62,12 +61,12 @@ export async function saveJpg(
     jimp = undefined;
   }
   if (jimp) {
-    const buffer = await jimp.default.read(data).then(image => {
-      return image
-        .quality(config.jpg.quality)
-        .scaleToFit(config.maxSize, config.maxSize)
-        .getBufferAsync('image/jpeg');
-    });
+    const image = await jimp.default.read(data);
+    // https://github.com/sitespeedio/sitespeed.io/issues/3922
+    const buffer = await image
+      .quality(config.jpg.quality)
+      .scaleToFit(config.maxSize, config.maxSize, jimp.default.RESIZE_HERMITE)
+      .getBufferAsync('image/jpeg');
     return storageManager.writeData(
       `${name}.jpg`,
       buffer,


### PR DESCRIPTION
Default jimp resize didn't handle large values (2000) when running in Docker AMD on a a ARM so changing to another algorithm.

https://github.com/sitespeedio/sitespeed.io/issues/3922