### PR TITLE
[feat] Add support for TypeScript scripts, changing engineUtils.js

### DIFF
--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -79,5 +79,13 @@ jobs:
       run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.js --cjs
     - name: Run test with scripting.js
       run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.js
+    - name: Run test with scripting.mts
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.mts
+    - name: Run test with scripting.cts
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.cts
+    - name: Run test with scripting.ts
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.ts --cjs
+    - name: Run test with scripting.ts
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.ts
     - name: Test extra profile run Chrome
       run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ -n 1 --viewPort 1000x600 --xvfb  --enableProfileRun

--- a/lib/support/engineUtils.js
+++ b/lib/support/engineUtils.js
@@ -19,17 +19,20 @@ async function loadFile(script, options, throwError) {
   // if the script is an AsyncFunction, return it.
   if (script instanceof AsyncFunction) {
     return script;
-  } else if (!script.endsWith('js')) {
+  } else if (!script.endsWith('js') && !script.endsWith('ts')) {
     // This is an inline script
     return script;
   }
-  // If we follow correct naming for modules (.mjs) or commonjs (.cjs)
+  // If we have TypeScript file or follow correct naming for modules (.mjs) or commonjs (.cjs)
   // we just loads it. .js files is loaded as commonjs if you set
   // --cjs true
   if (
     options.cjs === false ||
     script.endsWith('.mjs') ||
-    script.endsWith('.cjs')
+    script.endsWith('.cjs') ||
+    script.endsWith('.mts') ||
+    script.endsWith('.cts') ||
+    script.endsWith('.ts')
   ) {
     let myFunction = await import(pathToFileURL(path.resolve(script)));
     return myFunction.default ?? myFunction;

--- a/lib/support/engineUtils.js
+++ b/lib/support/engineUtils.js
@@ -23,16 +23,15 @@ async function loadFile(script, options, throwError) {
     // This is an inline script
     return script;
   }
-  // If we have TypeScript file or follow correct naming for modules (.mjs) or commonjs (.cjs)
-  // we just loads it. .js files is loaded as commonjs if you set
+  // If we follow correct naming for modules (.mjs/.mts) or commonjs (.cjs/.cts)
+  // we just loads it. .js/.ts files is loaded as commonjs if you set
   // --cjs true
   if (
     options.cjs === false ||
     script.endsWith('.mjs') ||
     script.endsWith('.cjs') ||
     script.endsWith('.mts') ||
-    script.endsWith('.cts') ||
-    script.endsWith('.ts')
+    script.endsWith('.cts')
   ) {
     let myFunction = await import(pathToFileURL(path.resolve(script)));
     return myFunction.default ?? myFunction;

--- a/test/data/scripting/common.cts
+++ b/test/data/scripting/common.cts
@@ -1,0 +1,11 @@
+interface BrowsertimeCommands {
+    measure: {
+        start: (url: string) => Promise<void>;
+    };
+}
+
+type BrowsertimeContext = unknown;
+
+module.exports = async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
+    return commands.measure.start('https://www.sitespeed.io');
+};

--- a/test/data/scripting/common.ts
+++ b/test/data/scripting/common.ts
@@ -1,0 +1,11 @@
+interface BrowsertimeCommands {
+    measure: {
+        start: (url: string) => Promise<void>;
+    };
+}
+
+type BrowsertimeContext = unknown;
+
+module.exports = async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
+    return commands.measure.start('https://www.sitespeed.io');
+};

--- a/test/data/scripting/module.mts
+++ b/test/data/scripting/module.mts
@@ -1,0 +1,11 @@
+interface BrowsertimeCommands {
+    measure: {
+        start: (url: string) => Promise<void>;
+    };
+}
+
+type BrowsertimeContext = unknown;
+
+export default async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
+    return commands.measure.start('https://www.sitespeed.io');
+};

--- a/test/data/scripting/module.ts
+++ b/test/data/scripting/module.ts
@@ -1,0 +1,11 @@
+interface BrowsertimeCommands {
+    measure: {
+        start: (url: string) => Promise<void>;
+    };
+}
+
+type BrowsertimeContext = unknown;
+
+export default async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
+    return commands.measure.start('https://www.sitespeed.io');
+};


### PR DESCRIPTION
Node.js now supports TypeScript (see https://nodejs.org/api/typescript.html). Adding support for it in sitespeed/browseritime scripts.