### PR TITLE
Split Chrome CI into parallel basic and video jobs

### DIFF
--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -7,7 +7,93 @@ on:
     branches:
     - main
 jobs:
-  build:
+  basic:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: block
+        allowed-endpoints: >
+          accounts.google.com:443
+          android.clients.google.com:443
+          api.snapcraft.io:443
+          azure.archive.ubuntu.com:80
+          canonical-bos01.cdn.snapcraftcontent.com:443
+          canonical-lgw01.cdn.snapcraftcontent.com:443
+          clients2.google.com:80
+          dl-ssl.google.com:443
+          dl.google.com:80
+          esm.ubuntu.com:443
+          files.pythonhosted.org:443
+          github.com:443
+          motd.ubuntu.com:443
+          msedgedriver.microsoft.com:443
+          mtalk.google.com:5228
+          nodejs.org:443
+          packages.microsoft.com:443
+          pypi.org:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
+          www.google.com:443
+          www.sitespeed.io:443
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Use Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      with:
+        node-version: '24.x'
+        cache: 'npm'
+    - name: Install latest Chrome
+      run: |
+        wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+        sudo apt-get update
+        sudo apt-get --only-upgrade install google-chrome-stable
+        google-chrome --version
+    - name: Install Browsertime
+      run: npm ci
+    - name: Install dependencies
+      run: |
+        sudo apt-get install net-tools -y
+        python -m pip install virtualenv
+        sudo modprobe ifb numifbs=1
+    - name: Start local HTTP server
+      run: (npm run start-server&)
+    - name: Test Chrome with CPU throttle and preURL
+      run: ./bin/browsertime.js -b chrome --skipHar -n 1 --preURL http://127.0.0.1:3000/simple/ -r header:value --chrome.CPUThrottlingRate 2 --chrome.cdp.performance --xvfb --chrome.enableChromeDriverLog --chrome.collectConsoleLog http://127.0.0.1:3000/dimple/
+    - name: Test pre/post scripts
+      run: ./bin/browsertime.js -b chrome test/data/navigationscript/measure.cjs -n 1 --preScript test/data/prepostscripts/preSample.cjs --postScript test/data/prepostscripts/postSample.cjs --xvfb
+    - name: Test Chrome with emulated mobile
+      run: ./bin/browsertime.js -b chrome --chrome.mobileEmulation.deviceName 'iPhone 6' http://127.0.0.1:3000/simple/ --xvfb
+    - name: Test Chrome with web driver nagivation
+      run: ./bin/browsertime.js -b chrome -n 1 http://127.0.0.1:3000/simple/ --webdriverPageload --xvfb
+    - name: Test navigate to the same URL twice
+      run: ./bin/browsertime.js -b chrome test/data/navigationscript/sameURLTwice.cjs -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
+    - name: Test navigate to the same URL twice by clicking on a link
+      run: ./bin/browsertime.js -b chrome test/data/navigationscript/sameURLTwiceWithClick.cjs -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
+    - name: Test using alias for one URL
+      run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ --urlAlias my_url --xvfb
+    - name: Test using alias for multiple URLs
+      run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ http://127.0.0.1:3000/dimple/ --urlAlias startPage --urlAlias documentation --xvfb
+    - name: Run test with pre-test functionality
+      run: ./bin/browsertime.js -b chrome --preWarmServer --xvfb http://127.0.0.1:3000/simple/
+    - name: Run test with screenshots
+      run: ./bin/browsertime.js -b chrome --screenshotLCP --screenshotLS --xvfb http://127.0.0.1:3000/simple/
+    - name: Run test with tcp dump
+      run: ./bin/browsertime.js -b chrome --xvfb http://127.0.0.1:3000/simple/ -n 1 --tcpdump
+    - name: Run test with scripting.mjs
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.mjs
+    - name: Run test with scripting.cjs
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.cjs
+    - name: Run test with scripting.js
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.js --cjs
+    - name: Run test with scripting.js
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.js
+    - name: Test extra profile run Chrome
+      run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ -n 1 --viewPort 1000x600 --xvfb  --enableProfileRun
+  video:
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
@@ -62,52 +148,13 @@ jobs:
         python -m pip install --upgrade --user pip
         python -m pip install --upgrade --user setuptools==70.0.0
         python -m pip install --user pyssim OpenCV-Python Numpy
