### PR TITLE
Add tests for mouse unified selectors, scroll, and wait.byPageToComplete

### DIFF
--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -167,6 +167,8 @@ jobs:
       run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/stopWatch.cjs
     - name: Test measure with alias
       run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/measureAlias.cjs
+    - name: Test scroll commands
+      run: ./bin/browsertime.js -b chrome -n 1 --xvfb test/data/commandscripts/scrollToBottom.cjs
     - name: Test extra profile run Chrome
       run: ./bin/browsertime.js -b chrome http://127.0.0.1:3000/simple/ -n 1 --viewPort 1000x600 --xvfb  --enableProfileRun
   video:

--- a/test/data/commandscripts/newCommands.cjs
+++ b/test/data/commandscripts/newCommands.cjs
@@ -165,4 +165,20 @@ module.exports = async function (context, commands) {
   // Test clickAndMeasure
   await commands.navigate('http://127.0.0.1:3000/simple/');
   await commands.measure.clickAndMeasure('dimple', 'a[href="/dimple/"]');
+
+  // Test mouse unified selectors
+  await commands.navigate('http://127.0.0.1:3000/simple/');
+  await commands.mouse.singleClick('a[href="/dimple/"]');
+  await commands.wait.byTime(500);
+  await commands.navigate('http://127.0.0.1:3000/simple/');
+  await commands.mouse.doubleClick('#clickable');
+  await commands.mouse.contextClick('#clickable');
+
+  // Test wait.byPageToComplete
+  await commands.navigate('http://127.0.0.1:3000/simple/');
+  await commands.wait.byPageToComplete();
+
+  // Test scroll commands
+  await commands.scroll.toBottom(20);
+  await commands.scroll.byPixels(0, -200);
 };


### PR DESCRIPTION
Test mouse.singleClick/doubleClick/contextClick with unified selectors, wait.byPageToComplete, and
  scroll.toBottom/byPixels in newCommands.cjs. Add scrollToBottom.cjs to Chrome CI.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I43b5b3f16d5302da991347302e672fd006967f75