### PR TITLE
Speed up macOS CI by skipping brew update and installing browsers in parallel

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,12 +28,14 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
-    - name: Install dependencies
+    - name: Install browsers
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
       run: |
-        brew update
-        brew install google-chrome
-        brew install --cask firefox
-        brew install --cask microsoft-edge
+        brew install --cask google-chrome &
+        brew install --cask firefox &
+        brew install --cask microsoft-edge &
+        wait
     - name: Test Chrome
       run: ./bin/browsertime.js -b chrome -n 1 https://www.sitespeed.io/
     - name: Test Firefox

--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -27,17 +27,15 @@ jobs:
         python-version: '3.12'
         cache: 'pip'
     - name: Install FFMPEG
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
       run: brew install ffmpeg@7 && brew link ffmpeg@7
     - name: Install browsertime
       run: npm ci
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade --user pip
-        python -m pip install --upgrade --user setuptools
+        python -m pip install --upgrade --user pip setuptools
         python -m pip install --user pyssim OpenCV-Python Numpy
-        python -m pip --version
-        python -m pip show Pillow
-        python -m pip show pyssim
     - name: Check Safaridriver
       run: sudo safaridriver --enable
     #- name: Check display


### PR DESCRIPTION

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I89dc8484f2bfae13f79003fb2fa227840a657fbf