### PR TITLE
Use new Firefox PerfStats API

### DIFF
--- a/lib/firefox/perfStats.js
+++ b/lib/firefox/perfStats.js
@@ -6,15 +6,51 @@ export class PerfStats {
     this.runner = runner;
   }
 
-  async start(featureMask) {
+  async start(features) {
     const runner = this.runner;
-    const script = `ChromeUtils.setPerfStatsCollectionMask(${featureMask});`;
+
+    // Parse features if it's a string
+    let featuresArray = features;
+    if (typeof features === 'string') {
+      featuresArray = features
+        .split(',')
+        .map(f => f.trim())
+        .filter(f => f.length > 0);
+    }
+
+    // eslint-disable-next-line prettier/prettier
+    const allFeaturesMask = 0xFF_FF_FF_FF;
+
+    const script = `
+      if (typeof ChromeUtils.setPerfStatsFeatures === 'function') {
+        if (!${JSON.stringify(featuresArray)} || ${JSON.stringify(featuresArray)}.length === 0) {
+          ChromeUtils.enableAllPerfStatsFeatures();
+        } else {
+          ChromeUtils.setPerfStatsFeatures(${JSON.stringify(featuresArray)});
+        }
+      } else if (typeof ChromeUtils.setPerfStatsCollectionMask === 'function') {
+        ChromeUtils.setPerfStatsCollectionMask(${features || allFeaturesMask});
+      } else {
+        throw new Error('PerfStats API not available in this Firefox version');
+      }
+    `;
+
     return runner.runPrivilegedScript(script, 'Start PerfStats Measurement');
   }
 
   async stop() {
     const runner = this.runner;
-    const script = `ChromeUtils.setPerfStatsCollectionMask(0);`;
+
+    const script = `
+      if (typeof ChromeUtils.setPerfStatsFeatures === 'function') {
+        ChromeUtils.setPerfStatsFeatures([]);
+      } else if (typeof ChromeUtils.setPerfStatsCollectionMask === 'function') {
+        ChromeUtils.setPerfStatsCollectionMask(0);
+      } else {
+        throw new Error('PerfStats API not available in this Firefox version');
+      }
+    `;
+
     return runner.runPrivilegedScript(script, 'Stop PerfStats Measurement');
   }
 

--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -177,7 +177,7 @@ export class Firefox {
 
     if (this.firefoxConfig.perfStats) {
       this.perfStats = new PerfStats(runner);
-      return this.perfStats.start(this.firefoxConfig.perfStatsParams.mask);
+      return this.perfStats.start(this.firefoxConfig.perfStatsParams?.features);
     }
 
     this.testStartTime = Date.now();

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -549,11 +549,10 @@ export function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
-    .option('firefox.perfStatsParams.mask', {
-      describe: 'Mask to decide which features to enable',
-      // eslint-disable-next-line prettier/prettier
-      default: 0xFF_FF_FF_FF,
-      type: 'number',
+    .option('firefox.perfStatsParams.features', {
+      describe:
+        'Comma-separated list of PerfStats features to enable. If not provided, all features will be enabled.',
+      type: 'string',
       group: 'firefox'
     })
     .option('firefox.collectMozLog', {


### PR DESCRIPTION
The existing perf stats API accepts a 32-bit bitmask so it only supports up to 32 features.  We've recently exceeded that limit and need to update this API.  In https://bugzilla.mozilla.org/show_bug.cgi?id=1981299 I've changed the API to take an array of feature strings instead of a bitmask.  

Browsertime will need to update to use the new API, but I've left backwards compatibility to the older interface as well.