### PR TITLE
Revert "Use Bidi HAR by default for Firefox"

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -454,7 +454,7 @@ export function parseCommandLine() {
     })
     .option('firefox.bidihar', {
       describe: 'Use the new bidi HAR generator',
-      default: true,
+      default: false,
       type: 'boolean',
       group: 'firefox'
     })


### PR DESCRIPTION
Reverts sitespeedio/browsertime#2089. I want this to go in the next major.