### PR TITLE
Add actions.clear() after perform() in mouse commands

### DIFF
--- a/lib/core/engine/command/mouse/clickAndHold.js
+++ b/lib/core/engine/command/mouse/clickAndHold.js
@@ -117,7 +117,8 @@ export class ClickAndHold {
   async releaseAtXpath(xpath) {
     try {
       const element = await this.driver.findElement(By.xpath(xpath));
-      return this.actions.move({ origin: element }).release().perform();
+      await this.actions.move({ origin: element }).release().perform();
+      return this.actions.clear();
     } catch (error) {
       log.error('Could not release on xpath %s', xpath);
       log.verbose(error);
@@ -136,7 +137,8 @@ export class ClickAndHold {
   async releaseAtSelector(selector) {
     try {
       const element = await this.driver.findElement(By.css(selector));
-      return this.actions.move({ origin: element }).release().perform();
+      await this.actions.move({ origin: element }).release().perform();
+      return this.actions.clear();
     } catch (error) {
       log.error('Could not release on selector %s', selector);
       log.verbose(error);
@@ -155,10 +157,11 @@ export class ClickAndHold {
    */
   async releaseAtPosition(xPos, yPos) {
     try {
-      return this.actions
+      await this.actions
         .move({ x: xPos, y: yPos, origin: Origin.VIEWPORT })
         .release()
         .perform();
+      return this.actions.clear();
     } catch (error) {
       log.error('Could not release at position (%d,%d)', xPos, yPos);
       log.verbose(error);

--- a/lib/core/engine/command/mouse/contextClick.js
+++ b/lib/core/engine/command/mouse/contextClick.js
@@ -31,7 +31,8 @@ export class ContextClick {
   async byXpath(xpath) {
     try {
       const element = await this.driver.findElement(By.xpath(xpath));
-      return this.actions.contextClick(element).perform();
+      await this.actions.contextClick(element).perform();
+      return this.actions.clear();
     } catch (error) {
       log.error('Could not context click on element with xpath %s', xpath);
       log.verbose(error);
@@ -50,7 +51,8 @@ export class ContextClick {
   async bySelector(selector) {
     try {
       const element = await this.driver.findElement(By.css(selector));
-      return this.actions.contextClick(element).perform();
+      await this.actions.contextClick(element).perform();
+      return this.actions.clear();
     } catch (error) {
       log.error('Could not context click on element with css %s', selector);
       log.verbose(error);
@@ -69,7 +71,8 @@ export class ContextClick {
    */
   async atCursor() {
     try {
-      return this.actions.contextClick().perform();
+      await this.actions.contextClick().perform();
+      return this.actions.clear();
     } catch (error) {
       log.error('Could not perform context click');
       log.verbose(error);

--- a/lib/core/engine/command/mouse/doubleClick.js
+++ b/lib/core/engine/command/mouse/doubleClick.js
@@ -38,6 +38,7 @@ export class DoubleClick {
         .getDriver()
         .findElement(By.xpath(xpath));
       await this.actions.doubleClick(element).perform();
+      await this.actions.clear();
       if (options && 'wait' in options && options.wait === true) {
         return this.browser.extraWait(this.pageCompleteCheck);
       }
@@ -63,6 +64,7 @@ export class DoubleClick {
         .getDriver()
         .findElement(By.css(selector));
       await this.actions.doubleClick(element).perform();
+      await this.actions.clear();
       if (options && 'wait' in options && options.wait === true) {
         return this.browser.extraWait(this.pageCompleteCheck);
       }
@@ -86,6 +88,7 @@ export class DoubleClick {
   async atCursor(options) {
     try {
       await this.actions.doubleClick().perform();
+      await this.actions.clear();
       if (options && 'wait' in options && options.wait === true) {
         return this.browser.extraWait(this.pageCompleteCheck);
       }

--- a/lib/core/engine/command/mouse/singleClick.js
+++ b/lib/core/engine/command/mouse/singleClick.js
@@ -52,6 +52,7 @@ export class SingleClick {
           .getDriver()
           .findElement(By.xpath(xpath));
         await this.actions.click(element).perform();
+        await this.actions.clear();
         if (options && 'wait' in options && options.wait === true) {
           log.warn(
             'Please use the byXpathAndWait method instead. We want to deprecate and remove the options from this method so we follow the same pattern everywhere.'
@@ -94,6 +95,7 @@ export class SingleClick {
           .getDriver()
           .findElement(By.css(selector));
         await this.actions.click(element).perform();
+        await this.actions.clear();
         if (options && 'wait' in options && options.wait === true) {
           log.warn(
             'Please use the bySelectorAndWait method instead. We want to deprecate and remove the options from this method so we follow the same pattern everywhere.'
@@ -132,6 +134,7 @@ export class SingleClick {
       undefined,
       async () => {
         await this.actions.click().perform();
+        await this.actions.clear();
         if (options && 'wait' in options && options.wait === true) {
           log.warn(
             'Please use the atCursorAndWait method instead.We want to deprecate and remove the options from this method so we follow the same pattern everywhere.'
@@ -243,7 +246,8 @@ export class SingleClick {
       id,
       async () => {
         const element = await this.browser.getDriver().findElement(By.id(id));
-        return this.actions.click(element).perform();
+        await this.actions.click(element).perform();
+        return this.actions.clear();
       },
       this.browser
     );


### PR DESCRIPTION
Mouse commands (singleClick, doubleClick, contextClick, clickAndHold) were missing actions.clear() after perform(), which could leak pointer/key state between actions. For clickAndHold, clear is only added after release methods. MouseMove is left without clear since moves are often composed with held button state (e.g. drag-and-drop).

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I63ddb146c501f56802c9decb5d0e848c07d3a7f3