### PR TITLE
Add soft navigation support for Chrome

### DIFF
--- a/browserscripts/timings/softNavigations.js
+++ b/browserscripts/timings/softNavigations.js
@@ -1,0 +1,94 @@
+(function () {
+  const supported = PerformanceObserver.supportedEntryTypes;
+  if (!supported || supported.indexOf('soft-navigation') === -1) {
+    return;
+  }
+  var startIndex = window.__bt_softNavCount || 0;
+  const allNew = performance.getEntriesByType('soft-navigation').slice(startIndex);
+  if (allNew.length === 0) {
+    return;
+  }
+  // Use the last entry — a single user interaction can trigger
+  // multiple intermediate soft navigations (e.g. React, Turbo)
+  const entry = allNew[allNew.length - 1];
+  var navId = entry.navigationId;
+
+  // CLS for this soft navigation
+  var cls = 0;
+  if (supported.indexOf('layout-shift') !== -1) {
+    const observer = new PerformanceObserver(list => {});
+    observer.observe({type: 'layout-shift', buffered: true});
+    const shifts = observer.takeRecords().filter(function (s) {
+      return s.navigationId === navId;
+    });
+    var max = 0;
+    var curr = 0;
+    var firstTs = Number.NEGATIVE_INFINITY;
+    var prevTs = Number.NEGATIVE_INFINITY;
+    for (let s of shifts) {
+      if (s.hadRecentInput) continue;
+      if (s.startTime - firstTs > 5000 || s.startTime - prevTs > 1000) {
+        firstTs = s.startTime;
+        curr = 0;
+      }
+      prevTs = s.startTime;
+      curr += s.value;
+      max = Math.max(max, curr);
+    }
+    cls = max;
+  }
+
+  // INP for this soft navigation
+  var inp = 0;
+  if (supported.indexOf('event') !== -1) {
+    const observer = new PerformanceObserver(list => {});
+    observer.observe({type: 'event', buffered: true});
+    const events = observer.takeRecords().filter(function (e) {
+      return e.navigationId === navId && e.interactionId;
+    });
+    const MAX_INTERACTIONS = 10;
+    const longestList = [];
+    const longestMap = {};
+    for (let e of events) {
+      var minLongest = longestList[longestList.length - 1];
+      var existing = longestMap[e.interactionId];
+      if (existing || longestList.length < MAX_INTERACTIONS || e.duration > minLongest.latency) {
+        if (existing) {
+          existing.latency = Math.max(existing.latency, e.duration);
+        } else {
+          var interaction = { id: e.interactionId, latency: e.duration };
+          longestMap[interaction.id] = interaction;
+          longestList.push(interaction);
+        }
+        longestList.sort(function (a, b) { return b.latency - a.latency; });
+        longestList.splice(MAX_INTERACTIONS).forEach(function (i) { delete longestMap[i.id]; });
+      }
+    }
+    var inpEntry = longestList[longestList.length - 1];
+    inp = inpEntry ? inpEntry.latency : 0;
+  }
+
+  // LCP value
+  var lcp = 0;
+  if (entry.largestInteractionContentfulPaint) {
+    lcp = typeof entry.largestInteractionContentfulPaint === 'number'
+      ? entry.largestInteractionContentfulPaint
+      : entry.largestInteractionContentfulPaint.renderTime ||
+        entry.largestInteractionContentfulPaint.loadTime ||
+        entry.largestInteractionContentfulPaint.startTime || 0;
+  }
+
+  return [{
+    name: entry.name,
+    navigationId: navId,
+    interactionId: entry.interactionId,
+    startTime: Number(entry.startTime.toFixed(0)),
+    duration: Number(entry.duration.toFixed(0)),
+    firstContentfulPaint: entry.presentationTime
+      ? Number(entry.presentationTime.toFixed(0))
+      : 0,
+    largestInteractionContentfulPaint: Number(lcp.toFixed(0)),
+    cumulativeLayoutShift: cls,
+    interactionToNextPaint: inp
+  }];
+})();

