### PR TITLE
Add measure.clickAndMeasure() shortcut for click-and-measure pattern

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -338,6 +338,31 @@ export class Measure {
 
     return;
   }
+
+  /**
+   * @private
+   */
+  setClick(click) {
+    this._click = click;
+  }
+
+  /**
+   * Starts a measurement, clicks on an element matching the given CSS selector,
+   * waits for the page complete check, and stops the measurement. This is
+   * a shortcut for the common pattern of measure.start/click/measure.stop.
+   *
+   * @async
+   * @param {string} alias - The friendly name for this measurement.
+   * @param {string} selector - The CSS selector of the element to click.
+   * @returns {Promise} A promise that resolves with the collected metrics data.
+   * @throws {Error} Throws an error if the element is not found or the measurement fails.
+   */
+  async clickAndMeasure(alias, selector) {
+    await this.start(alias);
+    await this._click.bySelectorAndWait(selector);
+    return this.stop();
+  }
+
   /**
    * Stops the measurement process, collects metrics, and handles any post-measurement tasks.
    * It finalizes the URL being tested, manages any URL-specific metadata, stops any ongoing video recordings,

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -122,6 +122,8 @@ export class Commands {
      */
     this.click = new Click(browser, pageCompleteCheck);
 
+    measure.setClick(this.click);
+
     /**
      * Provides functionality to control page scrolling in the browser.
      * @type {Scroll}


### PR DESCRIPTION
Add a convenience method that combines the common three-step pattern of measure.start(alias) / click.bySelectorAndWait(selector) / measure.stop() into a single call: measure.clickAndMeasure(alias, selector).

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I1e39864f5dace055b51521d3cc00e5adf8a3a4bb