### PR TITLE
Add commands.waitForUrl() for waiting on URL changes

### DIFF
--- a/lib/core/engine/commands.js
+++ b/lib/core/engine/commands.js
@@ -783,5 +783,31 @@ export class Commands {
           element
         );
     };
+
+    /**
+     * Waits until the browser's current URL contains the given string.
+     * Useful after form submissions, login redirects, or SPA navigation.
+     * @async
+     * @example await commands.waitForUrl('dashboard');
+     * @example await commands.waitForUrl('/account', { timeout: 10000 });
+     * @param {string} pattern - The string to match against the current URL.
+     * @param {Object} [urlOptions] - Options.
+     * @param {number} [urlOptions.timeout=10000] - Maximum time to wait in milliseconds.
+     * @returns {Promise<void>}
+     * @throws {Error} Throws an error if the URL does not match within the timeout.
+     * @type {Function}
+     */
+    this.waitForUrl = async (pattern, urlOptions = {}) => {
+      const timeout = urlOptions.timeout ?? 10_000;
+      const driver = browser.getDriver();
+      try {
+        await driver.wait(webdriver.until.urlContains(pattern), timeout);
+      } catch {
+        const currentUrl = await driver.getCurrentUrl();
+        throw new Error(
+          `URL did not contain '${pattern}' within ${timeout} ms. Current URL: ${currentUrl}`
+        );
+      }
+    };
   }
 }


### PR DESCRIPTION
Wait until the browser URL contains a given string. Default 10s timeout. Error message includes current URL for
  debugging. Useful after form submissions, login redirects, or SPA navigation.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I01ab08a3a17472821315b70bc12f65830868e8cd