### PR TITLE
Improve CI test coverage with new command scripts and form elements

### DIFF
--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -79,6 +79,8 @@ jobs:
       run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ http://127.0.0.1:3000/dimple/ --urlAlias startPage --urlAlias documentation --xvfb
     - name: Run test with pre-test functionality
       run: ./bin/browsertime.js -b chrome --preWarmServer --xvfb http://127.0.0.1:3000/simple/
+    - name: Test Chrome CDP and trace commands
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/chrome.cjs
   scripting:
     runs-on: ubuntu-22.04
     steps:
@@ -159,6 +161,12 @@ jobs:
       run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/misc.cjs
     - name: Test new convenience commands
       run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/newCommands.cjs
+    - name: Test Selenium Actions API
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/actions.cjs
+    - name: Test stopWatch commands
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/stopWatch.cjs
+    - name: Test measure with alias
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/measureAlias.cjs
     - name: Test extra profile run Chrome
       run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ -n 1 --viewPort 1000x600 --xvfb  --enableProfileRun
   video:

--- a/.github/workflows/linux-firefox.yml
+++ b/.github/workflows/linux-firefox.yml
@@ -77,3 +77,5 @@ jobs:
       run: ./bin/browsertime.js -b firefox --pageCompleteCheckNetworkIdle --xvfb http://127.0.0.1:3000/simple/
     - name: Test extra profile run Firefox
       run: ./bin/browsertime.js -b firefox http://127.0.0.1:3000/simple/ -n 1 --viewPort 1000x600 --xvfb  --enableProfileRun
+    - name: Test Firefox BiDi and profiler commands
+      run: ./bin/browsertime.js -b firefox test/data/commandscripts/firefox.cjs -n 1 --xvfb

--- a/test/data/commandscripts/newCommands.cjs
+++ b/test/data/commandscripts/newCommands.cjs
@@ -145,4 +145,24 @@ module.exports = async function (context, commands) {
       `Expected select value 'api' after byText but got '${selectValueAfterByText}'`
     );
   }
+
+  // Test check/uncheck/isChecked
+  const isCheckedBefore = await commands.isChecked('#exact-match');
+  if (isCheckedBefore) {
+    throw new Error('Expected checkbox to be unchecked initially');
+  }
+  await commands.check('#exact-match');
+  const isCheckedAfter = await commands.isChecked('#exact-match');
+  if (!isCheckedAfter) {
+    throw new Error('Expected checkbox to be checked after check()');
+  }
+  await commands.uncheck('#exact-match');
+  const isCheckedFinal = await commands.isChecked('#exact-match');
+  if (isCheckedFinal) {
+    throw new Error('Expected checkbox to be unchecked after uncheck()');
+  }
+
+  // Test clickAndMeasure
+  await commands.navigate('http://127.0.0.1:3000/simple/');
+  await commands.measure.clickAndMeasure('dimple', 'a[href="/dimple/"]');
 };

--- a/test/data/html/search/index.html
+++ b/test/data/html/search/index.html
@@ -11,5 +11,8 @@
             <option value="blog">Blog</option>
             <option value="api">API Reference</option>
         </select>
+        <label><input type="checkbox" id="exact-match"> Exact match</label>
+        <label><input type="radio" name="sort" id="sort-relevance" value="relevance" checked> Relevance</label>
+        <label><input type="radio" name="sort" id="sort-date" value="date"> Date</label>
     </body>
 </html>


### PR DESCRIPTION
Add checkbox and radio buttons to search test page. Extend newCommands.cjs with check/uncheck/isChecked and clickAndMeasure tests. Add CI steps for chrome.cjs (CDP/trace), actions.cjs (Actions API), stopWatch.cjs, measureAlias.cjs in Chrome workflow and firefox.cjs (BiDi/profiler) in Firefox workflow.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: Icafc6463a9cd5e280cd95f898131582027252f8e