### PR TITLE
Add Node.js version check for TypeScript scripts and fix loadPageComp…

### DIFF
--- a/lib/support/engineUtils.js
+++ b/lib/support/engineUtils.js
@@ -23,6 +23,15 @@ async function loadFile(script, options, throwError) {
     // This is an inline script
     return script;
   }
+
+  if (script.endsWith('ts')) {
+    const [major, minor] = process.versions.node.split('.').map(Number);
+    if (major < 22 || (major === 22 && minor < 18)) {
+      throw new Error(
+        `TypeScript scripts require Node.js 22.18.0 or later. You are running ${process.versions.node}.`
+      );
+    }
+  }
   // If we follow correct naming for modules (.mjs/.mts) or commonjs (.cjs/.cts)
   // we just loads it. .js/.ts files is loaded as commonjs if you set
   // --cjs true
@@ -92,7 +101,7 @@ export async function loadPrePostScripts(scripts, options) {
 }
 
 export async function loadPageCompleteScript(script) {
-  if (script && script.endsWith('js')) {
+  if (script && (script.endsWith('js') || script.endsWith('ts'))) {
     return readFile(path.resolve(script), 'utf8');
   }
   return script;


### PR DESCRIPTION
…leteScript

Throw a clear error message when loading a .ts script on Node.js older than 22.18.0, which lacks native type stripping support. Also update loadPageCompleteScript to handle .ts file extensions for consistency.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Ie211eff88530438a0e59eea0d8bfb46ddb2fdfc6