### PR TITLE
Pull JIT dumps and markers after Simpleperf profiling

### DIFF
--- a/lib/core/engine/command/simpleperf.js
+++ b/lib/core/engine/command/simpleperf.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 const { join } = path;
 import { execa } from 'execa';
 import { existsSync, renameSync } from 'node:fs';
-import { isAndroidConfigured } from '../../../android/index.js';
+import { Android, isAndroidConfigured } from '../../../android/index.js';
 // const delay = ms => new Promise(res => setTimeout(res, ms));
 /**
  * Manages the collection of perfetto traces on Android.
@@ -104,7 +104,7 @@ export class SimplePerfProfiler {
     }
 
     // Execute simpleperf.
-    const packageName =
+    this.packageName =
       this.options.browser === 'firefox'
         ? this.options.firefox?.android?.package
         : this.options.chrome?.android?.package;
@@ -113,7 +113,7 @@ export class SimplePerfProfiler {
     let args = [
       ...profilerOptions,
       '-p',
-      packageName,
+      this.packageName,
       '-r',
       recordOptions,
       '--log',
@@ -167,6 +167,23 @@ export class SimplePerfProfiler {
     log.info('Stop simpleperf profiler.');
     this.simpleperfProcess.kill('SIGINT');
 
+    const pullJitMarkerFiles = async () => {
+      const android = new Android(this.options);
+      const filesDir = `/storage/emulated/0/Android/data/${this.packageName}/files`;
+      const listing = await android._runCommandAndGet(
+        `ls ${filesDir}/jit-* ${filesDir}/marker-* 2>/dev/null`
+      );
+      if (listing) {
+        for (const file of listing.split('\n').filter(f => f.trim())) {
+          const fileName = file.trim().split('/').pop();
+          await android._downloadFile(
+            file.trim(),
+            join(this.dataDir, fileName)
+          );
+        }
+      }
+    };
+
     // Return when "profiling is finished." is found, or an error.
     return new Promise((resolve, reject) => {
       let stderrStream = this.simpleperfProcess.stderr;
@@ -181,7 +198,9 @@ export class SimplePerfProfiler {
           this.profilerOptions.includes('--skip_collect_binaries')
         ) {
           stderrStream.removeAllListeners('data');
-          return resolve();
+          // Pull any JIT dumps and marker files if possible.
+          pullJitMarkerFiles().then(resolve).catch(resolve);
+          return;
         }
         if (/profiling is finished./.test(dataStr)) {
           stderrStream.removeAllListeners('data');
@@ -192,7 +211,8 @@ export class SimplePerfProfiler {
           } else {
             log.info('binary_cache does not exist.');
           }
-          return resolve();
+          pullJitMarkerFiles().then(resolve).catch(resolve);
+          return;
         }
       });
       stderrStream.once('error', reject);


### PR DESCRIPTION
Minor improvement: When `commands.simpleperf.stop()` is called during a Browsertime test, try and pull any JIT dumps and marker files that may be emitted by the browser from the Android device. These files can be used to enrich Simpleperf profiles.