### PR TITLE
Get the url from the `result` array in GeckoProfiler.stop

### DIFF
--- a/lib/core/engine/command/geckoProfiler.js
+++ b/lib/core/engine/command/geckoProfiler.js
@@ -1,11 +1,12 @@
 import intel from 'intel';
 const log = intel.getLogger('browsertime.command.geckoprofiler');
 export class GeckoProfiler {
-  constructor(GeckoProfiler, browser, index, options) {
+  constructor(GeckoProfiler, browser, index, options, result) {
     this.GeckoProfiler = GeckoProfiler;
     this.browser = browser;
     this.index = index;
     this.options = options;
+    this.result = result;
   }
 
   async start() {
@@ -25,11 +26,7 @@ export class GeckoProfiler {
   async stop() {
     if (this.options.browser === 'firefox') {
       if (this.options.firefox.geckoProfilerRecordingType === 'custom') {
-        const url = await this.browser
-          .getDriver()
-          .executeScript('return document.documentURI;');
-
-        return this.GeckoProfiler.stop(this.index, url);
+        return this.GeckoProfiler.stop(this.index, this.result[0].url);
       }
     } else {
       throw new Error('Geckoprofiler only works in Firefox');

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -159,7 +159,8 @@ export class Iteration {
         browserProfiler,
         browser,
         index,
-        this.options
+        this.options,
+        result
       );
       const cdp = new ChromeDevelopmentToolsProtocol(
         engineDelegate,


### PR DESCRIPTION
Previously for gecko profiler commands we were getting the test url by running a script that returns `document.documentURI`. This was working fine for most cases. But when one of our tests actually navigates to a different page from the starting page, it gets the destination url instead of the initial url. Since we need the initial url, it's better not to get the url like this, and get it directly from the `result` array.

Note that chrome trace command does something similar [here](https://github.com/sitespeedio/browsertime/blob/e3e5a46f6c9070c0ab66e543b85e60d021edc848/lib/core/engine/command/chromeTrace.js#L42).

cc @soulgalore and @92kns 
This fixes [Bug 1858709](https://bugzilla.mozilla.org/show_bug.cgi?id=1858709)