-        python -m pip --version
-        python -m pip show Pillow
-        python -m pip show pyssim
         python -m pip install virtualenv
         sudo modprobe ifb numifbs=1
-    - name: Browser versions
-      run: |
-        google-chrome --version
     - name: Start local HTTP server
       run: (npm run start-server&)
-    # - run: VTENV_OPTS="-p python3" make test
-    - name: Test Chrome with CPU throttle and preURL
-      run: ./bin/browsertime.js -b chrome --skipHar -n 1 --preURL http://127.0.0.1:3000/simple/ -r header:value --chrome.CPUThrottlingRate 2 --chrome.cdp.performance --xvfb --chrome.enableChromeDriverLog --chrome.collectConsoleLog http://127.0.0.1:3000/dimple/
-    - name: Test pre/post scripts
-      run: ./bin/browsertime.js -b chrome test/data/navigationscript/measure.cjs -n 1 --preScript test/data/prepostscripts/preSample.cjs --postScript test/data/prepostscripts/postSample.cjs --xvfb
-    - name: Test navigation and page complete check inactivity
-      run: ./bin/browsertime.js -b chrome test/data/navigationscript/navigateAndStartInTwoSteps.cjs -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
     - name: Test multi pages with video and visual metrics
       run: ./bin/browsertime.js -b chrome test/data/navigationscript/multi.cjs -n 3 --chrome.timeline --video --visualMetrics --visualElements --viewPort 1000x600 --xvfb
-    - name: Test Chrome with emulated mobile
-      run: ./bin/browsertime.js -b chrome --chrome.mobileEmulation.deviceName 'iPhone 6' http://127.0.0.1:3000/simple/ --xvfb
-    - name: Test Chrome with web driver nagivation
-      run: ./bin/browsertime.js -b chrome -n 1 http://127.0.0.1:3000/simple/ --webdriverPageload --xvfb
-    - name: Test navigate to the same URL twice
-      run: ./bin/browsertime.js -b chrome test/data/navigationscript/sameURLTwice.cjs -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
-    - name: Test navigate to the same URL twice by clicking on a link
-      run: ./bin/browsertime.js -b chrome test/data/navigationscript/sameURLTwiceWithClick.cjs -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
-    - name: Test using alias for one URL
-      run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ --urlAlias my_url --xvfb
-    - name: Test using alias for multiple URLs
-      run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ http://127.0.0.1:3000/dimple/ --urlAlias startPage --urlAlias documentation --xvfb
-    - name: Run test with pre-test functionality
-      run: ./bin/browsertime.js -b chrome --preWarmServer --xvfb http://127.0.0.1:3000/simple/
-    - name: Run test with screenshots
-      run: ./bin/browsertime.js -b chrome --screenshotLCP --screenshotLS --xvfb http://127.0.0.1:3000/simple/
+    - name: Test navigation and page complete check inactivity
+      run: ./bin/browsertime.js -b chrome test/data/navigationscript/navigateAndStartInTwoSteps.cjs -n 1 --pageCompleteCheckInactivity --timeToSettle 1000 --xvfb
     - name: Run test with check network idle in Chrome
       run: ./bin/browsertime.js -b chrome --pageCompleteCheckNetworkIdle --xvfb http://127.0.0.1:3000/simple/
-    - name: Run test with tcp dump
-      run: ./bin/browsertime.js -b chrome --xvfb http://127.0.0.1:3000/simple/ -n 1 --tcpdump
-    - name: Run test with scripting.mjs
-      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.mjs
-    - name: Run test with scripting.cjs
-      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.cjs
-    - name: Run test with scripting.js
-      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/common.js --cjs
-    - name: Run test with scripting.js
-      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/scripting/module.js
-    - name: Test extra profile run Chrome
-      run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ -n 1 --viewPort 1000x600 --xvfb  --enableProfileRun


### PR DESCRIPTION
Split the Chrome workflow into two parallel jobs to halve wall-clock time from ~12 min to ~6 min. The basic job runs 16 fast tests without video dependencies. The video job runs 3 slow tests (multi pages with visualMetrics, network idle, page complete check inactivity) that need ffmpeg and Python.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: If1c5b296dd81ca7e318d9b7134c1b58b3440a719