### PR TITLE
Use markedAsFailure for exitCode and only set if undefined.

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -149,10 +149,16 @@ async function run(urls, options) {
       const resultDirectory = relative(process.cwd(), storageManager.directory);
 
       // check for errors
-      for (let eachResult of result) {
-        for (let errors of eachResult.errors) {
-          if (errors.length > 0) {
+      // If we have set the exit code in scripts, respect that
+      if (process.exitCode === undefined) {
+        for (let eachResult of result) {
+          if (eachResult.markedAsFailure === 1) {
             process.exitCode = 1;
+          }
+          for (let errors of eachResult.errors) {
+            if (errors.length > 0) {
+              process.exitCode = 1;
+            }
           }
         }
       }


### PR DESCRIPTION
Respect markedAsFailure from your run and exit with an error. This also only sets the error code if it's not set. That means you can set the exitCode in your script and it will be respected.