### PR TITLE
Rename click wait option from wait to waitForNavigation

### DIFF
--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -67,7 +67,7 @@ export class Click {
    * @async
    * @param {string} selector - The selector string. CSS by default, or use a prefix like 'id:', 'xpath:', 'text:', 'link:', 'name:', 'class:'.
    * @param {Object} [options] - Options for the click action.
-   * @param {boolean} [options.wait=false] - If true, waits for the page complete check after clicking.
+   * @param {boolean} [options.waitForNavigation=false] - If true, waits for the page complete check after clicking.
    * @returns {Promise<void>} A promise that resolves when the click action is performed.
    * @throws {Error} Throws an error if the element is not found.
    */
@@ -82,7 +82,7 @@ export class Click {
         await this._waitForElement(driver, locator);
         const element = await driver.findElement(locator);
         await this._clickElement(element);
-        if (options.wait) {
+        if (options.waitForNavigation) {
           await this.browser.extraWait(this.pageCompleteCheck);
         }
       },

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -130,10 +130,10 @@ export class Commands {
      * @async
      * @example await commands.click('#login-btn');
      * @example await commands.click('id:login-btn');
-     * @example await commands.click('text:Submit', { wait: true });
+     * @example await commands.click('text:Submit', { waitForNavigation: true });
      * @param {string} selector - The selector string.
      * @param {Object} [clickOptions] - Options for the click.
-     * @param {boolean} [clickOptions.wait=false] - If true, waits for page complete check after clicking.
+     * @param {boolean} [clickOptions.waitForNavigation=false] - If true, waits for the page to complete loading after clicking.
      * @returns {Promise<void>}
      */
     this.click = async (selector, clickOptions) =>


### PR DESCRIPTION
Rename the { wait: true } option to { waitForNavigation: true } in the unified commands.click() method. The new name makes it clear that we're waiting for the page to complete loading after a navigation, not just waiting for the element.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I45f95021166f6c0b96ce41b947b308ce100f0121