### PR TITLE
Drain ffmpeg/ffprobe stderr after the process exits

### DIFF
--- a/visualmetrics/visualmetrics-portable.py
+++ b/visualmetrics/visualmetrics-portable.py
@@ -460,11 +460,14 @@ def extract_frames(video, directory, full_resolution, viewport):
             os.path.join(dir_escaped, "img-%d.png"),
         ]
         logging.debug(" ".join(command))
-        lines = []
 
-        proc = subprocess.Popen(command, stderr=subprocess.PIPE, encoding="UTF-8")
-        while proc.poll() is None:
-            lines.extend(iter(proc.stderr.readline, ""))
+        # Use subprocess.run so the full stderr stream is read after the
+        # process exits. The previous Popen + poll loop stopped reading once
+        # poll() returned, dropping any buffered tail; with `-v debug` ffmpeg
+        # also writes enough to fill the OS pipe buffer and could deadlock
+        # blocked on write while we waited on poll().
+        result = subprocess.run(command, stderr=subprocess.PIPE, encoding="UTF-8")
+        lines = result.stderr.splitlines()
 
         pattern = re.compile(r"keep pts:[0-9]+ pts_time:(?P<timecode>[0-9\.]+)")
         frame_count = 0
@@ -492,11 +495,8 @@ def find_recording_platform(video):
     command = ["ffprobe", video]
     logging.debug(command)
 
-    lines = []
-    proc = subprocess.Popen(command, stderr=subprocess.PIPE, encoding="UTF-8")
-
-    while proc.poll() is None:
-        lines.extend(iter(proc.stderr.readline, ""))
+    result = subprocess.run(command, stderr=subprocess.PIPE, encoding="UTF-8")
+    lines = result.stderr.splitlines()
 
     is_mobile = False
     matcher = re.compile(".*com\.android\.version.*")


### PR DESCRIPTION
The frame-extraction and recording-platform helpers spawned ffmpeg/ffprobe with stderr piped, then read stderr only while the process was still alive (while proc.poll() is None). That had two problems. Anything ffmpeg buffered between the last successful read and process exit was lost — and since extract_frames depends on parsing every keep pts: line out of ffmpeg's debug output, those lost lines silently mean lost frames in the filmstrip. Worse, ffmpeg's -v debug output is large enough to fill the OS pipe buffer; if it filled before we'd read enough, ffmpeg blocked on write and the script hung waiting on poll().

Replace the Popen+poll loop with subprocess.run, which reads stderr to EOF after the process exits, fixing both the data loss and the deadlock.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: I4a1bd0f97d99a811276cc9be128b94ad609e3b28