### PR TITLE
Fix intermittent crash when setting orange background before body exists

### DIFF
--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -6,6 +6,9 @@ export async function setOrangeBackground(driver) {
   // We tried other ways for Android (access an orange page)
   // That works fine ... but break scripts
   // https://github.com/sitespeedio/browsertime/issues/802
+  // Wait for document.body to exist before trying to add the orange overlay
+  await driver.wait(until.elementsLocated(By.css('body')));
+
   const orangeScript = `
         (function() {
           const orange = document.createElement('div');


### PR DESCRIPTION
On Edge/Windows the orange overlay script could run before document.body existed, causing Cannot read properties of null (reading 'clientWidth'). Wait for the body element to be present before executing the script.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I57c0b3d3d80a790567d93c4de28ae633ff796256