### PR TITLE
Call stopSampling on browser stop during android power testing.

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -489,8 +489,12 @@ export class Chromium {
       await unlink(netlog);
     }
 
-    if (this.android && this.options.androidPower) {
-      await this.android.stopPowerTesting();
+    if (this.android) {
+      if (this.options.androidPower) {
+        await this.android.stopPowerTesting();
+      } else if (this.options.androidUsbPower) {
+        await usbPowerProfiler.stopSampling();
+      }
     }
 
     if (this.cdpClient) {

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -397,8 +397,12 @@ export class Firefox {
    * Before the browser is stopped/closed.
    */
   async beforeBrowserStop() {
-    if (isAndroidConfigured(this.options) && this.options.androidPower) {
-      await this.android.stopPowerTesting();
+    if (isAndroidConfigured(this.options)) {
+      if (this.options.androidPower) {
+        await this.android.stopPowerTesting();
+      } else if (this.options.androidUsbPower) {
+        await usbPowerProfiler.stopSampling();
+      }
     }
   }
 


### PR DESCRIPTION
This patch resolves an issue that occurs on some systems where the power testing needs to explicitly be stopped before the next iteration.