### PR TITLE
Document new commands, update changelog, and expand CI test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 * Added `commands.clear(selector)` to clear form element content [#2413](https://github.com/sitespeedio/browsertime/pull/2413).
 * Added `commands.fill({ selector: text, ... })` for filling multiple form fields at once [#2414](https://github.com/sitespeedio/browsertime/pull/2414).
 * Added unified selector syntax to mouse commands: `commands.mouse.singleClick(selector)`, `commands.mouse.doubleClick(selector)`, `commands.mouse.contextClick(selector)`, `commands.mouse.moveTo(selector)` [#2415](https://github.com/sitespeedio/browsertime/pull/2415).
+* Added `commands.cookie` for managing browser cookies: `get`, `getAll`, `set`, `delete`, `deleteAll` [#2420](https://github.com/sitespeedio/browsertime/pull/2420).
+* Added `commands.getAttribute(selector, name)`, `commands.isEnabled(selector)`, and `commands.isChecked(selector)` for element state queries [#2421](https://github.com/sitespeedio/browsertime/pull/2421).
+* Added `commands.hover(selector)` as alias for mouse.moveTo, `commands.press(key)` for keyboard input, `commands.getTitle()` and `commands.getUrl()` for page info [#2422](https://github.com/sitespeedio/browsertime/pull/2422).
+* Added `commands.check(selector)` and `commands.uncheck(selector)` for checkbox/radio interactions [#2423](https://github.com/sitespeedio/browsertime/pull/2423).
 * Firefox 149 in the Docker container [#2375](https://github.com/sitespeedio/browsertime/pull/2375).
 
 ### Fixed

--- a/jsdoc/tutorials/04-Interact-with-the-page.md
+++ b/jsdoc/tutorials/04-Interact-with-the-page.md
@@ -261,6 +261,28 @@ await commands.select('id:language', 'en');
 await commands.select('name:currency', 'USD');
 ```
 
+## Cookies
+
+Manage browser cookies — useful for login flows, consent banners, and A/B testing:
+
+```javascript
+// Set a cookie
+await commands.cookie.set('session', 'abc123');
+await commands.cookie.set('consent', 'true', { path: '/', secure: true });
+
+// Get a cookie
+const session = await commands.cookie.get('session');
+
+// Get all cookies
+const all = await commands.cookie.getAll();
+
+// Delete a specific cookie
+await commands.cookie.delete('session');
+
+// Delete all cookies
+await commands.cookie.deleteAll();
+```
+
 ## Convenience methods
 
 ### Get text, value, and visibility
@@ -308,6 +330,58 @@ await commands.fill({
   '#password': 'secret',
   'id:email': 'user@example.com'
 });
+```
+
+### Check and uncheck
+
+Toggle checkboxes and radio buttons. Only clicks if the state needs to change:
+
+```javascript
+await commands.check('#agree-terms');
+await commands.uncheck('id:newsletter');
+
+// Verify the state
+const checked = await commands.isChecked('#agree-terms');
+```
+
+### Hover
+
+Hover over an element (triggers mouseover/hover CSS states):
+
+```javascript
+await commands.hover('#menu-item');
+await commands.hover('id:tooltip-trigger');
+```
+
+### Press keyboard keys
+
+Send keyboard key presses like Enter, Tab, Escape:
+
+```javascript
+await commands.press('Enter');
+await commands.press('Tab');
+await commands.press('Escape');
+```
+
+### Get element attributes and state
+
+```javascript
+// Get any attribute
+const href = await commands.getAttribute('#my-link', 'href');
+const dataId = await commands.getAttribute('id:item', 'data-id');
+
+// Check if enabled/disabled
+const enabled = await commands.isEnabled('#submit-btn');
+
+// Check checkbox/radio state
+const checked = await commands.isChecked('#agree-terms');
+```
+
+### Get page information
+
+```javascript
+const title = await commands.getTitle();
+const url = await commands.getUrl();
 ```
 
 ## Alert boxes

--- a/test/data/commandscripts/newCommands.cjs
+++ b/test/data/commandscripts/newCommands.cjs
@@ -78,4 +78,49 @@ module.exports = async function (context, commands) {
   if (!element) {
     throw new Error('Expected find to return an element');
   }
+
+  // Test getAttribute
+  const placeholder = await commands.getAttribute('#clickable', 'placeholder');
+  if (placeholder !== 'Clickable') {
+    throw new Error(`Expected placeholder 'Clickable' but got '${placeholder}'`);
+  }
+
+  // Test isEnabled
+  const enabled = await commands.isEnabled('#clickable');
+  if (!enabled) {
+    throw new Error('Expected input to be enabled');
+  }
+
+  // Test hover
+  await commands.hover('a[href="/dimple/"]');
+
+  // Test press (type something then press a key)
+  await commands.clear('#clickable');
+  await commands.type('#clickable', 'test');
+  await commands.press('Backspace');
+
+  // Test getTitle
+  const title = await commands.getTitle();
+  if (!title.includes('simple')) {
+    throw new Error(`Expected title to contain 'simple' but got '${title}'`);
+  }
+
+  // Test getUrl
+  const url = await commands.getUrl();
+  if (!url.includes('127.0.0.1')) {
+    throw new Error(`Expected url to contain '127.0.0.1' but got '${url}'`);
+  }
+
+  // Test cookie commands
+  await commands.cookie.deleteAll();
+  await commands.cookie.set('test_cookie', 'browsertime');
+  const cookie = await commands.cookie.get('test_cookie');
+  if (!cookie || cookie.value !== 'browsertime') {
+    throw new Error('Cookie set/get failed');
+  }
+  await commands.cookie.delete('test_cookie');
+  const deleted = await commands.cookie.get('test_cookie');
+  if (deleted) {
+    throw new Error('Cookie delete failed');
+  }
 };


### PR DESCRIPTION
Add documentation for cookie, check/uncheck, hover, press, getAttribute, isEnabled, isChecked, getTitle, and getUrl commands in the interaction tutorial. Add changelog entries. Expand newCommands.cjs test script to cover all new commands.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I5b1840c4f441a395b02ab0776a417c11dd19dd94