### PR TITLE
Update scripting documentation with new API features

### DIFF
--- a/jsdoc/tutorials/02-Running-Scripts.md
+++ b/jsdoc/tutorials/02-Running-Scripts.md
@@ -55,10 +55,10 @@ export default async function (context, commands) {
   await commands.measure.start(
     'https://dashboard.sitespeed.io/d/000000044/page-timing-metrics?orgId=1','pageTimingMetricsDefault'
   );
-  await commands.click.byClassName('gf-timepicker-nav-btn');
+  await commands.click('class:gf-timepicker-nav-btn');
   await commands.wait.byTime(1000);
   await commands.measure.start('pageTimingMetrics30Days');
-  await commands.click.byLinkTextAndWait('Last 30 days');
+  await commands.click('link:Last 30 days', { waitForNavigation: true });
   await commands.measure.stop();
 };
 ~~~

--- a/jsdoc/tutorials/03-Measurement-Commands.md
+++ b/jsdoc/tutorials/03-Measurement-Commands.md
@@ -32,9 +32,24 @@ export default async function (context, commands) {
   await commands.navigate('https://www.sitespeed.io');
 
   await commands.measure.start('Documentation');
-  // Using a xxxAndWait command will make the page wait for a navigation
-  await commands.click.byLinkTextAndWait('Documentation');
+  await commands.click('link:Documentation', { waitForNavigation: true });
   return commands.measure.stop();
+}
+```
+
+### Click and measure shortcut
+
+For the common pattern of start/click/stop, you can use `clickAndMeasure`:
+
+```javascript
+/**
+ * @param {import('browsertime').BrowsertimeContext} context
+ * @param {import('browsertime').BrowsertimeCommands} commands
+ */
+export default async function (context, commands) {
+  await commands.navigate('https://www.sitespeed.io');
+  // This is equivalent to measure.start + click.bySelectorAndWait + measure.stop
+  return commands.measure.clickAndMeasure('Documentation', 'a[href="/documentation/"]');
 }
 ```
 
@@ -119,7 +134,7 @@ Here's an example on how to do that:
 export default async function (context, commands) {
   await commands.measure.start('https://react.dev');
   await commands.measure.start('Learn');
-  await commands.mouse.singleClick.byLinkTextAndWait('Learn');
+  await commands.click('link:Learn', { waitForNavigation: true });
   return commands.measure.stop();
 }
 ```

--- a/jsdoc/tutorials/04-Interact-with-the-page.md
+++ b/jsdoc/tutorials/04-Interact-with-the-page.md
@@ -1,6 +1,33 @@
 There are multiple ways to interact with the current page. We have tried to add the most common ways so you don't need to use Selenium directly, and if yoiu think something is missing, please [create an issue](https://github.com/sitespeedio/browsertime/issues/new). 
 
+## Auto-wait for elements
+
+By default, Browsertime waits up to 6 seconds for elements to appear before interacting with them. This means you usually don’t need explicit `commands.wait.*` calls before clicking or typing — the commands will automatically poll until the element exists in the DOM.
+
+You can configure the timeout with `--timeouts.elementWait`:
+
+```bash
+# Wait up to 10 seconds for elements
+browsertime --timeouts.elementWait 10000 myScript.mjs
+
+# Disable auto-wait (fail immediately if element not found)
+browsertime --timeouts.elementWait 0 myScript.mjs
+```
+
 ## Finding elements
+
+You can use `commands.find(selector, options)` to find an element and get a Selenium WebElement back. It uses the configured `--timeouts.elementWait` as the default timeout:
+
+```javascript
+// Find an element (auto-waits using the configured timeout)
+const element = await commands.find(‘#my-element’);
+
+// Find with a custom timeout
+const element = await commands.find(‘#my-element’, { timeout: 5000 });
+
+// Wait for the element to be visible, not just present in the DOM
+const element = await commands.find(‘#my-element’, { timeout: 5000, visible: true });
+```
 
 One of the key things in your script is to be able to find the right element to invoke. If the element has an id it’s easy. If not you can use developer tools in your favourite browser. The all work mostly the same: Open DevTools in the page you want to inspect, click on the element and right click on DevTools for that element. Then you will see something like this:
 
