### PR TITLE
Include current page URL in element interaction error messages

### DIFF
--- a/lib/core/engine/command/addText.js
+++ b/lib/core/engine/command/addText.js
@@ -16,6 +16,17 @@ export class AddText {
   }
 
   /**
+   * @private
+   */
+  async _getUrl() {
+    try {
+      return ` on ${await this.browser.getDriver().getCurrentUrl()}`;
+    } catch {
+      return '';
+    }
+  }
+
+  /**
    * Adds text to an element identified by its ID.
    *
    * @async
@@ -33,6 +44,7 @@ export class AddText {
       await element.clear();
       return element.sendKeys(text);
     } catch (error) {
+      const url = await this._getUrl();
       log.error(
         'Could not add text %s to id %s error:%s',
         text,
@@ -40,7 +52,7 @@ export class AddText {
         error.message
       );
       log.verbose(error);
-      throw new Error(`Could not add text ${text} to id ${id}`);
+      throw new Error(`Could not add text ${text} to id ${id}${url}`);
     }
   }
 
@@ -62,6 +74,7 @@ export class AddText {
       await element.clear();
       return element.sendKeys(text);
     } catch (error) {
+      const url = await this._getUrl();
       log.error(
         'Could not add text %s to xpath %s error: %s',
         text,
@@ -69,7 +82,7 @@ export class AddText {
         error.message
       );
       log.verbose(error);
-      throw new Error(`Could not add text ${text} to xpath ${xpath}`);
+      throw new Error(`Could not add text ${text} to xpath ${xpath}${url}`);
     }
   }
 
@@ -91,6 +104,7 @@ export class AddText {
       await element.clear();
       return element.sendKeys(text);
     } catch (error) {
+      const url = await this._getUrl();
       log.error(
         'Could not add text %s to selector %s error: %s',
         text,
@@ -98,7 +112,9 @@ export class AddText {
         error.message
       );
       log.verbose(error);
-      throw new Error(`Could not add text ${text} to selector ${selector}`);
+      throw new Error(
+        `Could not add text ${text} to selector ${selector}${url}`
+      );
     }
   }
 
@@ -120,6 +136,7 @@ export class AddText {
       await element.clear();
       return element.sendKeys(text);
     } catch (error) {
+      const url = await this._getUrl();
       log.error(
         'Could not add text %s to class name %s error: %s',
         text,
@@ -127,7 +144,9 @@ export class AddText {
         error.message
       );
       log.verbose(error);
-      throw new Error(`Could not add text ${text} to class name ${className}`);
+      throw new Error(
+        `Could not add text ${text} to class name ${className}${url}`
+      );
     }
   }
 
@@ -149,6 +168,7 @@ export class AddText {
       await element.clear();
       return element.sendKeys(text);
     } catch (error) {
+      const url = await this._getUrl();
       log.error(
         'Could not add text %s to name attribute %s error: %s',
         text,
@@ -156,7 +176,9 @@ export class AddText {
         error.message
       );
       log.verbose(error);
-      throw new Error(`Could not add text ${text} to name attribute ${name}`);
+      throw new Error(
+        `Could not add text ${text} to name attribute ${name}${url}`
+      );
     }
   }
 }

--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -59,7 +59,8 @@ export class Click {
           .getDriver()
           .findElement(By.className(className));
         return this._clickElement(element);
-      }
+      },
+      this.browser
     );
   }
 
@@ -84,8 +85,12 @@ export class Click {
    * @throws {Error} Throws an error if the link is not found.
    */
   async byLinkText(text) {
-    return executeCommand(log, 'Could not find link by text %s', text, () =>
-      this.byXpath(`//a[text()='${text}']`)
+    return executeCommand(
+      log,
+      'Could not find link by text %s',
+      text,
+      () => this.byXpath(`//a[text()='${text}']`),
+      this.browser
     );
   }
 
@@ -98,8 +103,12 @@ export class Click {
    * @throws {Error} Throws an error if the link is not found.
    */
   async byLinkTextAndWait(text) {
-    return executeCommand(log, 'Could not find link by text %s', text, () =>
-      this.byXpathAndWait(`//a[text()='${text}']`)
+    return executeCommand(
+      log,
+      'Could not find link by text %s',
+      text,
+      () => this.byXpathAndWait(`//a[text()='${text}']`),
+      this.browser
     );
   }
 
@@ -116,7 +125,8 @@ export class Click {
       log,
       'Could not find link by partial text %s',
       text,
-      () => this.byXpath(`//a[contains(text(),'${text}')]`)
+      () => this.byXpath(`//a[contains(text(),'${text}')]`),
+      this.browser
     );
   }
 
@@ -133,7 +143,8 @@ export class Click {
       log,
       'Could not find link by partial text %s',
       text,
-      () => this.byXpathAndWait(`//a[contains(text(),'${text}')]`)
+      () => this.byXpathAndWait(`//a[contains(text(),'${text}')]`),
+      this.browser
     );
   }
 
@@ -155,7 +166,8 @@ export class Click {
           .getDriver()
           .findElement(By.xpath(xpath));
         return this._clickElement(element);
-      }
+      },
+      this.browser
     );
   }
   /**
@@ -190,7 +202,8 @@ export class Click {
           : `return ${trimmed};`;
         const element = await this.browser.getDriver().executeScript(script);
         return this._clickElement(element);
-      }
+      },
+      this.browser
     );
   }
 
@@ -222,7 +235,8 @@ export class Click {
       async () => {
         const element = await this.browser.getDriver().findElement(By.id(id));
         return this._clickElement(element);
-      }
+      },
+      this.browser
     );
   }
 
@@ -244,7 +258,8 @@ export class Click {
           .getDriver()
           .findElement(By.name(name));
         return this._clickElement(element);
-      }
+      },
+      this.browser
     );
   }
 
@@ -276,7 +291,8 @@ export class Click {
           .getDriver()
           .findElement(By.css(selector));
         return this._clickElement(element);
-      }
+      },
+      this.browser
     );
   }
 

--- a/lib/core/engine/command/commandHelper.js
+++ b/lib/core/engine/command/commandHelper.js
@@ -9,22 +9,37 @@
  * @param {string} errorMessage - printf-style message (with %s placeholder).
  * @param {string|undefined} identifier - Value to interpolate into the message, or undefined if none.
  * @param {Function} fn - The async function to execute.
+ * @param {Object} [browser] - Optional browser instance. When provided, the current page URL is appended to the error message.
  * @returns {Promise<*>} The return value of fn.
  */
