### PR TITLE
Add hover, press, getTitle, and getUrl convenience methods

### DIFF
--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -616,5 +616,60 @@ export class Commands {
         await this.addText(selector, text);
       }
     };
+
+    /**
+     * Hovers over an element matching the selector. This is a convenience
+     * alias for commands.mouse.moveTo(selector).
+     * @async
+     * @example await commands.hover('#menu-item');
+     * @example await commands.hover('id:tooltip-trigger');
+     * @param {string} selector - The CSS selector or prefixed selector.
+     * @returns {Promise<void>}
+     * @throws {Error} Throws an error if the element is not found.
+     * @type {Function}
+     */
+    this.hover = async selector => {
+      return this.mouse.moveTo(selector);
+    };
+
+    /**
+     * Presses a keyboard key. Use key names like 'Enter', 'Tab', 'Escape',
+     * 'Backspace', 'ArrowUp', 'ArrowDown', etc.
+     * @async
+     * @example await commands.press('Enter');
+     * @example await commands.press('Tab');
+     * @example await commands.press('Escape');
+     * @param {string} key - The key name to press (e.g. 'Enter', 'Tab', 'Escape').
+     * @returns {Promise<void>}
+     * @type {Function}
+     */
+    this.press = async key => {
+      const keyValue = webdriver.Key[key.toUpperCase()] || key;
+      const driver = browser.getDriver();
+      await driver.actions({ async: true }).sendKeys(keyValue).perform();
+      return driver.actions().clear();
+    };
+
+    /**
+     * Gets the title of the current page.
+     * @async
+     * @example const title = await commands.getTitle();
+     * @returns {Promise<string>} The page title.
+     * @type {Function}
+     */
+    this.getTitle = async () => {
+      return browser.getDriver().getTitle();
+    };
+
+    /**
+     * Gets the URL of the current page.
+     * @async
+     * @example const url = await commands.getUrl();
+     * @returns {Promise<string>} The current URL.
+     * @type {Function}
+     */
+    this.getUrl = async () => {
+      return browser.getDriver().getCurrentUrl();
+    };
   }
 }


### PR DESCRIPTION
Add hover(sel) as alias for mouse.moveTo, press(key) for keyboard input (Enter, Tab, Escape etc.), getTitle() and getUrl() for page info.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I14d8b4f777bcd9c900260fdc087a0667e2fd2e28