### PR TITLE
Add commands.exists(selector) for non-throwing element checks

### DIFF
--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -1,3 +1,6 @@
+import webdriver from 'selenium-webdriver';
+
+import { parseSelector } from './command/selectorParser.js';
 import { Actions } from './command/actions.js';
 import { AddText } from './command/addText.js';
 import { Click } from './command/click.js';
@@ -450,5 +453,33 @@ export class Commands {
      * @type {Function}
      */
     this.find = this.element.find.bind(this.element);
+
+    /**
+     * Checks if an element matching the selector exists in the DOM.
+     * Unlike find(), this does not throw if the element is not found.
+     * @async
+     * @example
+     * if (await commands.exists('#cookie-banner')) {
+     *   await commands.click('#accept-cookies');
+     * }
+     * @param {string} selector - The CSS selector or prefixed selector.
+     * @param {Object} [existsOptions] - Options.
+     * @param {number} [existsOptions.timeout=0] - Maximum time to wait for the element. Default 0 (no wait).
+     * @returns {Promise<boolean>} True if the element exists.
+     * @type {Function}
+     */
+    this.exists = async (selector, existsOptions = {}) => {
+      const { locator } = parseSelector(selector);
+      const timeout = existsOptions.timeout ?? 0;
+      const driver = browser.getDriver();
+      try {
+        await (timeout > 0
+          ? driver.wait(webdriver.until.elementLocated(locator), timeout)
+          : driver.findElement(locator));
+        return true;
+      } catch {
+        return false;
+      }
+    };
   }
 }


### PR DESCRIPTION
Add exists(selector, { timeout }) that returns a boolean instead of throwing when an element is not found. Defaults  to no wait (instant check). Useful for conditional flows like dismissing optional banners.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I5e6631e407c68baeda93f24bd949bba6baeabebc