### PR TITLE
Add allow system access for upcoming Firefox release

### DIFF
--- a/lib/firefox/webdriver/builder.js
+++ b/lib/firefox/webdriver/builder.js
@@ -43,6 +43,8 @@ export async function configureBuilder(builder, baseDir, options) {
     }
   }
 
+  serviceBuilder.addArguments('--allow-system-access');
+
   builder.setFirefoxService(serviceBuilder);
 
   const ffOptions = new Options();


### PR DESCRIPTION
In upcoming Firefox you need the flag to be able to run privileged JavaScript. However in the current version of Firefox you get this error on startup:
 
<img width="1058" alt="Screenshot 2025-03-29 at 13 08 57" src="https://github.com/user-attachments/assets/25248826-cf31-4637-b560-f69e3401fc59" />
