### PR TITLE
Fix Firefox network idle timeout when no network events arrive

### DIFF
--- a/lib/firefox/networkManager.js
+++ b/lib/firefox/networkManager.js
@@ -41,8 +41,8 @@ export class NetworkManager {
     await this.bidi.subscribe('network.fetchError', this.browsingContextIds);
 
     let inflight = 0;
-    let lastRequestTimestamp;
-    let lastResponseTimestamp;
+    let lastRequestTimestamp = Date.now();
+    let lastResponseTimestamp = Date.now();
     this.ws = await this.bidi.socket;
     const messageHandler = function (event) {
       const { method } = JSON.parse(Buffer.from(event.toString()));


### PR DESCRIPTION
he network idle timestamps were initialized as undefined, so Math.max(undefined, undefined) returned NaN and the idle check never triggered when no network events arrived after subscribing. Initialize timestamps to Date.now() so the idle timer starts immediately.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Iea3eb58f248971d540416c84a30b62efba9372e8