### PR TITLE
Use browsertime's exported types in TypeScript test scripts

### DIFF
--- a/test/data/scripting/common.cts
+++ b/test/data/scripting/common.cts
@@ -1,10 +1,4 @@
-interface BrowsertimeCommands {
-    measure: {
-        start: (url: string) => Promise<void>;
-    };
-}
-
-type BrowsertimeContext = unknown;
+import type { BrowsertimeContext, BrowsertimeCommands } from 'browsertime';
 
 module.exports = async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
     return commands.measure.start('https://www.sitespeed.io');

--- a/test/data/scripting/common.ts
+++ b/test/data/scripting/common.ts
@@ -1,10 +1,4 @@
-interface BrowsertimeCommands {
-    measure: {
-        start: (url: string) => Promise<void>;
-    };
-}
-
-type BrowsertimeContext = unknown;
+import type { BrowsertimeContext, BrowsertimeCommands } from 'browsertime';
 
 module.exports = async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
     return commands.measure.start('https://www.sitespeed.io');

--- a/test/data/scripting/module.mts
+++ b/test/data/scripting/module.mts
@@ -1,11 +1,5 @@
-interface BrowsertimeCommands {
-    measure: {
-        start: (url: string) => Promise<void>;
-    };
-}
-
-type BrowsertimeContext = unknown;
+import type { BrowsertimeContext, BrowsertimeCommands } from 'browsertime';
 
 export default async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
     return commands.measure.start('https://www.sitespeed.io');
-};
+}

--- a/test/data/scripting/module.ts
+++ b/test/data/scripting/module.ts
@@ -1,11 +1,5 @@
-interface BrowsertimeCommands {
-    measure: {
-        start: (url: string) => Promise<void>;
-    };
-}
-
-type BrowsertimeContext = unknown;
+import type { BrowsertimeContext, BrowsertimeCommands } from 'browsertime';
 
 export default async function (_context: BrowsertimeContext, commands: BrowsertimeCommands) {
     return commands.measure.start('https://www.sitespeed.io');
-};
+}


### PR DESCRIPTION
Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Ic86e6393fd8679902ccebab44d0622ada80084b3