### PR TITLE
Add commands.find() helper for element lookup with auto-wait

### DIFF
--- a/lib/core/engine/command/element.js
+++ b/lib/core/engine/command/element.js
@@ -1,17 +1,21 @@
 // We disable these because they are needed for code completion
 /* eslint no-unused-vars: "off" */
-import { By, WebElement } from 'selenium-webdriver';
+import webdriver, { By, WebElement } from 'selenium-webdriver';
 /**
  * This class provides a way to get hokld of Seleniums WebElements.
  * @class
  * @hideconstructor
  */
 export class Element {
-  constructor(browser) {
+  constructor(browser, options) {
     /**
      * @private
      */
     this.driver = browser.getDriver();
+    /**
+     * @private
+     */
+    this.options = options;
   }
 
   /**
@@ -62,5 +66,36 @@ export class Element {
    */
   async getByName(name) {
     return this.driver.findElement(By.name(name));
+  }
+
+  /**
+   * Finds an element using a CSS selector, with optional waiting and visibility check.
+   *
+   * @param {string} selector - The CSS selector of the element.
+   * @param {Object} [options] - Options for finding the element.
+   * @param {number} [options.timeout] - Maximum time in milliseconds to wait for the element. Defaults to the configured --timeouts.elementWait value.
+   * @param {boolean} [options.visible=false] - If true, waits for the element to be visible, not just present.
+   * @returns {Promise<WebElement>} A promise that resolves to the WebElement found.
+   * @throws {Error} Throws an error if the element is not found within the timeout.
+   */
+  async find(selector, options = {}) {
+    const timeout = options.timeout ?? this.options?.timeouts?.elementWait ?? 0;
+    const visible = options.visible ?? false;
+    const locator = By.css(selector);
+
+    if (timeout > 0) {
+      const element = await this.driver.wait(
+        webdriver.until.elementLocated(locator),
+        timeout
+      );
+      if (visible) {
+        await this.driver.wait(
+          webdriver.until.elementIsVisible(element),
+          timeout
+        );
+      }
+      return element;
+    }
+    return this.driver.findElement(locator);
   }
 }

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -300,6 +300,20 @@ export class Commands {
      * Get Selenium's WebElements.
      * @type {Element}
      */
-    this.element = new Element(browser);
+    this.element = new Element(browser, options);
+
+    /**
+     * Finds an element using a CSS selector, with optional waiting and visibility check.
+     * @async
+     * @example const element = await commands.find('.my-element', { timeout: 5000, visible: true });
+     * @param {string} selector - The CSS selector of the element.
+     * @param {Object} [options] - Options for finding the element.
+     * @param {number} [options.timeout] - Maximum time in milliseconds to wait for the element. Defaults to the configured --timeouts.elementWait value.
+     * @param {boolean} [options.visible=false] - If true, waits for the element to be visible.
+     * @returns {Promise<WebElement>} A promise that resolves to the WebElement found.
+     * @throws {Error} Throws an error if the element is not found.
+     * @type {Function}
+     */
+    this.find = this.element.find.bind(this.element);
   }
 }


### PR DESCRIPTION
Add a find(selector, options) method that combines element lookup with optional waiting and visibility checks. Uses the configured --timeouts.elementWait as default timeout, so it auto-waits when that option is set. Timeout can be overridden per-call.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I24a347097604f60fd2c579f5bbe0656092a2dd56