### PR TITLE
Add unified selector syntax to mouse commands

### DIFF
--- a/lib/core/engine/command/mouse/contextClick.js
+++ b/lib/core/engine/command/mouse/contextClick.js
@@ -1,5 +1,8 @@
 import { getLogger } from '@sitespeed.io/log';
 import { By } from 'selenium-webdriver';
+import webdriver from 'selenium-webdriver';
+import { executeCommand } from '../commandHelper.js';
+import { parseSelector } from '../selectorParser.js';
 const log = getLogger('browsertime.command.mouse');
 
 /**
@@ -9,7 +12,11 @@ const log = getLogger('browsertime.command.mouse');
  * @hideconstructor
  */
 export class ContextClick {
-  constructor(browser) {
+  constructor(browser, options) {
+    /**
+     * @private
+     */
+    this.browser = browser;
     /**
      * @private
      */
@@ -18,9 +25,49 @@ export class ContextClick {
      * @private
      */
     this.actions = this.driver.actions({ async: true });
+    /**
+     * @private
+     */
+    this.options = options;
   }
 
   /**
+   * @private
+   */
+  async _waitForElement(driver, locator) {
+    const timeout = this.options?.timeouts?.elementWait ?? 0;
+    if (timeout > 0) {
+      await driver.wait(webdriver.until.elementLocated(locator), timeout);
+    }
+  }
+
+  /**
+   * Performs a context click (right-click) on an element using a unified selector string.
+   *
+   * @async
+   * @param {string} selector - The selector string. CSS by default, or use a prefix.
+   * @returns {Promise<void>}
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async run(selector) {
+    const { locator, description } = parseSelector(selector);
+    return executeCommand(
+      log,
+      'Could not context click on element %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await this.actions.contextClick(element).perform();
+        await this.actions.clear();
+      },
+      this.browser
+    );
+  }
+
+  /**
+   * @private
    * Performs a context click (right-click) on an element that matches a given XPath selector.
    *
    * @async
@@ -41,6 +88,7 @@ export class ContextClick {
   }
 
   /**
+   * @private
    * Performs a context click (right-click) on an element that matches a given CSS selector.
    *
    * @async
@@ -63,6 +111,7 @@ export class ContextClick {
   }
 
   /**
+   * @private
    * Performs a context click (right-click) at the current cursor position.
    *
    * @async

--- a/lib/core/engine/command/mouse/doubleClick.js
+++ b/lib/core/engine/command/mouse/doubleClick.js
@@ -1,5 +1,8 @@
 import { getLogger } from '@sitespeed.io/log';
 import { By } from 'selenium-webdriver';
+import webdriver from 'selenium-webdriver';
+import { executeCommand } from '../commandHelper.js';
+import { parseSelector } from '../selectorParser.js';
 const log = getLogger('browsertime.command.mouse');
 /**
  * Provides functionality to perform a double-click action on elements in a web page.
@@ -8,7 +11,7 @@ const log = getLogger('browsertime.command.mouse');
  * @hideconstructor
  */
 export class DoubleClick {
-  constructor(browser, pageCompleteCheck) {
+  constructor(browser, pageCompleteCheck, options) {
     /**
      * @private
      */
@@ -21,9 +24,49 @@ export class DoubleClick {
      * @private
      */
     this.pageCompleteCheck = pageCompleteCheck;
+    /**
+     * @private
+     */
+    this.options = options;
   }
 
   /**
+   * @private
+   */
+  async _waitForElement(driver, locator) {
+    const timeout = this.options?.timeouts?.elementWait ?? 0;
+    if (timeout > 0) {
+      await driver.wait(webdriver.until.elementLocated(locator), timeout);
+    }
+  }
+
+  /**
+   * Performs a double click on an element using a unified selector string.
+   *
+   * @async
+   * @param {string} selector - The selector string. CSS by default, or use a prefix.
+   * @returns {Promise<void>}
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async run(selector) {
+    const { locator, description } = parseSelector(selector);
+    return executeCommand(
+      log,
+      'Could not double click on element %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await this.actions.doubleClick(element).perform();
+        await this.actions.clear();
+      },
+      this.browser
+    );
+  }
+
+  /**
+   * @private
    * Performs a mouse double-click on an element matching a given XPath selector.
    *
    * @async
@@ -50,6 +93,7 @@ export class DoubleClick {
   }
 
   /**
+   * @private
    * Performs a mouse double-click on an element matching a given CSS selector.
    *
    * @async
@@ -78,6 +122,7 @@ export class DoubleClick {
   }
 
   /**
+   * @private
    * Performs a mouse double-click at the current cursor position.
    *
    * @async

--- a/lib/core/engine/command/mouse/mouseMove.js
+++ b/lib/core/engine/command/mouse/mouseMove.js
@@ -1,5 +1,8 @@
 import { getLogger } from '@sitespeed.io/log';
 import { By, Origin } from 'selenium-webdriver';
+import webdriver from 'selenium-webdriver';
+import { executeCommand } from '../commandHelper.js';
+import { parseSelector } from '../selectorParser.js';
 const log = getLogger('browsertime.command.mouse');
 /**
  * Provides functionality to move the mouse cursor to elements or specific positions on a web page.
@@ -8,7 +11,11 @@ const log = getLogger('browsertime.command.mouse');
  * @hideconstructor
  */
 export class MouseMove {
-  constructor(browser) {
+  constructor(browser, options) {
+    /**
+     * @private
+     */
+    this.browser = browser;
     /**
      * @private
      */
@@ -17,9 +24,48 @@ export class MouseMove {
      * @private
      */
     this.actions = this.driver.actions({ async: true });
+    /**
+     * @private
+     */
+    this.options = options;
   }
 
   /**
+   * @private
+   */
+  async _waitForElement(driver, locator) {
+    const timeout = this.options?.timeouts?.elementWait ?? 0;
+    if (timeout > 0) {
+      await driver.wait(webdriver.until.elementLocated(locator), timeout);
+    }
+  }
+
+  /**
+   * Moves the mouse cursor to an element using a unified selector string.
+   *
+   * @async
+   * @param {string} selector - The selector string. CSS by default, or use a prefix.
+   * @returns {Promise<void>}
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async run(selector) {
+    const { locator, description } = parseSelector(selector);
+    return executeCommand(
+      log,
+      'Could not move mouse to element %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        return this.actions.move({ origin: element }).perform();
+      },
+      this.browser
+    );
+  }
+
+  /**
+   * @private
    * Moves the mouse cursor to an element that matches a given XPath selector.
    *
    * @async
@@ -39,6 +85,7 @@ export class MouseMove {
   }
 
   /**
+   * @private
    * Moves the mouse cursor to an element that matches a given CSS selector.
    *
    * @async
@@ -58,6 +105,7 @@ export class MouseMove {
   }
 
   /**
+   * @private
    * Moves the mouse cursor to a specific position on the screen.
    *
    * @async
@@ -77,6 +125,7 @@ export class MouseMove {
   }
 
   /**
+   * @private
    * Moves the mouse cursor by an offset from its current position.
    *
    * @async

--- a/lib/core/engine/command/mouse/singleClick.js
+++ b/lib/core/engine/command/mouse/singleClick.js
@@ -1,6 +1,8 @@
 import { getLogger } from '@sitespeed.io/log';
 import { By } from 'selenium-webdriver';
+import webdriver from 'selenium-webdriver';
 import { executeCommand } from '../commandHelper.js';
+import { parseSelector } from '../selectorParser.js';
 const log = getLogger('browsertime.command.mouse');
 
 /**
@@ -10,7 +12,7 @@ const log = getLogger('browsertime.command.mouse');
  * @class
  */
 export class SingleClick {
-  constructor(browser, pageCompleteCheck) {
+  constructor(browser, pageCompleteCheck, options) {
     /**
      * @private
      */
@@ -23,6 +25,50 @@ export class SingleClick {
      * @private
      */
     this.pageCompleteCheck = pageCompleteCheck;
+    /**
+     * @private
+     */
+    this.options = options;
+  }
+
+  /**
+   * @private
+   */
+  async _waitForElement(driver, locator) {
+    const timeout = this.options?.timeouts?.elementWait ?? 0;
+    if (timeout > 0) {
+      await driver.wait(webdriver.until.elementLocated(locator), timeout);
+    }
+  }
+
+  /**
+   * Performs a single click on an element using a unified selector string.
+   *
+   * @async
+   * @param {string} selector - The selector string. CSS by default, or use a prefix.
+   * @param {Object} [options] - Options for the click action.
+   * @param {boolean} [options.waitForNavigation=false] - If true, waits for page complete check.
+   * @returns {Promise<void>}
+   * @throws {Error} Throws an error if the element is not found.
+   */
+  async run(selector, options = {}) {
+    const { locator, description } = parseSelector(selector);
+    return executeCommand(
+      log,
+      'Could not single click on element %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await this.actions.click(element).perform();
+        await this.actions.clear();
+        if (options.waitForNavigation) {
+          await this.browser.extraWait(this.pageCompleteCheck);
+        }
+      },
+      this.browser
+    );
   }
 
   /**
@@ -34,6 +80,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Performs a single mouse click on an element matching a given XPath selector.
    *
    * @async
@@ -65,6 +112,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Performs a single mouse click on an element matching a given XPath selector and wait for page complete check.
    *
    * @async
@@ -77,6 +125,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Performs a single mouse click on an element matching a given CSS selector.
    *
    * @async
@@ -108,6 +157,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Performs a single mouse click on an element matching a given CSS selector and waits on the page complete check.
    *
    * @async
@@ -120,6 +170,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Performs a single mouse click at the current cursor position.
    *
    * @async
@@ -147,6 +198,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Performs a single mouse click at the current cursor position and waits on the
    * page complete check.
    *
@@ -159,6 +211,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Clicks on a link whose visible text matches the given string.
    *
    * @async
@@ -177,6 +230,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Clicks on a link whose visible text matches the given string and waits on the opage complete check.
    *
    * @async
@@ -195,6 +249,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Clicks on a link whose visible text contains the given substring.
    *
    * @async
@@ -213,6 +268,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Clicks on a link whose visible text contains the given substring and waits on the
    * page complete check.
    *
@@ -232,6 +288,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Clicks on a element with a specific id.
    *
    * @async
@@ -254,6 +311,7 @@ export class SingleClick {
   }
 
   /**
+   * @private
    * Clicks on a element with a specific id and wait on the page complete check
    *
    * @async

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -351,33 +351,73 @@ export class Commands {
      * Interact with the page using the mouse.
      * @type {Object}
      */
+    const singleClickInstance = new SingleClick(
+      browser,
+      pageCompleteCheck,
+      options
+    );
+    const doubleClickInstance = new DoubleClick(
+      browser,
+      pageCompleteCheck,
+      options
+    );
+    const contextClickInstance = new ContextClick(browser, options);
+    const mouseMoveInstance = new MouseMove(browser, options);
+    const clickAndHoldInstance = new ClickAndHold(browser);
+
     this.mouse = {
-      /**
-       *  Move the mouse cursor to elements or specific positions on a web page.
-       * @type {MouseMove}
-       */
-      moveTo: new MouseMove(browser),
-      /**
-       *  Perform a context click (right-click) on elements in a web page.
-       * @type {ContextClick}
-       */
-      contextClick: new ContextClick(browser),
-      /**
-       *  Provides functionality to perform a single click action on elements or at specific positions in a web page.
-       * @type {SingleClick}
-       */
-      singleClick: new SingleClick(browser, pageCompleteCheck),
-      /**
-       *  Provides functionality to perform a double-click action on elements in a web page.
-       * @type {DoubleClick}
-       */
-      doubleClick: new DoubleClick(browser, pageCompleteCheck),
-      /**
-       *  Provides functionality to click and hold elements on a web page using different strategies.
-       * @type {ClickAndHold}
-       */
-      clickAndHold: new ClickAndHold(browser)
+      moveTo: async selector => mouseMoveInstance.run(selector),
+      singleClick: async (selector, mouseOptions) =>
+        singleClickInstance.run(selector, mouseOptions),
+      doubleClick: async selector => doubleClickInstance.run(selector),
+      contextClick: async selector => contextClickInstance.run(selector),
+      clickAndHold: clickAndHoldInstance
     };
+
+    // Preserve backward-compatible methods on each mouse command
+    for (const key of Object.getOwnPropertyNames(
+      Object.getPrototypeOf(mouseMoveInstance)
+    )) {
+      if (
+        key !== 'constructor' &&
+        typeof mouseMoveInstance[key] === 'function'
+      ) {
+        this.mouse.moveTo[key] = mouseMoveInstance[key].bind(mouseMoveInstance);
+      }
+    }
+    for (const key of Object.getOwnPropertyNames(
+      Object.getPrototypeOf(singleClickInstance)
+    )) {
+      if (
+        key !== 'constructor' &&
+        typeof singleClickInstance[key] === 'function'
+      ) {
+        this.mouse.singleClick[key] =
+          singleClickInstance[key].bind(singleClickInstance);
+      }
+    }
+    for (const key of Object.getOwnPropertyNames(
+      Object.getPrototypeOf(doubleClickInstance)
+    )) {
+      if (
+        key !== 'constructor' &&
+        typeof doubleClickInstance[key] === 'function'
+      ) {
+        this.mouse.doubleClick[key] =
+          doubleClickInstance[key].bind(doubleClickInstance);
+      }
+    }
+    for (const key of Object.getOwnPropertyNames(
+      Object.getPrototypeOf(contextClickInstance)
+    )) {
+      if (
+        key !== 'constructor' &&
+        typeof contextClickInstance[key] === 'function'
+      ) {
+        this.mouse.contextClick[key] =
+          contextClickInstance[key].bind(contextClickInstance);
+      }
+    }
 
     /**
      * Interact with a select element.


### PR DESCRIPTION
Add run(selector) methods to singleClick, doubleClick, contextClick, and mouseMove. Users can now call commands.mouse.singleClick('#btn'), commands.mouse.doubleClick('id:item'), etc. with the same prefix-based selectors as other commands. Legacy by* methods preserved but marked @private in docs.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I6e4a10d0fab83c21a458df03d3d358e251c06d0c