@@ -79,11 +106,10 @@ Run JavaScript and wait for [page complete check](/documentation/sitespeed.io/br
 
 
 ## Click
-The click command finds an element and runs `.click()` on the element.
+The click command finds an element and clicks it using real OS-level mouse events via the Selenium Actions API. The element must be visible and interactable.
 
-Click commands have two different versions: One that will return a promise when the link has been clicked and one that will return a promise that will be fullfilled when the link has been clicked and the browser navigated to the new URL and the [page complete check](/documentation/sitespeed.io/browsers/#choose-when-to-end-your-test) is done.
-
-If it does not find the link, it will throw an error, so make sure to catch it if you want an alternative flow.
+### Unified selector syntax (recommended)
+The simplest way to click is using `commands.click(selector)` with a unified selector string. CSS selectors are the default, and you can use prefixes for other strategies:
 
 ```javascript
 /**
@@ -92,14 +118,39 @@ If it does not find the link, it will throw an error, so make sure to catch it i
  */
 export default async function (context, commands) {
   await commands.navigate('https://www.sitespeed.io/');
-  try {
-    await commands.click.byLinkText('Documentation');
-    await commands.click.byLinkTextAndWait('Documentation');
-  } catch(error) {
-    context.log.error('Could not find the link text "Documentation"', error);
-  }
+
+  // CSS selector (default)
+  await commands.click('#login-btn');
+
+  // By text content (any element, not just links)
+  await commands.click('text:Documentation');
+
+  // By link text (only <a> tags)
+  await commands.click('link:Documentation');
+
+  // By ID
+  await commands.click('id:login-btn');
+
+  // By XPath
+  await commands.click('xpath://button[contains(text(), "Submit")]');
+
+  // By name attribute
+  await commands.click('name:email');
+
+  // By class name
+  await commands.click('class:btn-primary');
+
+  // Wait for page complete check after clicking (replaces AndWait methods)
+  await commands.click('link:Documentation', { waitForNavigation: true });
 }
 ```
+
+Supported prefixes: `id:`, `xpath:`, `text:`, `link:`, `name:`, `class:`. No prefix means CSS selector.
+
+### Legacy click methods
+The older `commands.click.bySelector()`, `commands.click.byId()` etc. methods still work. The `AndWait` variants (like `byLinkTextAndWait`) are deprecated — use `commands.click(selector, { waitForNavigation: true })` instead.
+
+If it does not find the element, it will throw an error with the current page URL included for easier debugging.
 
 ### All click commands
 You can find all the [click commands here](Click.html).
@@ -146,8 +197,19 @@ export default async function (context, commands) {
 };
 ```
 
-## Add text
-You can add text to input elements. The element needs to visible. You can also send pressable keys as Unicode PUA ([PrivateUser Area](https://en.wikipedia.org/wiki/Private_Use_Areas)) format. 
+## Type text
+
+The easiest way to type text into an input element is using `commands.type(selector, text)`:
+
+```javascript
+await commands.type('#search-input', 'my search query');
+await commands.type('.email-field', 'user@example.com');
+```
+
+The parameter order is selector first, then text — matching the convention used by most frameworks.
+
+### Add text (legacy)
+You can also use the `addText` command. The element needs to be visible. You can also send pressable keys as Unicode PUA ([PrivateUser Area](https://en.wikipedia.org/wiki/Private_Use_Areas)) format.
 
 The [add text command](AddText.html).
 

--- a/jsdoc/tutorials/09-Examples.md
+++ b/jsdoc/tutorials/09-Examples.md
@@ -1,5 +1,7 @@
 Here are some examples on how you can use the scripting capabilities.
 
+> **Note:** Some examples below use the older `commands.click.byIdAndWait()` and `commands.addText.byId()` style. The recommended approach is to use `commands.click(selector, { wait: true })` and `commands.type(selector, text)` instead. The `AndWait` methods are deprecated. See the [interaction tutorial](tutorial-04-Interact-with-the-page.html) for details.
+
 ### Measure multiple pages
 
 Test multiple pages in a script:


### PR DESCRIPTION
Update tutorials to document the unified selector syntax (commands.click('#btn')), waitForNavigation option, commands.type(), commands.find(), commands.measure.clickAndMeasure(), auto-wait for elements, and AndWait deprecation. Add a note to the examples page about the recommended new style.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I12751205579aac656955cf13e26aeffc30953355