### PR TITLE
Enable form autofill in Firefox preferences

### DIFF
--- a/lib/firefox/settings/firefoxPreferences.js
+++ b/lib/firefox/settings/firefoxPreferences.js
@@ -43,6 +43,9 @@ export const defaultFirefoxPreferences = {
   // Prevent network access for recommendations by default. The payload is {'results':[]}.
   'extensions.getAddons.discovery.api_url':
     'data:;base64,eyJyZXN1bHRzIjpbXX0%3D',
+  // Enable form autofill
+  'extensions.formautofill.addresses.enabled': false,
+  'extensions.formautofill.creditCards.enabled': false,
   // Treat WebExtension API/schema warnings as errors.
   'extensions.webextensions.warnings-as-errors': true,
   // Disable useragent updates.


### PR DESCRIPTION
This was recently disabled in the firefox recommended preferences, and may impact performance. I've been advised to re-add it by :sparky!