### PR TITLE
Add the ability to set different CPU speed on Moto G 5.

### DIFF
--- a/lib/android/root.js
+++ b/lib/android/root.js
@@ -79,13 +79,35 @@ export class RootedDevice {
   async setCPUPerformanceMotoG5() {
     //  # MSM8937(8x 1.4GHz)
     // values obtained from:
-    // /sys/devices/system/cpu/cpufreq/policy0/scaling_available_frequencies
+    // cat /sys/devices/system/cpu/cpu1/cpufreq/scaling_available_frequencies
+    // 960000 1094400 1209600 1248000 1344000 1401000
+
+    let cpuSpeed = 1_401_000;
+    if (
+      this.options.androidPinCPUSpeed === 'min' ||
+      (this.options.android && this.options.android.pinCPUSpeed === 'min')
+    ) {
+      log.info('Set min CPU speed');
+      cpuSpeed = 960_000;
+    } else if (
+      this.options.androidPinCPUSpeed === 'middle' ||
+      (this.options.android && this.options.android.pinCPUSpeed === 'middle')
+    ) {
+      log.info('Set middle CPU speed');
+      cpuSpeed = 1_209_600;
+    } else {
+      log.info('Set max CPU speed');
+    }
+
     for (let index = 0; index < 8; index++) {
       await this.client._runAsRoot(
         `echo performance > /sys/devices/system/cpu/cpu${index}/cpufreq/scaling_governor`
       );
       await this.client._runAsRoot(
-        `echo 1401000 > /sys/devices/system/cpu/cpu${index}/cpufreq/scaling_min_freq`
+        `echo ${cpuSpeed} > /sys/devices/system/cpu/cpu${index}/cpufreq/scaling_min_freq`
+      );
+      await this.client._runAsRoot(
+        `echo ${cpuSpeed} > /sys/devices/system/cpu/cpu${index}/cpufreq/scaling_max_freq`
       );
     }
   }

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -757,7 +757,7 @@ export function parseCommandLine() {
       choices: ['min', 'middle', 'max'],
       default: 'min',
       describe:
-        'Using a Samsung A51 you can choose how to pin the CPU to better align the speed with your users',
+        'Using a Samsung A51 or Moto G5 you can choose how to pin the CPU to better align the speed with your users. This only works on rooted phones and together with --android.rooted',
       group: 'android'
     })
     .option('android.batteryTemperatureLimit', {


### PR DESCRIPTION
Warning this changes the old default (max) to run min as default so this should go in a major version.