### PR TITLE
Disable quicksuggest since it beacon back many requests.

### DIFF
--- a/lib/firefox/settings/firefoxPreferences.js
+++ b/lib/firefox/settings/firefoxPreferences.js
@@ -204,5 +204,10 @@ export const defaultFirefoxPreferences = {
   // https://firefox-source-docs.mozilla.org/toolkit/components/glean/dev/preferences.html
   'telemetry.fog.test.localhost_port': -1,
   'telemetry.fog.test.activity_limit': -1,
-  'telemetry.fog.test.inactivity_limit': -1
+  'telemetry.fog.test.inactivity_limit': -1,
+
+  'browser.urlbar.suggest.quicksuggest': false,
+  'browser.urlbar.groupLabels.enabled': false,
+  'browser.urlbar.suggest.quicksuggest.nonsponsored': false,
+  'browser.urlbar.suggest.quicksuggest.sponsored': false
 };


### PR DESCRIPTION
The Wikipedia tests running direct against Wikipedia is really unstable for Firefox. Looking at the mozlog I could see 1125 requests (where 7 of them is for Wikipedia portal page). I disabled quicksuggest as in this commit and the number of request s went down to 181.