### PR TITLE
Add Cookie command class for managing browser cookies

### DIFF
--- a/lib/core/engine/command/cookie.js
+++ b/lib/core/engine/command/cookie.js
@@ -1,0 +1,85 @@
+import { getLogger } from '@sitespeed.io/log';
+const log = getLogger('browsertime.command.cookie');
+
+/**
+ * Provides functionality to manage browser cookies.
+ *
+ * @class
+ * @hideconstructor
+ */
+export class Cookie {
+  constructor(browser) {
+    /**
+     * @private
+     */
+    this.driver = browser.getDriver();
+  }
+
+  /**
+   * Gets all cookies for the current page.
+   *
+   * @async
+   * @returns {Promise<Array>} An array of cookie objects.
+   */
+  async getAll() {
+    return this.driver.manage().getCookies();
+  }
+
+  /**
+   * Gets a specific cookie by name.
+   *
+   * @async
+   * @param {string} name - The name of the cookie.
+   * @returns {Promise<Object|undefined>} The cookie object, or undefined if not found.
+   */
+  async get(name) {
+    try {
+      return await this.driver.manage().getCookie(name);
+    } catch {
+      // Cookie not found
+    }
+  }
+
+  /**
+   * Sets a cookie.
+   *
+   * @async
+   * @param {string} name - The name of the cookie.
+   * @param {string} value - The value of the cookie.
+   * @param {Object} [options] - Optional cookie properties.
+   * @param {string} [options.domain] - The domain the cookie is visible to.
+   * @param {string} [options.path] - The cookie path.
+   * @param {boolean} [options.secure] - Whether the cookie is secure.
+   * @param {boolean} [options.httpOnly] - Whether the cookie is HTTP only.
+   * @param {Date} [options.expiry] - When the cookie expires.
+   * @returns {Promise<void>}
+   */
+  async set(name, value, options = {}) {
+    const cookie = { name, value, ...options };
+    log.debug('Setting cookie %s', name);
+    return this.driver.manage().addCookie(cookie);
+  }
+
+  /**
+   * Deletes a specific cookie by name.
+   *
+   * @async
+   * @param {string} name - The name of the cookie to delete.
+   * @returns {Promise<void>}
+   */
+  async delete(name) {
+    log.debug('Deleting cookie %s', name);
+    return this.driver.manage().deleteCookie(name);
+  }
+
+  /**
+   * Deletes all cookies for the current page.
+   *
+   * @async
+   * @returns {Promise<void>}
+   */
+  async deleteAll() {
+    log.debug('Deleting all cookies');
+    return this.driver.manage().deleteAllCookies();
+  }
+}

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -12,6 +12,7 @@ import { Switch } from './command/switch.js';
 import { Screenshot } from './command/screenshot.js';
 import { Set } from './command/set.js';
 import { Cache } from './command/cache.js';
+import { Cookie } from './command/cookie.js';
 import { Meta } from './command/meta.js';
 import { Watch as StopWatch } from './command/stopWatch.js';
 import { Select } from './command/select.js';
@@ -311,6 +312,12 @@ export class Commands {
      * @type {Cache}
      */
     this.cache = new Cache(browser, options.browser, cdp);
+
+    /**
+     * Manages browser cookies — get, set, delete individual or all cookies.
+     * @type {Cookie}
+     */
+    this.cookie = new Cookie(browser);
 
     /**
      * Adds metadata to the user journey.


### PR DESCRIPTION
Add commands.cookie with getAll, get, set, delete, and deleteAll methods wrapping Selenium's cookie management API.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Ifea96c221c94cb0f347ad1cda8002d97fe339fd6