### PR TITLE
Add Safari iOS HAR capture via ios_webkit_debug_proxy

### DIFF
--- a/lib/safari/har.js
+++ b/lib/safari/har.js
@@ -1,0 +1,131 @@
+import { harFromMessages } from 'chrome-har';
+import { getLogger } from '@sitespeed.io/log';
+import { cleanSensitiveHeaders } from '../support/har/index.js';
+
+const log = getLogger('browsertime.safari.har');
+
+export async function getHar(
+  adapter,
+  result,
+  index,
+  inspectorClient,
+  includeResponseBodies,
+  aliasAndUrl,
+  cleanHeaders
+) {
+  const messages = adapter.getMessages();
+
+  let har;
+  try {
+    har = harFromMessages(messages);
+  } catch (error) {
+    log.error('Failed to generate HAR from messages: %s', error.message);
+    log.verbose(error);
+    return getEmptyHar();
+  }
+
+  // Fix timing values and remove cached entries without timing data
+  har.log.entries = har.log.entries.filter(entry => {
+    // Remove entries without _requestTime — these are cached resources
+    // that WebKit reported but have no useful timing data
+    const noTiming =
+      entry._requestTime === undefined || entry._requestTime === 0;
+    if (noTiming) {
+      return false;
+    }
+
+    // Fix any remaining NaN/non-number timing values
+    if (entry.timings) {
+      for (const key of Object.keys(entry.timings)) {
+        if (key === 'comment') {
+          // comment must be a string per HAR spec
+          if (typeof entry.timings[key] !== 'string') {
+            delete entry.timings[key];
+          }
+        } else if (
+          typeof entry.timings[key] !== 'number' ||
+          !Number.isFinite(entry.timings[key])
+        ) {
+          entry.timings[key] = 0;
+        }
+      }
+    }
+    if (typeof entry.time !== 'number' || !Number.isFinite(entry.time)) {
+      entry.time = 0;
+    }
+    return true;
+  });
+
+  // Add browser info
+  har.log.creator = {
+    name: 'Browsertime',
+    version: '1.0'
+  };
+  har.log.browser = {
+    name: 'Safari',
+    version: ''
+  };
+
+  // Clean sensitive headers if requested
+  if (cleanHeaders === true) {
+    for (const entry of har.log.entries ?? []) {
+      for (const header of entry.request?.headers ?? []) {
+        header.value = cleanSensitiveHeaders(header.name, header.value);
+      }
+      for (const header of entry.response?.headers ?? []) {
+        header.value = cleanSensitiveHeaders(header.name, header.value);
+      }
+    }
+  }
+
+  // Handle response bodies
+  if (
+    inspectorClient &&
+    (includeResponseBodies === 'html' || includeResponseBodies === 'all')
+  ) {
+    for (const entry of har.log.entries) {
+      if (
+        includeResponseBodies === 'html' &&
+        !entry.response.content.mimeType?.includes('text/html')
+      ) {
+        continue;
+      }
+      try {
+        const response = await inspectorClient.send('Network.getResponseBody', {
+          requestId: entry._requestId
+        });
+        if (response?.result?.body) {
+          entry.response.content.text = response.result.body;
+          if (response.result.base64Encoded) {
+            entry.response.content.encoding = 'base64';
+          }
+        }
+      } catch {
+        log.debug('Could not get response body for %s', entry.request.url);
+      }
+    }
+  }
+
+  // Set page title and URL
+  if (har.log.pages.length > 0) {
+    const url = result.url || '';
+    har.log.pages[0].title = `${url} run ${index}`;
+    const alias = aliasAndUrl[url] || url;
+    har.log.pages[0]._url = url;
+    har.log.pages[0]._alias = alias;
+  }
+
+  return har;
+}
+
+function getEmptyHar() {
+  return {
+    log: {
+      version: '1.2',
+      creator: { name: 'Browsertime', version: '1.0' },
+      browser: { name: 'Safari', version: '' },
+      pages: [],
+      entries: []
+    }
+  };
+}

