### PR TITLE
Use WebDriver Actions API for click commands instead of JavaScript .click()

### DIFF
--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -1,15 +1,7 @@
 import { getLogger } from '@sitespeed.io/log';
+import { By } from 'selenium-webdriver';
 import { executeCommand } from './commandHelper.js';
 const log = getLogger('browsertime.command.click');
-
-function addClick(js) {
-  const trimmed = js.trim();
-  let script = `${trimmed}.click();`;
-  if (trimmed.endsWith(';')) {
-    script = `${trimmed.slice(0, -1)}.click();`;
-  }
-  return script;
-}
 
 /**
  * Provides functionality to perform click actions on elements in a web page using various selectors.
@@ -38,6 +30,15 @@ export class Click {
   }
 
   /**
+   * @private
+   */
+  async _clickElement(element) {
+    const driver = this.browser.getDriver();
+    await driver.actions({ async: true }).click(element).perform();
+    return driver.actions().clear();
+  }
+
+  /**
    * Clicks on an element identified by its class name.
    *
    * @async
@@ -50,11 +51,12 @@ export class Click {
       log,
       'Could not find element by class name %s',
       className,
-      () =>
-        this.browser.runScript(
-          `document.getElementsByClassName('${className}')[0].click();`,
-          'CUSTOM'
-        )
+      async () => {
+        const element = await this.browser
+          .getDriver()
+          .findElement(By.className(className));
+        return this._clickElement(element);
+      }
     );
   }
 
@@ -145,11 +147,11 @@ export class Click {
       log,
       'Could not find element by xpath %s',
       xpath,
-      () => {
-        // This is how Selenium do internally
-        const replaced = xpath.replaceAll('"', "'");
-        const script = `document.evaluate("${replaced}", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click();`;
-        return this.browser.runScript(script, 'CUSTOM');
+      async () => {
+        const element = await this.browser
+          .getDriver()
+          .findElement(By.xpath(xpath));
+        return this._clickElement(element);
       }
     );
   }
@@ -178,7 +180,14 @@ export class Click {
       log,
       'Could not find element by JavaScript %s',
       js,
-      () => this.browser.runScript(addClick(js), 'CUSTOM')
+      async () => {
+        const trimmed = js.trim();
+        const script = trimmed.endsWith(';')
+          ? `return ${trimmed.slice(0, -1)};`
+          : `return ${trimmed};`;
+        const element = await this.browser.getDriver().executeScript(script);
+        return this._clickElement(element);
+      }
     );
   }
 
@@ -203,11 +212,14 @@ export class Click {
    * @throws {Error} Throws an error if the element is not found.
    */
   async byId(id) {
-    return executeCommand(log, 'Could not find element by id %s', id, () =>
-      this.browser.runScript(
-        `document.getElementById('${id}').click();`,
-        'CUSTOM'
-      )
+    return executeCommand(
+      log,
+      'Could not find element by id %s',
+      id,
+      async () => {
+        const element = await this.browser.getDriver().findElement(By.id(id));
+        return this._clickElement(element);
+      }
     );
   }
 
@@ -220,11 +232,16 @@ export class Click {
    * @throws {Error} Throws an error if the element is not found.
    */
   async byName(name) {
-    return executeCommand(log, 'Could not find element by name %s', name, () =>
-      this.browser.runScript(
-        `document.querySelector("[name='${name}']").click()`,
-        'CUSTOM'
-      )
+    return executeCommand(
+      log,
+      'Could not find element by name %s',
+      name,
+      async () => {
+        const element = await this.browser
+          .getDriver()
+          .findElement(By.name(name));
+        return this._clickElement(element);
+      }
     );
   }
 
@@ -251,11 +268,12 @@ export class Click {
       log,
       'Could not click using selector %s',
       selector,
-      () =>
-        this.browser.runScript(
-          `document.querySelector('${selector}').click();`,
-          'CUSTOM'
-        )
+      async () => {
+        const element = await this.browser
+          .getDriver()
+          .findElement(By.css(selector));
+        return this._clickElement(element);
+      }
     );
   }
 

--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -37,7 +37,8 @@ export class Click {
    */
   async _clickElement(element) {
     const driver = this.browser.getDriver();
-    return driver.actions({ async: true }).click(element).perform();
+    await driver.actions({ async: true }).click(element).perform();
+    return driver.actions().clear();
   }
 
   /**

--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -5,6 +5,9 @@ const log = getLogger('browsertime.command.click');
 
 /**
  * Provides functionality to perform click actions on elements in a web page using various selectors.
+ * Uses the Selenium Actions API to generate real OS-level mouse events, which means
+ * the element must be visible and interactable. If you need to click a hidden element,
+ * use {@link JavaScript#run commands.js.run} to trigger a JavaScript click instead.
  *
  * @class
  * @hideconstructor

--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -34,8 +34,7 @@ export class Click {
    */
   async _clickElement(element) {
     const driver = this.browser.getDriver();
-    await driver.actions({ async: true }).click(element).perform();
-    return driver.actions().clear();
+    return driver.actions({ async: true }).click(element).perform();
   }
 
   /**

--- a/test/data/navigationscript/sameURLTwiceWithClick.cjs
+++ b/test/data/navigationscript/sameURLTwiceWithClick.cjs
@@ -7,6 +7,10 @@ module.exports = async function (context, commands) {
   await commands.js.run(
     'for (let node of document.body.childNodes) { if (node.style) node.style.display = "none";}'
   );
+  // Make the link visible so the Actions API click can interact with it
+  await commands.js.run(
+    "document.querySelector(\"a[href='/simple/']\").parentElement.style.display = '';"
+  );
   // Start measurning
   await commands.measure.start();
   // Click on the link for /simple/ and wait on navigation to happen


### PR DESCRIPTION
Switch click command methods from programmatic JavaScript .click() to Selenium WebDriver Actions API (findElement + actions.click.perform). This generates real OS-level mouse events that Chrome recognizes as user interactions, which is required for soft navigation detection.

One breaking change here: This will only click on visible elements.

Change-Id: I1ae103114024daf0e843df5ecd8058188e3d7a75