--- a/lib/chrome/har.js
+++ b/lib/chrome/har.js
@@ -23,6 +23,32 @@ export async function getHar(
   const logs = await runner.getLogs(Type.PERFORMANCE);
   const messages = logs.map(entry => JSON.parse(entry.message).message);
 
+  // Inject a SoftNavigation.detected event so chrome-har renames the
+  // current HAR page with the soft navigation URL. The PerformanceObserver
+  // API is the only reliable source that confirms all three soft navigation
+  // criteria (user interaction + URL change + visible paint).
+  try {
+    const softNavEntries = await runner.runScript(
+      `const supported = PerformanceObserver.supportedEntryTypes;
+       if (!supported || supported.indexOf('soft-navigation') === -1) return [];
+       const startIndex = window.__bt_softNavCount || 0;
+       const entries = performance.getEntriesByType('soft-navigation').slice(startIndex);
+       if (entries.length === 0) return [];
+       const last = entries[entries.length - 1];
+       return [{ url: last.name, startTime: last.startTime }];`,
+      'GET_SOFT_NAVIGATIONS_FOR_HAR'
+    );
+    if (softNavEntries && softNavEntries.length > 0) {
+      const entry = softNavEntries[0];
+      messages.push({
+        method: 'SoftNavigation.detected',
+        params: { url: entry.url, startTime: entry.startTime }
+      });
+    }
+  } catch {
+    // Soft navigations not supported, ignore
+  }
+
   if (logPerfEntries) {
     if (!result.extraJson) {
       result.extraJson = {};
@@ -68,15 +94,20 @@ export async function getHar(
   }
 
   if (har.log.pages.length > 0) {
-    har.log.pages[0].title = `${result.url} run ${index}`;
+    const page = har.log.pages[0];
+    // For soft navigations, use the soft navigation URL as the title
+    const pageUrl = page._softNavigation ? page.title : result.url;
+    page.title = `${pageUrl} run ${index}`;
     // Hack to add the URL from a SPA
-    if (result.alias && !aliasAndUrl[result.alias]) {
+    if (page._softNavigation) {
+      page._url = pageUrl;
+    } else if (result.alias && !aliasAndUrl[result.alias]) {
       aliasAndUrl[result.alias] = result.url;
-      har.log.pages[0]._url = result.url;
+      page._url = result.url;
     } else if (result.alias && aliasAndUrl[result.alias]) {
-      har.log.pages[0]._url = aliasAndUrl[result.alias];
+      page._url = aliasAndUrl[result.alias];
     } else {
-      har.log.pages[0]._url = result.url;
+      page._url = result.url;
     }
   }
   return har;

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -420,6 +420,45 @@ export class Chromium {
       result.renderBlocking.requests = render.renderBlockingInfo;
     }
 
+    // If a soft navigation was detected, promote its metrics to the
+    // standard locations so they flow through googleWebVitals, logging,
+    // and statistics just like regular page load metrics.
+    if (
+      result.browserScripts.timings &&
+      result.browserScripts.timings.softNavigations &&
+      result.browserScripts.timings.softNavigations.length > 0
+    ) {
+      const softNav = result.browserScripts.timings.softNavigations.at(-1);
+      const navStart = softNav.startTime;
+
+      if (softNav.firstContentfulPaint) {
+        result.browserScripts.timings.paintTiming =
+          result.browserScripts.timings.paintTiming || {};
+        result.browserScripts.timings.paintTiming['first-contentful-paint'] =
+          softNav.firstContentfulPaint - navStart;
+      }
+
+      if (softNav.largestInteractionContentfulPaint > 0) {
+        result.browserScripts.timings.largestContentfulPaint = {
+          renderTime: Math.max(
+            0,
+            softNav.largestInteractionContentfulPaint - navStart
+          )
+        };
+      }
+
+      if (softNav.cumulativeLayoutShift !== undefined) {
+        result.browserScripts.pageinfo = result.browserScripts.pageinfo || {};
+        result.browserScripts.pageinfo.cumulativeLayoutShift =
+          softNav.cumulativeLayoutShift;
+      }
+
+      if (softNav.interactionToNextPaint) {
+        result.browserScripts.timings.interactionToNextPaint =
+          softNav.interactionToNextPaint;
+      }
+    }
+
     // Google Web Vitals hacksery
     result.googleWebVitals = {};
     if (result.browserScripts.pageinfo) {

--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -19,6 +19,8 @@ const CHROME_AMD_EDGE_INTERNAL_PHONE_HOME = [
   'MAP optimizationguide-pa.googleapis.com 127.0.0.1'
 ];
 
+const CHROME_FEATURES_THAT_WE_ENABLE = ['SoftNavigationHeuristics'];
+
 const CHROME_FEATURES_THAT_WE_DISABLES = [
   'AutofillServerCommunication',
   'CalculateNativeWinOcclusion',
@@ -69,6 +71,10 @@ export function setupChromiumOptions(
 
   seleniumOptions.addArguments(
     '--disable-features=' + CHROME_FEATURES_THAT_WE_DISABLES.join(',')
+  );
+
+  seleniumOptions.addArguments(
+    '--enable-features=' + CHROME_FEATURES_THAT_WE_ENABLE.join(',')
   );
 
   const viewPort = getViewPort(options);
@@ -188,6 +194,12 @@ export function setupChromiumOptions(
       ) {
         seleniumOptions.addArguments(`${argument},ChromeWhatsNewUI`);
         log.debug('Set Chrome args %j', `${argument},ChromeWhatsNewUI`);
+      } else if (
+        argument.includes('enable-features') &&
+        !argument.includes('SoftNavigationHeuristics')
+      ) {
+        seleniumOptions.addArguments(`${argument},SoftNavigationHeuristics`);
+        log.debug('Set Chrome args %j', `${argument},SoftNavigationHeuristics`);
       } else {
         seleniumOptions.addArguments(argument);
         log.debug('Set Chrome args %j', argument);

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -265,6 +265,14 @@ export class Measure {
         .executeScript('window.performance.clearResourceTimings();');
     }
 
+    // Record current soft navigation count so browser scripts
+    // only collect entries from this measurement
+    await this.browser
+      .getDriver()
+      .executeScript(
+        'window.__bt_softNavCount = (performance.getEntriesByType("soft-navigation") || []).length;'
+      );
+
     if (this.measureVideo.shouldRecord()) {
       await this.measureVideo.start(this.numberOfMeasuredPages, this.index);
       // if we do not have the URL, we should remove the orange and


### PR DESCRIPTION
Single-page apps navigate without full page loads, so the user clicks, the URL changes, and content paints — but the standard FCP/LCP/CLS/INP metrics never re-fire. SPA route changes have been effectively invisible to browsertime, even though they're the dominant interaction model on modern frameworks (React, Next.js, Vue, Turbo).

Chrome's PerformanceObserver soft-navigation entry type is the only reliable signal that confirms all three criteria (user interaction + URL change + visible paint), so we use it to expose SPA navigations the same way we measure regular page loads — one HAR page renamed to the soft-nav URL, with the soft-nav metrics promoted into the standard locations so they flow through googleWebVitals, statistics, and logging without callers needing to know the difference.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Change-Id: I5137af662e5d82509e3d9e3e0380f84e8fd22420