### PR TITLE
Check if serverTiming is defined before gathering its metrics.

### DIFF
--- a/browserscripts/timings/serverTimings.js
+++ b/browserscripts/timings/serverTimings.js
@@ -1,12 +1,14 @@
 (function () {
     let t = window.performance.getEntriesByType('navigation')[0];
     const serverTimings = [];
-    for (let timing of t.serverTiming) {
-        serverTimings.push({
-            name: timing.name,
-            duration: timing.duration,
-            description: timing.description
-        });
+    if (t.serverTiming) {
+        for (let timing of t.serverTiming) {
+            serverTimings.push({
+                name: timing.name,
+                duration: timing.duration,
+                description: timing.description
+            });
+        }
     }
     return serverTimings;
 })();


### PR DESCRIPTION
This patch fixes an issue that occurs when taking a measurement with no navigations. In those cases, the `serverTiming` is undefined. Example for reproducing the failure:
```
module.exports = async function (context, commands) {
  context.log.info("Starting constant value regression test");
  await commands.measure.start("regression-test");
  await commands.measure.stop();
  await commands.measure.addObject({
    data: { metric: 1000 },
  });
};
```
