### PR TITLE
Add commands.fill() for filling multiple form fields at once

### DIFF
--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -450,5 +450,25 @@ export class Commands {
      * @type {Function}
      */
     this.find = this.element.find.bind(this.element);
+
+    /**
+     * Fills multiple form fields at once. Each key is a selector, each value is the text to type.
+     * @async
+     * @example
+     * await commands.fill({
+     *   '#username': 'admin',
+     *   '#password': 'secret',
+     *   'id:email': 'user@example.com'
+     * });
+     * @param {Object<string, string>} fields - An object mapping selectors to values.
+     * @returns {Promise<void>} A promise that resolves when all fields are filled.
+     * @throws {Error} Throws an error if any element is not found.
+     * @type {Function}
+     */
+    this.fill = async fields => {
+      for (const [selector, text] of Object.entries(fields)) {
+        await this.addText(selector, text);
+      }
+    };
   }
 }


### PR DESCRIPTION
Add fill({ selector: text, ... }) that accepts an object mapping selectors to values and fills each field. Delegates to addText() for unified selector support and auto-wait.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Ie6c9af9715e7a3e530cc454a5ea38f11260fbd02