### PR TITLE
Fix Firefox network idle timeout on repeated iterations

### DIFF
--- a/lib/firefox/networkManager.js
+++ b/lib/firefox/networkManager.js
@@ -14,6 +14,21 @@ export class NetworkManager {
     this.idleTime = getProperty(options, 'timeouts.networkIdle', 5000);
   }
 
+  async _cleanup(messageHandler) {
+    if (messageHandler && this.ws) {
+      this.ws.removeListener('message', messageHandler);
+    }
+    await this.bidi.unsubscribe(
+      'network.beforeRequestSent',
+      this.browsingContextIds
+    );
+    await this.bidi.unsubscribe(
+      'network.responseCompleted',
+      this.browsingContextIds
+    );
+    await this.bidi.unsubscribe('network.fetchError', this.browsingContextIds);
+  }
+
   async waitForNetworkIdle() {
     await this.bidi.subscribe(
       'network.beforeRequestSent',
@@ -29,7 +44,7 @@ export class NetworkManager {
     let lastRequestTimestamp;
     let lastResponseTimestamp;
     this.ws = await this.bidi.socket;
-    this.ws.on('message', function (event) {
+    const messageHandler = function (event) {
       const { method } = JSON.parse(Buffer.from(event.toString()));
       if (method) {
         switch (method) {
@@ -54,7 +69,8 @@ export class NetworkManager {
           // No default
         }
       }
-    });
+    };
+    this.ws.on('message', messageHandler);
 
     const startTime = Date.now();
 
@@ -71,20 +87,7 @@ export class NetworkManager {
               inflight
           );
         }
-        await this.bidi.unsubscribe(
-          'network.beforeRequestSent',
-          this.browsingContextIds
-        );
-        await this.bidi.unsubscribe(
-          'network.responseCompleted',
-          this.browsingContextIds
-        );
-
-        await this.bidi.unsubscribe(
-          'network.fetchError',
-          this.browsingContextIds
-        );
-
+        await this._cleanup(messageHandler);
         break;
       }
 
@@ -92,18 +95,7 @@ export class NetworkManager {
         log.info(
           'Timeout waiting for network idle. Inflight requests:' + inflight
         );
-        await this.bidi.unsubscribe(
-          'network.beforeRequestSent',
-          this.browsingContextIds
-        );
-        await this.bidi.unsubscribe(
-          'network.responseCompleted',
-          this.browsingContextIds
-        );
-        await this.bidi.unsubscribe(
-          'network.fetchError',
-          this.browsingContextIds
-        );
+        await this._cleanup(messageHandler);
         break;
       }
 


### PR DESCRIPTION
The WebSocket message listener for BiDi network events was never removed between iterations, causing listener leaks.

Old listeners would decrement a stale inflight counter, driving it negative (-1), which prevented the idle check from ever succeeding. Store the handler as a named function and remove it on cleanup.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I2f8e7b72eb948332c54966aa18e7000128b5a110