### PR TITLE
Change default timeouts.elementWait from 0 to 6000ms

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -195,10 +195,10 @@ export function parseCommandLine() {
       group: 'timeouts'
     })
     .option('timeouts.elementWait', {
-      default: 0,
+      default: 6000,
       type: 'number',
       describe:
-        'Timeout when waiting for an element to appear before interacting with it (click, addText etc), in milliseconds. Set to 0 to disable.',
+        'Timeout when waiting for an element to appear before interacting with it (click, addText etc), in milliseconds. Default is 6000 (6 seconds). Set to 0 to disable.',
       group: 'timeouts'
     })
     .option('chrome.args', {


### PR DESCRIPTION
Make element commands (click, addText) auto-wait up to 6 seconds for elements to appear by default. Previously the default was 0 (disabled), requiring manual commands.wait.* calls before interacting.

Users can set --timeouts.elementWait 0 to restore the old behavior.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Icf450fdbc46cf316ce745821ae829084cebc2a08