### PR TITLE
Split Chrome CI basic job into basic and scripting

### DIFF
--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -79,6 +79,60 @@ jobs:
       run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ http://127.0.0.1:3000/dimple/ --urlAlias startPage --urlAlias documentation --xvfb
     - name: Run test with pre-test functionality
       run: ./bin/browsertime.js -b chrome --preWarmServer --xvfb http://127.0.0.1:3000/simple/
+  scripting:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: block
+        allowed-endpoints: >
+          accounts.google.com:443
+          android.clients.google.com:443
+          api.snapcraft.io:443
+          azure.archive.ubuntu.com:80
+          canonical-bos01.cdn.snapcraftcontent.com:443
+          canonical-lgw01.cdn.snapcraftcontent.com:443
+          clients2.google.com:80
+          dl-ssl.google.com:443
+          dl.google.com:80
+          esm.ubuntu.com:443
+          files.pythonhosted.org:443
+          github.com:443
+          motd.ubuntu.com:443
+          msedgedriver.microsoft.com:443
+          mtalk.google.com:5228
+          nodejs.org:443
+          packages.microsoft.com:443
+          pypi.org:443
+          registry.npmjs.org:443
+          release-assets.githubusercontent.com:443
+          results-receiver.actions.githubusercontent.com:443
+          storage.googleapis.com:443
+          www.google.com:443
+          www.sitespeed.io:443
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Use Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      with:
+        node-version: '24.x'
+        cache: 'npm'
+    - name: Install latest Chrome
+      run: |
+        wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+        sudo apt-get update
+        sudo apt-get --only-upgrade install google-chrome-stable
+        google-chrome --version
+    - name: Install Browsertime
+      run: npm ci
+    - name: Install dependencies
+      run: |
+        sudo apt-get install net-tools -y
+        python -m pip install virtualenv
+        sudo modprobe ifb numifbs=1
+    - name: Start local HTTP server
+      run: (npm run start-server&)
     - name: Run test with screenshots
       run: ./bin/browsertime.js -b chrome --screenshotLCP --screenshotLS --xvfb http://127.0.0.1:3000/simple/
     - name: Run test with tcp dump


### PR DESCRIPTION
Split the basic job (11+ min) into two parallel jobs: basic for feature tests (~4 min) and scripting for script format/command tests (~5 min). All three Chrome jobs now run in parallel.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I9ca7e10f1f71031451d9680d935b6c86fb4c7592