### PR TITLE
Add commands.scrollIntoView(selector) convenience method

### DIFF
--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -752,5 +752,25 @@ export class Commands {
         return element.click();
       }
     };
+
+    /**
+     * Scrolls the page so that the element matching the selector is visible in the viewport.
+     * @async
+     * @example await commands.scrollIntoView('#footer');
+     * @example await commands.scrollIntoView('id:comments-section');
+     * @param {string} selector - The CSS selector or prefixed selector.
+     * @returns {Promise<void>}
+     * @throws {Error} Throws an error if the element is not found.
+     * @type {Function}
+     */
+    this.scrollIntoView = async selector => {
+      const element = await findElement(selector);
+      return browser
+        .getDriver()
+        .executeScript(
+          'arguments[0].scrollIntoView({block: "center", behavior: "instant"})',
+          element
+        );
+    };
   }
 }


### PR DESCRIPTION
Scrolls the page so the matched element is centered in the viewport. Uses block: "center" and behavior: "instant" to avoid smooth scroll interfering with timing.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I7e6fefc2a8ee89b68b925bea578b09cc6571978f