### PR TITLE
Add byText() and byTextAndWait() to click command

### DIFF
--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -138,6 +138,36 @@ export class Click {
   }
 
   /**
+   * Clicks on an element whose visible text matches the given string.
+   * This works on any element type, not just links.
+   *
+   * @async
+   * @param {string} text - The visible text of the element to click.
+   * @returns {Promise<void>} A promise that resolves when the click action is performed.
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async byText(text) {
+    return executeCommand(log, 'Could not find element by text %s', text, () =>
+      this.byXpath(`//*[normalize-space(text())='${text}']`)
+    );
+  }
+
+  /**
+   * Clicks on an element whose visible text matches the given string and waits for the page complete check to finish.
+   * This works on any element type, not just links.
+   *
+   * @async
+   * @param {string} text - The visible text of the element to click.
+   * @returns {Promise<void>} A promise that resolves when the click action and page complete check are finished.
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async byTextAndWait(text) {
+    return executeCommand(log, 'Could not find element by text %s', text, () =>
+      this.byXpathAndWait(`//*[normalize-space(text())='${text}']`)
+    );
+  }
+
+  /**
    * Clicks on an element that matches a given XPath selector.
    *
    * @async


### PR DESCRIPTION
Add click methods that match elements by visible text across all element types (buttons, spans, divs etc), not just <a> tags like byLinkText

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I5be4cce1a6072a0df83d5e8e7763b321c299ca00