### PR TITLE
Standardize error handling in command run() methods

### DIFF
--- a/lib/core/engine/command/addText.js
+++ b/lib/core/engine/command/addText.js
@@ -1,5 +1,6 @@
 import webdriver, { By } from 'selenium-webdriver';
 import { getLogger } from '@sitespeed.io/log';
+import { executeCommand } from './commandHelper.js';
 import { parseSelector } from './selectorParser.js';
 const log = getLogger('browsertime.command.addText');
 
@@ -54,18 +55,19 @@ export class AddText {
    */
   async run(selector, text) {
     const { locator, description } = parseSelector(selector);
-    const driver = this.browser.getDriver();
-    try {
-      await this._waitForElement(driver, locator);
-      const element = await driver.findElement(locator);
-      await element.clear();
-      return element.sendKeys(text);
-    } catch (error) {
-      const url = await this._getUrl();
-      log.error('Could not add text %s to %s', text, description);
-      log.verbose(error);
-      throw new Error(`Could not add text ${text} to ${description}${url}`);
-    }
+    return executeCommand(
+      log,
+      'Could not add text %s to %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await element.clear();
+        return element.sendKeys(text);
+      },
+      this.browser
+    );
   }
 
   /**

--- a/lib/core/engine/command/click.js
+++ b/lib/core/engine/command/click.js
@@ -215,8 +215,12 @@ export class Click {
    * @throws {Error} Throws an error if the element is not found.
    */
   async byText(text) {
-    return executeCommand(log, 'Could not find element by text %s', text, () =>
-      this.byXpath(`//*[normalize-space(text())='${text}']`)
+    return executeCommand(
+      log,
+      'Could not find element by text %s',
+      text,
+      () => this.byXpath(`//*[normalize-space(text())='${text}']`),
+      this.browser
     );
   }
 
@@ -231,8 +235,12 @@ export class Click {
    * @throws {Error} Throws an error if the element is not found.
    */
   async byTextAndWait(text) {
-    return executeCommand(log, 'Could not find element by text %s', text, () =>
-      this.byXpathAndWait(`//*[normalize-space(text())='${text}']`)
+    return executeCommand(
+      log,
+      'Could not find element by text %s',
+      text,
+      () => this.byXpathAndWait(`//*[normalize-space(text())='${text}']`),
+      this.browser
     );
   }
 

--- a/lib/core/engine/command/select.js
+++ b/lib/core/engine/command/select.js
@@ -1,5 +1,6 @@
 import webdriver from 'selenium-webdriver';
 import { getLogger } from '@sitespeed.io/log';
+import { executeCommand } from './commandHelper.js';
 import { parseSelector } from './selectorParser.js';
 const log = getLogger('browsertime.command.select');
 
@@ -44,19 +45,21 @@ export class Select {
    */
   async run(selector, value) {
     const { locator, description } = parseSelector(selector);
-    const driver = this.browser.getDriver();
-    try {
-      await this._waitForElement(driver, locator);
-      const element = await driver.findElement(locator);
-      await driver.executeScript(
-        `arguments[0].value = '${value}'; arguments[0].dispatchEvent(new Event('change'));`,
-        element
-      );
-    } catch (error) {
-      log.error('Could not select value for %s', description);
-      log.verbose(error);
-      throw new Error(`Could not select value for ${description}`);
-    }
+    return executeCommand(
+      log,
+      'Could not select value for %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await driver.executeScript(
+          `arguments[0].value = '${value}'; arguments[0].dispatchEvent(new Event('change'));`,
+          element
+        );
+      },
+      this.browser
+    );
   }
 
   /**
@@ -168,9 +171,9 @@ export class Select {
       const value = await this.browser.runScript(script, 'CUSTOM');
       return value;
     } catch (error) {
-      log.error('Could not deleselect by select id %s', selectId);
+      log.error('Could not deselect by select id %s', selectId);
       log.verbose(error);
-      throw new Error(`Could not deleselect by select id  ${selectId}`);
+      throw new Error(`Could not deselect by select id ${selectId}`);
     }
   }
 

--- a/lib/core/engine/command/set.js
+++ b/lib/core/engine/command/set.js
@@ -1,5 +1,6 @@
 import webdriver from 'selenium-webdriver';
 import { getLogger } from '@sitespeed.io/log';
+import { executeCommand } from './commandHelper.js';
 import { parseSelector } from './selectorParser.js';
 const log = getLogger('browsertime.command.set');
 
@@ -45,19 +46,21 @@ export class Set {
    */
   async run(selector, value, property = 'value') {
     const { locator, description } = parseSelector(selector);
-    const driver = this.browser.getDriver();
-    try {
-      await this._waitForElement(driver, locator);
-      const element = await driver.findElement(locator);
-      await driver.executeScript(
-        `arguments[0].${property} = '${value}';`,
-        element
-      );
-    } catch (error) {
-      log.error('Could not set %s on %s', property, description);
-      log.verbose(error);
-      throw new Error(`Could not set ${property} on ${description}`);
-    }
+    return executeCommand(
+      log,
+      `Could not set ${property} on %s`,
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await driver.executeScript(
+          `arguments[0].${property} = '${value}';`,
+          element
+        );
+      },
+      this.browser
+    );
   }
 
   /**

--- a/lib/core/engine/command/wait.js
+++ b/lib/core/engine/command/wait.js
@@ -1,5 +1,6 @@
 import webdriver from 'selenium-webdriver';
 import { getLogger } from '@sitespeed.io/log';
+import { executeCommand } from './commandHelper.js';
 import { parseSelector } from './selectorParser.js';
 const log = getLogger('browsertime.command.wait');
 const delay = ms => new Promise(res => setTimeout(res, ms));
@@ -62,7 +63,6 @@ export class Wait {
     const driver = this.browser.getDriver();
     await this.byId(id, maxTime);
     try {
-      driver.findElement;
       await driver.wait(
         webdriver.until.elementIsVisible(
           driver.findElement(webdriver.By.id(id))
@@ -118,7 +118,6 @@ export class Wait {
     const driver = this.browser.getDriver();
     await this.byXpath(xpath, maxTime);
     try {
-      driver.findElement;
       await driver.wait(
         webdriver.until.elementIsVisible(
           driver.findElement(webdriver.By.xpath(xpath))
@@ -238,21 +237,20 @@ export class Wait {
     const timeout = options.timeout ?? 6000;
     const visible = options.visible ?? false;
     const { locator, description } = parseSelector(selector);
-    const driver = this.browser.getDriver();
-
-    try {
-      await driver.wait(webdriver.until.elementLocated(locator), timeout);
-      if (visible) {
-        const element = await driver.findElement(locator);
-        await driver.wait(webdriver.until.elementIsVisible(element), timeout);
-      }
-    } catch (error) {
-      log.error('Element %s was not located in %s ms', description, timeout);
-      log.verbose(error);
-      throw new Error(
-        `Element ${description} was not located in ${timeout} ms`
-      );
-    }
+    return executeCommand(
+      log,
+      'Element %s was not located in ' + timeout + ' ms',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await driver.wait(webdriver.until.elementLocated(locator), timeout);
+        if (visible) {
+          const element = await driver.findElement(locator);
+          await driver.wait(webdriver.until.elementIsVisible(element), timeout);
+        }
+      },
+      this.browser
+    );
   }
 
   /**


### PR DESCRIPTION
Replace inline try/catch in addText, select, set, and wait run() methods with the shared executeCommand() helper for consistent error handling and URL inclusion in error messages. Fix missing this.browser in click.byText/byTextAndWait. Fix typo 'deleselect' in select.deselectById. Remove dead code in wait.byIdAndVisible and wait.byXpathAndVisible.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I7a80bcbf65da0624400f8e4d3bb6c066c9d6417b