### PR TITLE
Add commands.select.byText() to select dropdown options by visible text

### DIFF
--- a/lib/core/engine/command/select.js
+++ b/lib/core/engine/command/select.js
@@ -63,6 +63,44 @@ export class Select {
   }
 
   /**
+   * Selects an option in a select element by its visible text using a unified selector string.
+   *
+   * @async
+   * @param {string} selector - The selector string for the select element.
+   * @param {string} text - The visible text of the option to select.
+   * @returns {Promise<void>} A promise that resolves when the option is selected.
+   * @throws {Error} Throws an error if the select element or option is not found.
+   */
+  async runByText(selector, text) {
+    const { locator, description } = parseSelector(selector);
+    return executeCommand(
+      log,
+      'Could not select option by text for %s',
+      description,
+      async () => {
+        const driver = this.browser.getDriver();
+        await this._waitForElement(driver, locator);
+        const element = await driver.findElement(locator);
+        await driver.executeScript(
+          `const select = arguments[0];
+           const text = arguments[1];
+           for (const option of select.options) {
+             if (option.text === text || option.textContent.trim() === text) {
+               select.value = option.value;
+               select.dispatchEvent(new Event('change'));
+               return;
+             }
+           }
+           throw new Error('Option with text "' + text + '" not found');`,
+          element,
+          text
+        );
+      },
+      this.browser
+    );
+  }
+
+  /**
    * Selects an option in a `<select>` element by its ID and the value of the option.
    *
    * @async

--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -458,6 +458,17 @@ export class Commands {
     }
 
     /**
+     * Select an option in a select element by its visible text.
+     * @async
+     * @example await commands.select.byText('#country', 'Sweden');
+     * @param {string} selector - The selector string for the select element.
+     * @param {string} text - The visible text of the option to select.
+     * @returns {Promise<void>}
+     */
+    this.select.byText = async (selector, text) =>
+      selectInstance.runByText(selector, text);
+
+    /**
      * Selenium's action sequence functionality.
      * @type {Actions}
      * @see https://www.selenium.dev/documentation/webdriver/actions_api/


### PR DESCRIPTION
Select a dropdown option by its visible text content instead of its value attribute: commands.select.byText('#country', 'Sweden').

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I15b58fe7e12e92e696618b998c9a14093ed5ff94