### PR TITLE
Add commands.type() as shorthand for addText.bySelector()

### DIFF
--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -301,5 +301,21 @@ export class Commands {
      * @type {Element}
      */
     this.element = new Element(browser);
+
+    /**
+     * Types text into an element identified by a CSS selector.
+     * This is a convenience method that wraps {@link AddText#bySelector addText.bySelector}
+     * with a more conventional parameter order (selector first, then text).
+     * @async
+     * @example await commands.type('#search-input', 'search term');
+     * @param {string} selector - The CSS selector of the element.
+     * @param {string} text - The text to type into the element.
+     * @returns {Promise<void>} A promise that resolves when the text has been added.
+     * @throws {Error} Throws an error if the element is not found.
+     * @type {Function}
+     */
+    this.type = async (selector, text) => {
+      return this.addText.bySelector(text, selector);
+    };
   }
 }


### PR DESCRIPTION
Add commands.type(selector, text) as a convenience method with a more conventional parameter order (selector first, then text) compared to addText.bySelector(text, selector).

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Icc2a5c509074b2a8dbd1d69d1a40c727f14a7229