### PR TITLE
Improve how we compute the power consumption numbers from the Firefox Profiler output

### DIFF
--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -33,7 +33,20 @@ function computeCounterPowerSum(counter) {
 function computeFullProfilePower(profile) {
   let power = 0;
   for (const counter of profile.counters) {
-    if (counter.category === 'power') {
+    if (
+      counter.category === 'power' &&
+      // If power counters starts with "Power:", it means that there are several
+      // individual components that Firefox records. For Linux and Windows,
+      // intel CPUs might produce 'CPU package' to show the whole power
+      // consumption of the CPU. But on top of that it also shows some individual
+      // components like, DRAM, iGPU, individual CPU cores etc. We don't want
+      // to include them as it might produce double the power values it normally consumes.
+      //
+      // Linux track names: https://searchfox.org/mozilla-central/rev/5ad94327fc03d0e5bc6aa81c0d7d113c2dccf947/tools/profiler/core/PowerCounters-linux.cpp#48-70
+      // Windows track names: https://searchfox.org/mozilla-central/rev/5ad94327fc03d0e5bc6aa81c0d7d113c2dccf947/tools/profiler/core/PowerCounters-win.cpp#32-55
+      (!counter.name.startsWith('Power:') ||
+        counter.name === 'Power: CPU package')
+    ) {
       power += computeCounterPowerSum(counter);
     }
   }

--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -8,8 +8,8 @@ import { BrowserError } from '../support/errors.js';
 const delay = ms => new Promise(res => setTimeout(res, ms));
 const log = intel.getLogger('browsertime.firefox');
 
-// Return power usage in Wh
-function computePowerSum(counter) {
+// Return power usage in Wh for a single counter.
+function computeCounterPowerSum(counter) {
   let sum = 0;
   // Older Firefoxes see https://github.com/sitespeedio/sitespeed.io/issues/3944#issuecomment-1871090793
   if (counter.sample_groups) {
@@ -26,6 +26,23 @@ function computePowerSum(counter) {
     }
   }
   return sum * 1e-12;
+}
+
+// Return the power usage by the whole profile including the sub processes.
+// The return value is in Wh value.
+function computeFullProfilePower(profile) {
+  let power = 0;
+  for (const counter of profile.counters) {
+    if (counter.category === 'power') {
+      power += computeCounterPowerSum(counter);
+    }
+  }
+
+  for (const subprocessProfile of profile.processes) {
+    power += computeFullProfilePower(subprocessProfile);
+  }
+
+  return power;
 }
 
 /**
@@ -220,13 +237,8 @@ export class GeckoProfiler {
               path.join(pathToFolder(url, options))
             )
           );
-          let power = 0;
-          for (const counter of profile.counters) {
-            if (counter.category === 'power') {
-              power += computePowerSum(counter);
-            }
-          }
-          result.powerConsumption = Number(power);
+
+          result.powerConsumption = computeFullProfilePower(profile);
         } else {
           log.warning(
             'Missing power setting in geckoProfilerParams.features so power will not be collected'

--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -15,16 +15,29 @@ function computeCounterPowerSum(counter) {
   if (counter.sample_groups) {
     for (const groups of counter.sample_groups) {
       const countIndex = groups.samples.schema.count;
-      for (const sample of groups.samples.data) {
-        sum += sample[countIndex];
+      // NOTE: We intentionally ignore the first index of the counters as they
+      // might contain incorrect values.
+      for (
+        let sampleIndex = 1;
+        sampleIndex < groups.samples.data.length;
+        sampleIndex++
+      ) {
+        sum += groups.samples.data[sampleIndex][countIndex];
       }
     }
   } else {
     const countIndex = counter.samples.schema.count;
-    for (const sample of counter.samples.data) {
-      sum += sample[countIndex];
+    // NOTE: We intentionally ignore the first index of the counters as they
+    // might contain incorrect values.
+    for (
+      let sampleIndex = 1;
+      sampleIndex < counter.samples.data.length;
+      sampleIndex++
+    ) {
+      sum += counter.samples.data[sampleIndex][countIndex];
     }
   }
+
   return sum * 1e-12;
 }
 

--- a/lib/firefox/geckoProfiler.js
+++ b/lib/firefox/geckoProfiler.js
@@ -230,7 +230,7 @@ export class GeckoProfiler {
           geckoProfilerDefaults.features
         );
         if (chosenFeatures.includes('power')) {
-          log.info('Collecting CPU power consumtion');
+          log.info('Collecting CPU power consumption');
           const profile = JSON.parse(
             await storageManager.readData(
               `geckoProfile-${index}.json`,


### PR DESCRIPTION
Hey @soulgalore!


I was looking at some of the profiles and the powerConsumption metrics that's generated using the Firefox Profiler. And realized that there were some issues related to how we compute this number.

This feature was first implemented [here](https://github.com/sitespeedio/browsertime/pull/2046) (and [this is the issue](https://github.com/sitespeedio/sitespeed.io/issues/3944))

1. We were only looking at only the parent process counters. Because child process profiles are stored in the parent process' `processes` field, so now we look at the profiles recursively and sum all the power consumption counters coming from all the processes.
2. I excluded some of the power counters, because sometimes we were counting the power usage values twice. See the message of this commit for more details: https://github.com/sitespeedio/browsertime/commit/3003c71d50a155bd1ef7cf700d9b289a0f77f378
3. I change the counter loop to exclude the first value of the `count` values. In some platforms the first value can either be different, and might mean other things, or it can be incorrect. [We already have this logic in the profiler frontend](https://github.com/firefox-devtools/profiler/blob/6a683fa6ae2733dae49ff460edf6ee98ca626f09/src/profile-logic/profile-data.js#L1740-L1743) to ignore the first value for all the counters, so we weren't hitting this issue before. But I encountered this issue while I was comparing the values from the profiler frontend vs the browsertime.

I recommend looking at the PR commit-by-commit as the commit messages also provide some context.

To be able to test locally, you can follow the instructions here: https://github.com/sitespeedio/sitespeed.io/issues/3944#issuecomment-1874409458