### PR TITLE
Disable NodeJS 22 tests.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: ['chrome', 'firefox']
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Somehow the GitHub action for NodeJS 22 is broken, it cannot install some packages.