-export async function executeCommand(log, errorMessage, identifier, fn) {
+export async function executeCommand(
+  log,
+  errorMessage,
+  identifier,
+  fn,
+  browser
+) {
   try {
     return await fn();
   } catch (error) {
+    let url = '';
+    if (browser) {
+      try {
+        url = ` on ${await browser.getDriver().getCurrentUrl()}`;
+      } catch {
+        // If we can't get the URL, just skip it
+      }
+    }
+    const baseMessage =
+      identifier === undefined
+        ? errorMessage
+        : errorMessage.replace('%s', String(identifier));
     if (identifier === undefined) {
       log.error(errorMessage);
     } else {
       log.error(errorMessage, identifier);
     }
     log.verbose(error);
-    throw new Error(
-      identifier === undefined
-        ? errorMessage
-        : errorMessage.replace('%s', String(identifier))
-    );
+    throw new Error(`${baseMessage}${url}`);
   }
 }

--- a/lib/core/engine/command/mouse/singleClick.js
+++ b/lib/core/engine/command/mouse/singleClick.js
@@ -58,7 +58,8 @@ export class SingleClick {
           );
           return this.browser.extraWait(this.pageCompleteCheck);
         }
-      }
+      },
+      this.browser
     );
   }
 
@@ -99,7 +100,8 @@ export class SingleClick {
           );
           return this.browser.extraWait(this.pageCompleteCheck);
         }
-      }
+      },
+      this.browser
     );
   }
 
@@ -136,7 +138,8 @@ export class SingleClick {
           );
           return this.browser.extraWait(this.pageCompleteCheck);
         }
-      }
+      },
+      this.browser
     );
   }
 
@@ -161,8 +164,12 @@ export class SingleClick {
    * @throws {Error} Throws an error if the link is not found.
    */
   async byLinkText(text) {
-    return executeCommand(log, 'Could not find link by text %s', text, () =>
-      this.byXpath(`//a[text()='${text}']`)
+    return executeCommand(
+      log,
+      'Could not find link by text %s',
+      text,
+      () => this.byXpath(`//a[text()='${text}']`),
+      this.browser
     );
   }
 
@@ -175,8 +182,12 @@ export class SingleClick {
    * @throws {Error} Throws an error if the link is not found.
    */
   async byLinkTextAndWait(text) {
-    return executeCommand(log, 'Could not find link by text %s', text, () =>
-      this.byXpathAndWait(`//a[text()='${text}']`)
+    return executeCommand(
+      log,
+      'Could not find link by text %s',
+      text,
+      () => this.byXpathAndWait(`//a[text()='${text}']`),
+      this.browser
     );
   }
 
@@ -193,7 +204,8 @@ export class SingleClick {
       log,
       'Could not find link by partial text %s',
       text,
-      () => this.byXpath(`//a[contains(text(),'${text}')]`)
+      () => this.byXpath(`//a[contains(text(),'${text}')]`),
+      this.browser
     );
   }
 
@@ -211,7 +223,8 @@ export class SingleClick {
       log,
       'Could not find link by partial text %s',
       text,
-      () => this.byXpathAndWait(`//a[contains(text(),'${text}')]`)
+      () => this.byXpathAndWait(`//a[contains(text(),'${text}')]`),
+      this.browser
     );
   }
 
@@ -231,7 +244,8 @@ export class SingleClick {
       async () => {
         const element = await this.browser.getDriver().findElement(By.id(id));
         return this.actions.click(element).perform();
-      }
+      },
+      this.browser
     );
   }
 


### PR DESCRIPTION
When click, addText, or mouse commands fail to find an element, the error message now includes the page URL for easier debugging.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Id75886548da7c9171827e03527107551a848437d