--- a/lib/safari/safariInspectorClient.js
+++ b/lib/safari/safariInspectorClient.js
@@ -1,0 +1,306 @@
+/* global WebSocket */
+import { execa } from 'execa';
+import { getLogger } from '@sitespeed.io/log';
+
+const log = getLogger('browsertime.safari.inspector');
+
+export class SafariInspectorClient {
+  constructor(options) {
+    this.options = options;
+    this.safariOptions = options.safari || {};
+    this.port = options.iwdpPort || 9222;
+    this.connections = [];
+    this.targetId = undefined;
+    this.targetWs = undefined; // The WebSocket that owns the active target
+    this.messageId = 0;
+    this.pendingMessages = new Map();
+    this.eventListeners = new Map();
+    this.iwdpProcess = undefined;
+  }
+
+  async setup() {
+    await this._verifyIwdpInstalled();
+    await this._startIwdp();
+    await this._waitForIwdp();
+    await this._connectWebSockets();
+    await this._waitForTarget();
+  }
+
+  async _verifyIwdpInstalled() {
+    try {
+      await execa('which', ['ios_webkit_debug_proxy']);
+    } catch {
+      throw new Error(
+        'ios_webkit_debug_proxy is not installed. Install it with: brew install ios-webkit-debug-proxy'
+      );
+    }
+  }
+
+  async _startIwdp() {
+    const args = ['-F'];
+    if (this.safariOptions.deviceUDID) {
+      args.push('-u', this.safariOptions.deviceUDID);
+    }
+    log.debug('Starting ios_webkit_debug_proxy on port %d', this.port);
+    this.iwdpProcess = execa('ios_webkit_debug_proxy', args, {
+      stdio: 'ignore'
+    });
+    this.iwdpProcess.catch(error => {
+      if (!error.isCanceled) {
+        log.error('ios_webkit_debug_proxy failed: %s', error.message);
+      }
+    });
+  }
+
+  async _waitForIwdp() {
+    const maxRetries = 20;
+    const retryDelay = 500;
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const response = await fetch(`http://localhost:${this.port}/json`);
+        if (response.ok) {
+          log.debug('ios_webkit_debug_proxy is ready');
+          return;
+        }
+      } catch {
+        // Not ready yet
+      }
+      await new Promise(r => setTimeout(r, retryDelay));
+    }
+    throw new Error(
+      `ios_webkit_debug_proxy did not start within ${(maxRetries * retryDelay) / 1000} seconds`
+    );
+  }
+
+  async _connectWebSockets() {
+    const response = await fetch(`http://localhost:${this.port}/json`);
+    const pages = await response.json();
+
+    for (const page of pages) {
+      if (!page.webSocketDebuggerUrl) continue;
+      try {
+        const ws = await new Promise((resolve, reject) => {
+          const socket = new WebSocket(page.webSocketDebuggerUrl);
+          socket.addEventListener('open', () => resolve(socket));
+          socket.addEventListener('error', () =>
+            reject(new Error('WebSocket error'))
+          );
+          setTimeout(() => reject(new Error('timeout')), 5000);
+        });
+
+        ws.addEventListener('message', event => {
+          this._handleMessage(ws, JSON.parse(event.data));
+        });
+
+        this.connections.push({ ws, page });
+        log.debug('Connected to page: %s', page.title || page.url || 'unknown');
+      } catch {
+        // Skip pages we can't connect to
+      }
+    }
+
+    if (this.connections.length === 0) {
+      throw new Error(
+        'No inspectable Safari pages found via ios_webkit_debug_proxy'
+      );
+    }
+
+    log.debug('Connected to %d inspectable pages', this.connections.length);
+  }
+
+  async _waitForTarget() {
+    // Wait for targetCreated events
+    await new Promise(r => setTimeout(r, 1500));
+
+    if (this.targetId) {
+      log.debug('Network and Page enabled on target %s', this.targetId);
+    } else {
+      log.debug(
+        'No page target found yet — will enable Network when a target appears'
+      );
+    }
+  }
+
+  _handleMessage(ws, msg) {
+    // Handle Target.targetCreated — auto-enable Network on new page targets
+    if (msg.method === 'Target.targetCreated') {
+      const target = msg.params?.targetInfo;
+      if (target?.type === 'page') {
+        this.targetId = target.targetId;
+        this.targetWs = ws; // Remember which WebSocket owns this target
+        log.debug('Found page target: %s', this.targetId);
+        // Enable Network and Page on this target immediately
+        this._sendOnWs(ws, 'Target.sendMessageToTarget', {
+          targetId: target.targetId,
+          message: JSON.stringify({
+            id: ++this.messageId,
+            method: 'Network.enable',
+            params: {}
+          })
+        });
+        this._sendOnWs(ws, 'Target.sendMessageToTarget', {
+          targetId: target.targetId,
+          message: JSON.stringify({
+            id: ++this.messageId,
+            method: 'Page.enable',
+            params: {}
+          })
+        });
+      }
+    }
+
+    // Unwrap Target.dispatchMessageFromTarget — only from the active target
+    if (msg.method === 'Target.dispatchMessageFromTarget') {
+      try {
+        const innerMsg = JSON.parse(msg.params.message);
+        // Only dispatch events from the active target to avoid cross-tab noise
+        const fromTargetId = msg.params.targetId;
+        if (innerMsg.method && fromTargetId === this.targetId) {
+          const listeners = this.eventListeners.get(innerMsg.method) || [];
+          for (const cb of listeners) {
+            cb(innerMsg.params);
+          }
+        }
+        // Resolve pending commands
+        if (
+          innerMsg.id !== undefined &&
+          this.pendingMessages.has(innerMsg.id)
+        ) {
+          const { resolve } = this.pendingMessages.get(innerMsg.id);
+          this.pendingMessages.delete(innerMsg.id);
+          resolve(innerMsg);
+        }
+      } catch {
+        // Not valid JSON
+      }
+    }
+
+    // Resolve top-level responses
+    if (msg.id !== undefined && this.pendingMessages.has(msg.id)) {
+      const { resolve } = this.pendingMessages.get(msg.id);
+      this.pendingMessages.delete(msg.id);
+      resolve(msg);
+    }
+  }
+
+  /**
+   * Send a command to the active page target via Target.sendMessageToTarget.
+   */
+  async send(method, params = {}) {
+    if (!this.targetId || !this.targetWs) {
+      throw new Error('No target available for sending commands');
+    }
+    const innerId = ++this.messageId;
+    const innerMsg = JSON.stringify({ id: innerId, method, params });
+
+    return new Promise((resolve, reject) => {
+      this.pendingMessages.set(innerId, { resolve, reject });
+      try {
+        const outerId = ++this.messageId;
+        this.targetWs.send(
+          JSON.stringify({
+            id: outerId,
+            method: 'Target.sendMessageToTarget',
+            params: { targetId: this.targetId, message: innerMsg }
+          })
+        );
+      } catch (error) {
+        this.pendingMessages.delete(innerId);
+        reject(error);
+      }
+      setTimeout(() => {
+        if (this.pendingMessages.has(innerId)) {
+          this.pendingMessages.delete(innerId);
+          resolve({ error: 'timeout' });
+        }
+      }, 10_000);
+    });
+  }
+
+  /**
+   * Fire-and-forget send on a specific WebSocket.
+   */
+  _sendOnWs(ws, method, params) {
+    try {
+      ws.send(JSON.stringify({ id: ++this.messageId, method, params }));
+    } catch (error) {
+      log.debug('Send error: %s', error.message);
+    }
+  }
+
+  on(eventName, callback) {
+    if (!this.eventListeners.has(eventName)) {
+      this.eventListeners.set(eventName, []);
+    }
+    this.eventListeners.get(eventName).push(callback);
+  }
+
+  removeAllListeners() {
+    this.eventListeners.clear();
+  }
+
+  /**
+   * Reconnect to iwdp to discover new pages that appeared after initial setup.
+   * This is needed because safaridriver may create new tabs that weren't
+   * in the original page list.
+   */
+  async reconnect() {
+    const response = await fetch(`http://localhost:${this.port}/json`);
+    const pages = await response.json();
+
+    // Find pages we're not already connected to
+    const connectedUrls = new Set(
+      this.connections.map(c => c.page.webSocketDebuggerUrl)
+    );
+
+    for (const page of pages) {
+      if (!page.webSocketDebuggerUrl) continue;
+      if (connectedUrls.has(page.webSocketDebuggerUrl)) continue;
+
+      try {
+        const ws = await new Promise((resolve, reject) => {
+          const socket = new WebSocket(page.webSocketDebuggerUrl);
+          socket.addEventListener('open', () => resolve(socket));
+          socket.addEventListener('error', () =>
+            reject(new Error('WebSocket error'))
+          );
+          setTimeout(() => reject(new Error('timeout')), 3000);
+        });
+
+        ws.addEventListener('message', event => {
+          this._handleMessage(ws, JSON.parse(event.data));
+        });
+
+        this.connections.push({ ws, page });
+        log.debug(
+          'Reconnected to new page: %s (%s)',
+          page.title || 'untitled',
+          page.url || 'no url'
+        );
+      } catch {
+        // Skip
+      }
+    }
+  }
+
+  async close() {
+    for (const conn of this.connections) {
+      try {
+        conn.ws.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+    this.connections = [];
+    this.targetWs = undefined;
+    if (this.iwdpProcess) {
+      try {
+        this.iwdpProcess.kill();
+      } catch {
+        // Ignore kill errors
+      }
+      this.iwdpProcess = undefined;
+    }
+    log.debug('Safari inspector client closed');
+  }
+}

--- a/lib/safari/webdriver/safari.js
+++ b/lib/safari/webdriver/safari.js
@@ -1,11 +1,23 @@
 // const log = require('intel').getLogger('browsertime.safari');
 import { execaCommand as command } from 'execa';
+import { getLogger } from '@sitespeed.io/log';
+import { SafariInspectorClient } from '../safariInspectorClient.js';
+import { WebkitToCdpAdapter } from '../webkitToCdpAdapter.js';
+import { getHar } from '../har.js';
+import { getEmptyHAR, mergeHars } from '../../support/har/index.js';
+
 const delay = ms => new Promise(res => setTimeout(res, ms));
+const log = getLogger('browsertime.safari');
 
 export class Safari {
   constructor(storageManager, options) {
     this.options = options;
     this.safariOptions = options.safari || {};
+    this.skipHar = options.skipHar || false;
+    this.hars = [];
+    this.aliasAndUrl = {};
+    this.inspectorClient = undefined;
+    this.adapter = undefined;
   }
 
   /**
@@ -19,7 +31,12 @@ export class Safari {
           shell: true
         }
       );
-      return delay(2000);
+      await delay(2000);
+
+      // Start the inspector client for HAR capture
+      if (!this.skipHar) {
+        this.inspectorClient = new SafariInspectorClient(this.options);
+      }
     }
   }
 
@@ -27,7 +44,11 @@ export class Safari {
    * The browser is up and running, now its time to start to
    * configure what you need.
    */
-  async afterBrowserStart() {}
+  async afterBrowserStart() {
+    if (this.safariOptions.ios && this.inspectorClient) {
+      await this.inspectorClient.setup();
+    }
+  }
 
   /**
    * Before the first iteration of your tests start.
@@ -37,7 +58,36 @@ export class Safari {
   /**
    * Before each URL/test runs.
    */
-  async beforeEachURL() {}
+  async beforeEachURL() {
+    if (this.inspectorClient) {
+      this.adapter = new WebkitToCdpAdapter();
+      this.inspectorClient.removeAllListeners();
+
+      // Register listeners for all network and page events
+      const networkEvents = [
+        'Network.requestWillBeSent',
+        'Network.responseReceived',
+        'Network.dataReceived',
+        'Network.loadingFinished',
+        'Network.loadingFailed',
+        'Network.requestServedFromMemoryCache',
+        'Page.loadEventFired',
+        'Page.domContentEventFired'
+      ];
+      for (const event of networkEvents) {
+        this.inspectorClient.on(event, params => {
+          this.adapter.onWebkitEvent(event, params);
+        });
+      }
+
+      // Reconnect to iwdp to pick up any new pages after safaridriver setup
+      try {
+        await this.inspectorClient.reconnect();
+      } catch (error) {
+        log.debug('Reconnect attempt: %s', error.message);
+      }
+    }
+  }
 
   /**
    * When the page has finsihed loading, this functions runs (before
@@ -45,19 +95,44 @@ export class Safari {
    * stop trace logging, stop measuring etc.
    *
    */
-  async afterPageCompleteCheck(runner) {
+  async afterPageCompleteCheck(runner, index, url, alias) {
     const resources = await runner.runScript(
       'return performance.getEntriesByType("resource");',
       'RESOURCE_TIMINGS'
     );
 
-    return {
+    const result = {
       browserScripts: {
         timings: {
           resourceTimings: resources
         }
-      }
+      },
+      url,
+      alias
     };
+
+    // Collect HAR from inspector client
+    if (this.inspectorClient && this.adapter) {
+      try {
+        const har = await getHar(
+          this.adapter,
+          result,
+          index,
+          this.inspectorClient,
+          this.safariOptions.includeResponseBodies,
+          this.aliasAndUrl,
+          this.options.cleanSensitiveHeaders
+        );
+        if (har.log.entries.length > 0) {
+          this.hars.push(har);
+          log.debug('Captured HAR with %d entries', har.log.entries.length);
+        }
+      } catch (error) {
+        log.error('Failed to generate HAR: %s', error.message);
+      }
+    }
+
+    return result;
   }
 
   /**
@@ -68,19 +143,31 @@ export class Safari {
   /**
    * This method is called if a runs fail
    */
-  failing() {}
+  failing(url) {
+    if (!this.skipHar) {
+      this.hars.push(getEmptyHAR(url, 'Safari'));
+    }
+  }
 
   /**
    * Get the HAR file for all the runs.
    */
   async getHARs() {
-    return [];
+    if (this.hars.length > 0) {
+      return { har: mergeHars(this.hars) };
+    }
+    return {};
   }
 
   /**
    * Before the browser is stopped/closed.
    */
-  async beforeBrowserStop() {}
+  async beforeBrowserStop() {
+    if (this.inspectorClient) {
+      await this.inspectorClient.close();
+      this.inspectorClient = undefined;
+    }
+  }
 
   async afterBrowserStopped() {
     if (this.safariOptions.useSimulator) {
@@ -98,6 +185,6 @@ export class Safari {
   }
 
   async waitForNetworkIdle() {
-    throw new Error('waitForNetworkIdle is not implemented in Safari');
+    throw new Error('waitForNetworkIdle is not yet implemented for Safari');
   }
 }

--- a/lib/safari/webkitToCdpAdapter.js
+++ b/lib/safari/webkitToCdpAdapter.js
@@ -1,0 +1,241 @@
+import { getLogger } from '@sitespeed.io/log';
+
+const log = getLogger('browsertime.safari.adapter');
+
+/**
+ * Adapts WebKit Inspector Protocol network events to Chrome DevTools Protocol
+ * format so they can be processed by chrome-har.
+ */
+export class WebkitToCdpAdapter {
+  constructor() {
+    this.messages = [];
+    this.responseMap = new Map();
+    this.requestTimestamps = new Map(); // requestId -> { timestamp, wallTime }
+    this.mainFrameId = undefined;
+    this.pageCreated = false;
+  }
+
+  onWebkitEvent(method, params) {
+    switch (method) {
+      case 'Network.requestWillBeSent': {
+        const adapted = this._adaptRequestWillBeSent(params);
+
+        // chrome-har needs a Page.frameNavigated event to create a page.
+        // Inject it when we see the first Document request.
+        if (!this.pageCreated && adapted.type === 'Document') {
+          this.mainFrameId = adapted.frameId || 'main';
+          this.messages.push({
+            method: 'Page.frameStartedLoading',
+            params: {
+              frameId: this.mainFrameId
+            }
+          });
+          this.pageCreated = true;
+        }
+
+        this.messages.push({
+          method: 'Network.requestWillBeSent',
+          params: adapted
+        });
+        break;
+      }
+      case 'Network.responseReceived': {
+        const adapted = {
+          method: 'Network.responseReceived',
+          params: this._adaptResponseReceived(params)
+        };
+        this.messages.push(adapted);
+        this.responseMap.set(params.requestId, adapted);
+        break;
+      }
+      case 'Network.dataReceived': {
+        this.messages.push({
+          method: 'Network.dataReceived',
+          params: {
+            requestId: params.requestId,
+            timestamp: params.timestamp,
+            dataLength: params.dataLength,
+            encodedDataLength: params.encodedDataLength || 0
+          }
+        });
+        break;
+      }
+      case 'Network.loadingFinished': {
+        this._patchResponseWithMetrics(params);
+        this.messages.push({
+          method: 'Network.loadingFinished',
+          params: {
+            requestId: params.requestId,
+            timestamp: params.timestamp,
+            encodedDataLength:
+              params.metrics?.responseBodyBytesReceived ??
+              params.encodedDataLength ??
+              0
+          }
+        });
+        break;
+      }
+      case 'Network.loadingFailed': {
+        this.messages.push({
+          method: 'Network.loadingFailed',
+          params: {
+            requestId: params.requestId,
+            timestamp: params.timestamp,
+            errorText: params.errorText || 'Failed',
+            canceled: params.canceled || false,
+            type: params.type
+          }
+        });
+        break;
+      }
+      case 'Network.requestServedFromMemoryCache': {
+        this.messages.push({
+          method: 'Network.requestServedFromMemoryCache',
+          params
+        });
+        break;
+      }
+      case 'Page.loadEventFired': {
+        this.messages.push({
+          method: 'Page.loadEventFired',
+          params: { timestamp: params.timestamp }
+        });
+        break;
+      }
+      case 'Page.domContentEventFired': {
+        this.messages.push({
+          method: 'Page.domContentEventFired',
+          params: { timestamp: params.timestamp }
+        });
+        break;
+      }
+      default: {
+        log.debug('Unhandled WebKit event: %s', method);
+      }
+    }
+  }
+
+  _adaptRequestWillBeSent(params) {
+    // Store timestamp mapping for converting timing.requestTime to epoch-relative
+    this.requestTimestamps.set(params.requestId, {
+      timestamp: params.timestamp,
+      wallTime: params.walltime || params.wallTime || Date.now() / 1000
+    });
+
+    return {
+      requestId: params.requestId,
+      frameId: params.frameId,
+      loaderId: params.loaderId || params.requestId,
+      documentURL: params.documentURL || '',
+      timestamp: params.timestamp,
+      wallTime: params.walltime || params.wallTime || Date.now() / 1000,
+      type: params.type,
+      initiator: params.initiator || { type: 'other' },
+      request: {
+        url: params.request?.url || '',
+        method: params.request?.method || 'GET',
+        headers: params.request?.headers || {},
+        postData: params.request?.postData,
+        initialPriority: 'Medium'
+      },
+      redirectResponse: params.redirectResponse
+        ? this._adaptResponse(params.redirectResponse)
+        : undefined
+    };
+  }
+
+  _adaptResponseReceived(params) {
+    return {
+      requestId: params.requestId,
+      frameId: params.frameId,
+      loaderId: params.loaderId || params.requestId,
+      timestamp: params.timestamp,
+      type: params.type,
+      response: this._adaptResponse(params.response || {})
+    };
+  }
+
+  _adaptResponse(response) {
+    const timing = response.timing
+      ? this._adaptTiming(response.timing)
+      : undefined;
+
+    return {
+      url: response.url || '',
+      status: response.status || 0,
+      statusText: response.statusText || '',
+      headers: response.headers || {},
+      mimeType: response.mimeType || '',
+      connectionId: String(response.connectionId || '0'),
+      remoteIPAddress: response.remoteIPAddress || '',
+      remotePort: response.remotePort || 0,
+      protocol: response.protocol || '',
+      encodedDataLength: response.encodedDataLength || 0,
+      fromDiskCache:
+        response.source === 'disk-cache' ||
+        response.source === 'memory-cache' ||
+        response.fromDiskCache === true,
+      fromServiceWorker: response.source === 'service-worker' || false,
+      timing
+    };
+  }
+
+  _adaptTiming(timing) {
+    // WebKit timing fields are ms offsets from fetchStart, similar to CDP
+    // but secureConnectionStart can be an absolute timestamp when reused
+    let sslStart = timing.secureConnectionStart ?? -1;
+    let sslEnd = timing.connectEnd ?? -1;
+
+    // Detect invalid SSL timestamps (WebKit sends huge negative numbers for reused connections)
+    if (sslStart > 100_000 || sslStart < -1) {
+      sslStart = -1;
+      sslEnd = -1;
+    }
+
+    return {
+      // WebKit uses startTime (seconds, page-relative) as the request base time
+      requestTime: Number(timing.startTime) || 0,
+      dnsStart: Number(timing.domainLookupStart ?? -1),
+      dnsEnd: Number(timing.domainLookupEnd ?? -1),
+      connectStart: Number(timing.connectStart ?? -1),
+      connectEnd: Number(timing.connectEnd ?? -1),
+      sslStart: Number(sslStart),
+      sslEnd: Number(sslEnd),
+      sendStart: Number(timing.requestStart ?? -1),
+      sendEnd: Number(timing.requestStart ?? -1),
+      receiveHeadersEnd: Number(timing.responseStart ?? -1)
+    };
+  }
+
+  _patchResponseWithMetrics(loadingFinishedParams) {
+    const metrics = loadingFinishedParams.metrics;
+    if (!metrics) return;
+
+    const responseMsg = this.responseMap.get(loadingFinishedParams.requestId);
+    if (!responseMsg) return;
+
+    const response = responseMsg.params.response;
+    if (metrics.remoteAddress && !response.remoteIPAddress) {
+      const separator = metrics.remoteAddress.lastIndexOf(':');
+      response.remoteIPAddress =
+        separator === -1
+          ? metrics.remoteAddress
+          : metrics.remoteAddress.slice(0, separator);
+    }
+    if (metrics.protocol && !response.protocol) {
+      response.protocol = metrics.protocol;
+    }
+  }
+
+  getMessages() {
+    return [...this.messages];
+  }
+
+  reset() {
+    this.messages = [];
+    this.responseMap.clear();
+    this.requestTimestamps.clear();
+    this.pageCreated = false;
+    this.mainFrameId = undefined;
+  }
+}

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -912,6 +912,12 @@ export function parseCommandLine() {
       type: 'boolean',
       group: 'safari'
     })
+    .option('safari.includeResponseBodies', {
+      describe:
+        'Include response bodies in HAR for Safari iOS. "none" (default), "html", or "all".',
+      default: 'none',
+      group: 'safari'
+    })
     /** Screenshot */
     .option('screenshot', {
       type: 'boolean',


### PR DESCRIPTION
Capture HAR files from Safari on iOS by connecting to ios_webkit_debug_proxy, enabling the WebKit Inspector Protocol's Network domain via Target routing, and adapting events to Chrome DevTools Protocol format for chrome-har processing. Browsertime starts and stops iwdp automatically and exits with a clear error if it's not installed. Uses Node.js built-in WebSocket — no new dependencies. Cached entries without timing data are filtered out. Adds --safari.includeResponseBodies CLI option. macOS Safari is unaffected.

Co-authored-by: Claude Opus 4.6 (1M context) noreply@anthropic.com
Change-Id: I656c458740e3ec6836aaeced0fa960d55add9c3d