### PR TITLE
Gather LargestContentfulPaint in Firefox.

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -47,7 +47,6 @@ function getNewResult(url, options) {
     deltaToTTFB: [],
     cpu: [],
     googleWebVitals: [],
-    firefoxWebVitals: [],
     extras: [],
     fullyLoaded: [],
     mainDocumentTimings: [],
@@ -398,13 +397,6 @@ export class Collector {
         results.googleWebVitals.push(data.googleWebVitals);
         statistics.addDeep({
           googleWebVitals: data.googleWebVitals
-        });
-      }
-
-      if (data.firefoxWebVitals) {
-        results.firefoxWebVitals.push(data.firefoxWebVitals);
-        statistics.addDeep({
-          firefoxWebVitals: data.firefoxWebVitals
         });
       }
 

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -47,6 +47,7 @@ function getNewResult(url, options) {
     deltaToTTFB: [],
     cpu: [],
     googleWebVitals: [],
+    firefoxWebVitals: [],
     extras: [],
     fullyLoaded: [],
     mainDocumentTimings: [],
@@ -397,6 +398,13 @@ export class Collector {
         results.googleWebVitals.push(data.googleWebVitals);
         statistics.addDeep({
           googleWebVitals: data.googleWebVitals
+        });
+      }
+
+      if (data.firefoxWebVitals) {
+        results.firefoxWebVitals.push(data.firefoxWebVitals);
+        statistics.addDeep({
+          firefoxWebVitals: data.firefoxWebVitals
         });
       }
 

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -225,12 +225,12 @@ export class Firefox {
       result.browserScripts.browser.appConstants = this.appConstants;
     }
 
-    result.firefoxWebVitals = {};
+    result.googleWebVitals = {};
     if (
       result.browserScripts.timings &&
       result.browserScripts.timings.largestContentfulPaint
     ) {
-      result.firefoxWebVitals.largestContentfulPaint =
+      result.googleWebVitals.largestContentfulPaint =
         result.browserScripts.timings.largestContentfulPaint.renderTime ||
         result.browserScripts.timings.largestContentfulPaint.loadTime;
     }

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -224,6 +224,15 @@ export class Firefox {
     if (this.appConstants) {
       result.browserScripts.browser.appConstants = this.appConstants;
     }
+
+    result.firefoxWebVitals = {};
+    if (result.browserScripts.timings) {
+      if (result.browserScripts.timings.largestContentfulPaint) {
+        result.firefoxWebVitals.largestContentfulPaint =
+          result.browserScripts.timings.largestContentfulPaint.renderTime ||
+          result.browserScripts.timings.largestContentfulPaint.loadTime;
+      }
+    }
   }
 
   async postWork(index, results) {

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -226,12 +226,13 @@ export class Firefox {
     }
 
     result.firefoxWebVitals = {};
-    if (result.browserScripts.timings) {
-      if (result.browserScripts.timings.largestContentfulPaint) {
-        result.firefoxWebVitals.largestContentfulPaint =
-          result.browserScripts.timings.largestContentfulPaint.renderTime ||
-          result.browserScripts.timings.largestContentfulPaint.loadTime;
-      }
+    if (
+      result.browserScripts.timings &&
+      result.browserScripts.timings.largestContentfulPaint
+    ) {
+      result.firefoxWebVitals.largestContentfulPaint =
+        result.browserScripts.timings.largestContentfulPaint.renderTime ||
+        result.browserScripts.timings.largestContentfulPaint.loadTime;
     }
   }
 


### PR DESCRIPTION
This patch adds the ability to gather LargestContentfulPaint with Firefox. It's gathered into a `firefoxWebVitals` entry similar to what is done with Chrome-based browsers.