### PR TITLE
Add pip caching to Linux and Windows CI workflows

### DIFF
--- a/.github/workflows/browser-beta.yml
+++ b/.github/workflows/browser-beta.yml
@@ -30,18 +30,17 @@ jobs:
         chrome-version: beta
     - name: Install Browsertime
       run: npm ci
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: '3.12'
+        cache: 'pip'
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
         sudo snap install ffmpeg
         sudo snap alias ffmpeg.ffprobe ffprobe
-        python -m pip install --upgrade --user pip
-        python -m pip install --upgrade --user setuptools==70.0.0
-        python -m pip install --user pyssim
-        python -m pip --version
-        python -m pip show Pillow
-        python -m pip show pyssim
-        python -m pip install virtualenv
+        python -m pip install --upgrade pip setuptools==70.0.0 pyssim virtualenv
         sudo modprobe ifb numifbs=1
     - name: Browser versions
       run: |

--- a/.github/workflows/browser-dev.yml
+++ b/.github/workflows/browser-dev.yml
@@ -30,18 +30,17 @@ jobs:
         chrome-version: dev
     - name: Install Browsertime
       run: npm ci
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: '3.12'
+        cache: 'pip'
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
         sudo snap install ffmpeg
         sudo snap alias ffmpeg.ffprobe ffprobe
-        python -m pip install --upgrade --user pip
-        python -m pip install --upgrade --user setuptools==70.0.0
-        python -m pip install --user pyssim OpenCV-Python Numpy
-        python -m pip --version
-        python -m pip show Pillow
-        python -m pip show pyssim
-        python -m pip install virtualenv
+        python -m pip install --upgrade pip setuptools==70.0.0 pyssim OpenCV-Python Numpy virtualenv
         sudo modprobe ifb numifbs=1
     - name: Browser versions
       run: |

--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -140,15 +140,17 @@ jobs:
         google-chrome --version
     - name: Install Browsertime
       run: npm ci
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: '3.12'
+        cache: 'pip'
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
         sudo snap install ffmpeg
         sudo snap alias ffmpeg.ffprobe ffprobe
-        python -m pip install --upgrade --user pip
-        python -m pip install --upgrade --user setuptools==70.0.0
-        python -m pip install --user pyssim OpenCV-Python Numpy
-        python -m pip install virtualenv
+        python -m pip install --upgrade pip setuptools==70.0.0 pyssim OpenCV-Python Numpy virtualenv
         sudo modprobe ifb numifbs=1
     - name: Start local HTTP server
       run: (npm run start-server&)

--- a/.github/workflows/linux-firefox.yml
+++ b/.github/workflows/linux-firefox.yml
@@ -43,18 +43,17 @@ jobs:
         firefox-version: '149.0'
     - name: Install Browsertime
       run: npm ci
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: '3.12'
+        cache: 'pip'
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
         sudo snap install ffmpeg
         sudo snap alias ffmpeg.ffprobe ffprobe
-        python -m pip install --upgrade --user pip
-        python -m pip install --upgrade --user setuptools==70.0.0
-        python -m pip install --user pyssim OpenCV-Python Numpy
-        python -m pip --version
-        python -m pip show Pillow
-        python -m pip show pyssim
-        python -m pip install virtualenv
+        python -m pip install --upgrade pip setuptools==70.0.0 pyssim OpenCV-Python Numpy virtualenv
         sudo modprobe ifb numifbs=1
     - name: Browser versions
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
+        cache: 'pip'
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
Add setup-python with cache: 'pip' to linux-chrome, linux-firefox, browser-beta, and browser-dev workflows.
Add cache: 'pip' to the existing setup-python in windows.yml. Combine multiple pip install commands into single calls and remove redundant diagnostic steps (pip --version, pip show).

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Iaeedc2214311a28fea8289937af831865cf9e9fd