### PR TITLE
Add unified selector syntax for commands.click() and deprecate AndWait methods

### DIFF
--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -1,6 +1,7 @@
 import { getLogger } from '@sitespeed.io/log';
 import webdriver, { By } from 'selenium-webdriver';
 import { executeCommand } from './commandHelper.js';
+import { parseSelector } from './selectorParser.js';
 const log = getLogger('browsertime.command.click');
 
 /**
@@ -42,6 +43,9 @@ export class Click {
    * @private
    */
   async _andWait(baseMethod, ...args) {
+    log.info(
+      'The AndWait methods are deprecated. Use commands.click(selector, { wait: true }) instead.'
+    );
     await baseMethod.apply(this, args);
     return this.browser.extraWait(this.pageCompleteCheck);
   }
@@ -53,6 +57,37 @@ export class Click {
     const driver = this.browser.getDriver();
     await driver.actions({ async: true }).click(element).perform();
     return driver.actions().clear();
+  }
+
+  /**
+   * Clicks on an element using a unified selector string.
+   * Supports CSS selectors (default), and prefix-based strategies:
+   * 'id:myId', 'xpath://button', 'text:Submit', 'link:Click here', 'name:email', 'class:btn'.
+   *
+   * @async
+   * @param {string} selector - The selector string. CSS by default, or use a prefix like 'id:', 'xpath:', 'text:', 'link:', 'name:', 'class:'.
+   * @param {Object} [options] - Options for the click action.
+   * @param {boolean} [options.wait=false] - If true, waits for the page complete check after clicking.
+   * @returns {Promise<void>} A promise that resolves when the click action is performed.
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async run(selector, options = {}) {
+    const { locator, description } = parseSelector(selector);
+    return executeCommand(
+      log,
+      'Could not find element by %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await this._clickElement(element);
+        if (options.wait) {
+          await this.browser.extraWait(this.pageCompleteCheck);
+        }
+      },
+      this.browser
+    );
   }
 
   /**

--- a/lib/core/engine/command/selectorParser.js
+++ b/lib/core/engine/command/selectorParser.js
@@ -1,0 +1,58 @@
+import { By } from 'selenium-webdriver';
+
+/**
+ * Parses a selector string into a Selenium By locator.
+ * Supports prefix-based strategies:
+ * - 'id:value' -> By.id('value')
+ * - 'xpath:expression' -> By.xpath('expression')
+ * - 'name:value' -> By.name('value')
+ * - 'text:value' -> By.xpath('//*[normalize-space(text())="value"]')
+ * - 'link:value' -> By.xpath('//a[text()="value"]')
+ * - 'class:value' -> By.className('value')
+ * - No prefix -> By.css(selector) (CSS selector is the default)
+ *
+ * @param {string} selector - The selector string to parse.
+ * @returns {{ locator: By, description: string }} The parsed locator and a human-readable description.
+ */
+export function parseSelector(selector) {
+  const colonIndex = selector.indexOf(':');
+  if (colonIndex > 0) {
+    const prefix = selector.slice(0, colonIndex).toLowerCase();
+    const value = selector.slice(colonIndex + 1);
+    switch (prefix) {
+      case 'id': {
+        return { locator: By.id(value), description: `id ${value}` };
+      }
+      case 'xpath': {
+        return { locator: By.xpath(value), description: `xpath ${value}` };
+      }
+      case 'name': {
+        return { locator: By.name(value), description: `name ${value}` };
+      }
+      case 'text': {
+        return {
+          locator: By.xpath(`//*[normalize-space(text())='${value}']`),
+          description: `text ${value}`
+        };
+      }
+      case 'link': {
+        return {
+          locator: By.xpath(`//a[text()='${value}']`),
+          description: `link text ${value}`
+        };
+      }
+      case 'class': {
+        return {
+          locator: By.className(value),
+          description: `class ${value}`
+        };
+      }
+      default: {
+        // Unknown prefix — treat entire string as CSS selector
+        return { locator: By.css(selector), description: `css ${selector}` };
+      }
+    }
+  }
+  // No prefix — CSS selector
+  return { locator: By.css(selector), description: `css ${selector}` };
+}

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -118,9 +118,34 @@ export class Commands {
 
     /**
      * Provides functionality to perform click actions on elements in a web page using various selectors.
-     * @type {Click}
+     * Can be called directly as a function with a unified selector string, or use the
+     * existing by* methods for backward compatibility.
+     * @type {Function & Click}
      */
-    this.click = new Click(browser, pageCompleteCheck, options);
+    const clickInstance = new Click(browser, pageCompleteCheck, options);
+
+    /**
+     * Click on an element using a unified selector string.
+     * Supports CSS selectors (default), and prefixes: 'id:', 'xpath:', 'text:', 'link:', 'name:', 'class:'.
+     * @async
+     * @example await commands.click('#login-btn');
+     * @example await commands.click('id:login-btn');
+     * @example await commands.click('text:Submit', { wait: true });
+     * @param {string} selector - The selector string.
+     * @param {Object} [clickOptions] - Options for the click.
+     * @param {boolean} [clickOptions.wait=false] - If true, waits for page complete check after clicking.
+     * @returns {Promise<void>}
+     */
+    this.click = async (selector, clickOptions) =>
+      clickInstance.run(selector, clickOptions);
+    // Preserve all existing by* methods for backward compatibility
+    for (const key of Object.getOwnPropertyNames(
+      Object.getPrototypeOf(clickInstance)
+    )) {
+      if (key !== 'constructor' && typeof clickInstance[key] === 'function') {
+        this.click[key] = clickInstance[key].bind(clickInstance);
+      }
+    }
 
     measure.setClick(this.click);
 


### PR DESCRIPTION

Add commands.click(selector, options) with prefix-based selector strategies: id:, xpath:, text:, link:, name:, class: — CSS selector is the default.

The { wait: true } option replaces the AndWait method variants, which now log a deprecation notice. All existing by* methods are preserved for backward compatibility.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I48dcb7307836b8bc5d24257ffddda76224bf06ce