### PR TITLE
Update index.js

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -154,10 +154,11 @@ export class Android {
   async getTemperature() {
     const temporary = Number(
       await this._runCommandAndGet(
-        `dumpsys battery | grep temperature | grep -Eo '[0-9]{1,3}'`
+        `dumpsys battery | awk '/^ *temperature:/ { print $2; exit }'`
       )
     );
-    return temporary / 10;
+    const temperature = Number(output.trim());
+    return Number.isFinite(temperature) ? temperature / 10 : undefined;
   }
 
   async getMeta() {


### PR DESCRIPTION
The current Android battery temperature parsing looks a bit too broad and can pick up unrelated numeric values from `dumpsys battery` output.

Today it uses:

```js
dumpsys battery | grep temperature | grep -Eo '[0-9]{1,3}'
```

That works only if the output contains a single relevant temperature match. On at least one real device I tested (Samsung A16 / Android 16), dumpsys battery returns both the expected battery field and additional log-style lines that also contain temperature, for example:

```
temperature: 242
03-23 14:19:54.299  Sending ACTION_BATTERY_CHANGED: ... temperature: 293, ...
03-23 14:27:46.675  Sending ACTION_BATTERY_CHANGED: ... temperature: 281, ...
```

With the current implementation, those extra matches can make the parser extract multiple unrelated numbers instead of the actual battery temperature field, which can then lead to invalid numeric values and downstream NaN warnings.

I’d suggest narrowing the parsing to the real temperature: field only, for example:

```js
async getTemperature() {
  const output = await this._runCommandAndGet(
    `dumpsys battery | awk '/^ *temperature:/ { print $2; exit }'`
  );
  const temperature = Number(output.trim());
  return Number.isFinite(temperature) ? temperature / 10 : undefined;
}
```

Why this looks safer:
- [x] matches only the actual battery temperature line
- [x] avoids unrelated numbers from additional output
- [x] preserves the existing / 10 conversion, which is correct for Android battery temperature values
- [x] returns undefined instead of propagating invalid values