### PR TITLE
Catch if we do not have any requests

### DIFF
--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -336,7 +336,12 @@ export class Engine {
 
     // Backfill the fully loaded data that we extract from the HAR
     // Only do this if we actually had requests
-    if (!options.skipHar && extras.har && extras.har.log && extras.har.log.entries.length > 0) {
+    if (
+      !options.skipHar &&
+      extras.har &&
+      extras.har.log &&
+      extras.har.log.entries.length > 0
+    ) {
       const fullyLoadedPerUrl = getFullyLoaded(extras.har);
       for (let data of fullyLoadedPerUrl) {
         collector.addFullyLoaded(data.url, data.fullyLoaded);

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -335,11 +335,13 @@ export class Engine {
     const extras = await engineDelegate.getHARs();
 
     // Backfill the fully loaded data that we extract from the HAR
-    if (!options.skipHar && extras.har) {
+    // Only do this if we actually had requests
+    if (!options.skipHar && extras.har && extras.har.log && extras.har.log.entries.length > 0) {
       const fullyLoadedPerUrl = getFullyLoaded(extras.har);
       for (let data of fullyLoadedPerUrl) {
         collector.addFullyLoaded(data.url, data.fullyLoaded);
       }
+
       // Add the timings from the main document
       const timings = getMainDocumentTimings(extras.har);
       for (let timing of timings) {


### PR DESCRIPTION
There's a glitch where we tried to get main document timings if we tested a URL that failed, that caused an unrecoverable error.