### PR TITLE
Add --timeouts.elementWait for auto-waiting on elements before intera…

### DIFF
--- a/lib/core/engine/command/addText.js
+++ b/lib/core/engine/command/addText.js
@@ -1,4 +1,4 @@
-import { By } from 'selenium-webdriver';
+import webdriver, { By } from 'selenium-webdriver';
 import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('browsertime.command.addText');
 
@@ -8,11 +8,25 @@ const log = getLogger('browsertime.command.addText');
  * @hideconstructor
  */
 export class AddText {
-  constructor(browser) {
+  constructor(browser, options) {
     /**
      * @private
      */
     this.browser = browser;
+    /**
+     * @private
+     */
+    this.options = options;
+  }
+
+  /**
+   * @private
+   */
+  async _waitForElement(driver, locator) {
+    const timeout = this.options?.timeouts?.elementWait ?? 0;
+    if (timeout > 0) {
+      await driver.wait(webdriver.until.elementLocated(locator), timeout);
+    }
   }
 
   /**
@@ -28,7 +42,9 @@ export class AddText {
   async byId(text, id) {
     const driver = this.browser.getDriver();
     try {
-      const element = await driver.findElement(By.id(id));
+      const locator = By.id(id);
+      await this._waitForElement(driver, locator);
+      const element = await driver.findElement(locator);
       // make sure we clear it
       await element.clear();
       return element.sendKeys(text);
@@ -57,7 +73,9 @@ export class AddText {
   async byXpath(text, xpath) {
     const driver = this.browser.getDriver();
     try {
-      const element = await driver.findElement(By.xpath(xpath));
+      const locator = By.xpath(xpath);
+      await this._waitForElement(driver, locator);
+      const element = await driver.findElement(locator);
       // make sure we clear it
       await element.clear();
       return element.sendKeys(text);
@@ -86,7 +104,9 @@ export class AddText {
   async bySelector(text, selector) {
     const driver = this.browser.getDriver();
     try {
-      const element = await driver.findElement(By.css(selector));
+      const locator = By.css(selector);
+      await this._waitForElement(driver, locator);
+      const element = await driver.findElement(locator);
       // make sure we clear it
       await element.clear();
       return element.sendKeys(text);
@@ -115,7 +135,9 @@ export class AddText {
   async byClassName(text, className) {
     const driver = this.browser.getDriver();
     try {
-      const element = await driver.findElement(By.className(className));
+      const locator = By.className(className);
+      await this._waitForElement(driver, locator);
+      const element = await driver.findElement(locator);
       // make sure we clear it
       await element.clear();
       return element.sendKeys(text);
@@ -144,7 +166,9 @@ export class AddText {
   async byName(text, name) {
     const driver = this.browser.getDriver();
     try {
-      const element = await driver.findElement(By.name(name));
+      const locator = By.name(name);
+      await this._waitForElement(driver, locator);
+      const element = await driver.findElement(locator);
       // make sure we clear it
       await element.clear();
       return element.sendKeys(text);

--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -1,5 +1,5 @@
 import { getLogger } from '@sitespeed.io/log';
-import { By } from 'selenium-webdriver';
+import webdriver, { By } from 'selenium-webdriver';
 import { executeCommand } from './commandHelper.js';
 const log = getLogger('browsertime.command.click');
 
@@ -13,7 +13,7 @@ const log = getLogger('browsertime.command.click');
  * @hideconstructor
  */
 export class Click {
-  constructor(browser, pageCompleteCheck) {
+  constructor(browser, pageCompleteCheck, options) {
     /**
      * @private
      */
@@ -22,6 +22,20 @@ export class Click {
      * @private
      */
     this.pageCompleteCheck = pageCompleteCheck;
+    /**
+     * @private
+     */
+    this.options = options;
+  }
+
+  /**
+   * @private
+   */
+  async _waitForElement(driver, locator) {
+    const timeout = this.options?.timeouts?.elementWait ?? 0;
+    if (timeout > 0) {
+      await driver.wait(webdriver.until.elementLocated(locator), timeout);
+    }
   }
 
   /**
@@ -55,9 +69,10 @@ export class Click {
       'Could not find element by class name %s',
       className,
       async () => {
-        const element = await this.browser
-          .getDriver()
-          .findElement(By.className(className));
+        const driver = this.browser.getDriver();
+        const locator = By.className(className);
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
         return this._clickElement(element);
       }
     );
@@ -151,9 +166,10 @@ export class Click {
       'Could not find element by xpath %s',
       xpath,
       async () => {
-        const element = await this.browser
-          .getDriver()
-          .findElement(By.xpath(xpath));
+        const driver = this.browser.getDriver();
+        const locator = By.xpath(xpath);
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
         return this._clickElement(element);
       }
     );
@@ -220,7 +236,10 @@ export class Click {
       'Could not find element by id %s',
       id,
       async () => {
-        const element = await this.browser.getDriver().findElement(By.id(id));
+        const driver = this.browser.getDriver();
+        const locator = By.id(id);
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
         return this._clickElement(element);
       }
     );
@@ -240,9 +259,10 @@ export class Click {
       'Could not find element by name %s',
       name,
       async () => {
-        const element = await this.browser
-          .getDriver()
-          .findElement(By.name(name));
+        const driver = this.browser.getDriver();
+        const locator = By.name(name);
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
         return this._clickElement(element);
       }
     );
@@ -272,9 +292,10 @@ export class Click {
       'Could not click using selector %s',
       selector,
       async () => {
-        const element = await this.browser
-          .getDriver()
-          .findElement(By.css(selector));
+        const driver = this.browser.getDriver();
+        const locator = By.css(selector);
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
         return this._clickElement(element);
       }
     );

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -120,7 +120,7 @@ export class Commands {
      * Provides functionality to perform click actions on elements in a web page using various selectors.
      * @type {Click}
      */
-    this.click = new Click(browser, pageCompleteCheck);
+    this.click = new Click(browser, pageCompleteCheck, options);
 
     /**
      * Provides functionality to control page scrolling in the browser.
@@ -132,7 +132,7 @@ export class Commands {
      * Provides functionality to add text to elements on a web page using various selectors.
      * @type {AddText}
      */
-    this.addText = new AddText(browser);
+    this.addText = new AddText(browser, options);
 
     /**
      * Provides functionality to wait for different conditions in the browser.

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -194,6 +194,13 @@ export function parseCommandLine() {
         'Timeout when running pageCompleteCheckNetworkIdle, in milliseconds',
       group: 'timeouts'
     })
+    .option('timeouts.elementWait', {
+      default: 0,
+      type: 'number',
+      describe:
+        'Timeout when waiting for an element to appear before interacting with it (click, addText etc), in milliseconds. Set to 0 to disable.',
+      group: 'timeouts'
+    })
     .option('chrome.args', {
       describe:
         'Extra command line arguments to pass to the Chrome process (e.g. --no-sandbox). ' +


### PR DESCRIPTION
…ction

Add a --timeouts.elementWait CLI option that makes click and addText commands automatically poll for the element to appear before acting. Default 0 (off) preserves current behavior. When set (e.g. --timeouts.elementWait 6000), commands wait up to that many milliseconds for the element to exist in the DOM before interacting.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I439fbba54da7d3e9e7521a02a6b7a7cd140ae67f