### PR TITLE
Fix broken Android object configuration object

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -63,11 +63,6 @@ function validateInput(argv) {
     }
   }
 
-  // hack to keep backward compability to --android
-  if (argv.android[0] === true) {
-    set(argv, 'android.enabled', true);
-  }
-
   if (argv.chrome && argv.chrome.mobileEmulation) {
     const m = argv.chrome.mobileEmulation;
     if (!(m.deviceName || (m.height && m.width && m.pixelRatio))) {
@@ -144,7 +139,11 @@ function validateInput(argv) {
 }
 
 export function parseCommandLine() {
-  let yargsInstance = yargs(hideBin(process.argv));
+  let argvFix = process.argv.map(arg =>
+    arg === '--android' ? '--android.enabled' : arg
+  );
+
+  let yargsInstance = yargs(hideBin(argvFix));
   let validated = yargsInstance
     .parserConfiguration({
       'camel-case-expansion': false,


### PR DESCRIPTION
This fixes the internal configuration object for android. The old solution created an array with objects instead of just keys on the object.