### PR TITLE
Add commands to start/stop and collect PerfStats performance counters

### DIFF
--- a/lib/core/engine/command/perfStats.js
+++ b/lib/core/engine/command/perfStats.js
@@ -1,0 +1,67 @@
+import { PerfStats } from '../../../firefox/perfStats.js';
+/**
+ * Manages the PerfStats interface used for collecting Firefox performance counters.
+ *
+ * @class
+ * @hideconstructor
+ */
+
+export class PerfStatsInterface {
+  constructor(browser, options) {
+    /**
+     * @private
+     */
+    this.PerfStats = new PerfStats(browser);
+    /**
+     * @private
+     */
+    this.options = options;
+  }
+
+  /**
+   * Starts PerfStats collection based on the given feature mask.
+   *
+   * @async
+   * @returns {Promise<void>} A promise that resolves when collection has started.
+   * @throws {Error} Throws an error if not running Firefox.
+   */
+  // eslint-disable-next-line prettier/prettier
+  async start(featureMask = 0xFF_FF_FF_FF) {
+    if (this.options.browser === 'firefox') {
+      return this.PerfStats.start(featureMask);
+    } else {
+      throw new Error('PerfStats only works in Firefox');
+    }
+  }
+
+  /**
+   * Stops PerfStats collection.
+   *
+   * @async
+   * @returns {Promise<void>} A promise that resolves when collection has stopped.
+   * @throws {Error} Throws an error if not running Firefox.
+   */
+  async stop() {
+    if (this.options.browser === 'firefox') {
+      return this.PerfStats.stop();
+    } else {
+      throw new Error('PerfStats only works in Firefox');
+    }
+  }
+
+  /**
+   * Returns an object that has cumulative perfstats statistics across each
+   * process for the features that were enabled. Should be called before stop().
+   *
+   * @async
+   * @returns {Object} Returns an object with cumulative results.
+   * @throws {Error} Throws an error if not running Firefox.
+   */
+  async collect() {
+    if (this.options.browser === 'firefox') {
+      return this.PerfStats.collect();
+    } else {
+      throw new Error('PerfStats only works in Firefox');
+    }
+  }
+}

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -28,6 +28,7 @@ import { Scroll } from './command/scroll.js';
 import { Navigation } from './command/navigation.js';
 import { GeckoProfiler } from '../../firefox/geckoProfiler.js';
 import { GeckoProfiler as GeckoProfilerCommand } from './command/geckoProfiler.js';
+import { PerfStatsInterface } from './command/perfStats.js';
 /**
  * Represents the set of commands available in a Browsertime script.
  * @hideconstructor
@@ -64,6 +65,10 @@ export class Commands {
       options
     );
 
+    /**
+     * Manages GeckoProfiler functionality to collect performance profiles.
+     * @type {GeckoProfiler}
+     */
     const browserProfiler = new GeckoProfiler(browser, storageManager, options);
     // Profiler
     this.profiler = new GeckoProfilerCommand(
@@ -73,6 +78,14 @@ export class Commands {
       options,
       result
     );
+
+    /**
+     * Manages PerfStats functionality to collect performance counters.
+     * @type {PerfStatsInterface}
+     */
+    const perfStats = new PerfStatsInterface(browser, options);
+    this.perfStats = perfStats;
+
     const cdp = new ChromeDevelopmentToolsProtocol(
       engineDelegate,
       options.browser

--- a/lib/firefox/perfStats.js
+++ b/lib/firefox/perfStats.js
@@ -2,14 +2,12 @@ import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('browsertime.firefox');
 
 export class PerfStats {
-  constructor(runner, firefoxConfig) {
+  constructor(runner) {
     this.runner = runner;
-    this.firefoxConfig = firefoxConfig;
   }
 
-  async start() {
+  async start(featureMask) {
     const runner = this.runner;
-    const featureMask = this.firefoxConfig.perfStatsParams.mask;
     const script = `ChromeUtils.setPerfStatsCollectionMask(${featureMask});`;
     return runner.runPrivilegedScript(script, 'Start PerfStats Measurement');
   }

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -176,8 +176,8 @@ export class Firefox {
     }
 
     if (this.firefoxConfig.perfStats) {
-      this.perfStats = new PerfStats(runner, this.firefoxConfig);
-      return this.perfStats.start();
+      this.perfStats = new PerfStats(runner);
+      return this.perfStats.start(this.firefoxConfig.perfStatsParams.mask);
     }
 
     this.testStartTime = Date.now();


### PR DESCRIPTION
This PR adds some new commands to control PerfStats in the Firefox browser.