### PR TITLE
Warn when --viewPort is too narrow for desktop Chrome

### DIFF
--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -82,6 +82,28 @@ export function setupChromiumOptions(
   if (viewPort) {
     seleniumOptions.addArguments('--window-position=0,0');
     seleniumOptions.addArguments('--window-size=' + viewPort.replace('x', ','));
+
+    // Desktop Chrome enforces a minimum window width (~500px) regardless of
+    // --window-size, so a request like --viewPort 360x640 silently becomes
+    // 500x640. The video and filmstrips are still cropped to the requested
+    // size, which is why they look chopped. Mobile emulation is the supported
+    // way to test smaller viewports — it tells the renderer to lay out at
+    // the requested size while the OS window can stay desktop-sized.
+    // See https://github.com/sitespeedio/browsertime/issues/1222
+    const usingEmulation =
+      browserOptions.mobileEmulation &&
+      (browserOptions.mobileEmulation.deviceName ||
+        (browserOptions.mobileEmulation.width &&
+          browserOptions.mobileEmulation.height));
+    if (!usingEmulation) {
+      const [w] = viewPort.split('x').map(Number);
+      if (w && w < 500) {
+        log.warn(
+          'Requested viewport %s — desktop Chrome enforces a minimum window width of about 500px and will silently use a wider window. The video, filmstrip and screenshots will be cropped because they are sized to the requested viewport. To test smaller viewports, use Chrome mobile emulation: --chrome.mobileEmulation.deviceName "iPhone X" (or set --chrome.mobileEmulation.width and --chrome.mobileEmulation.height).',
+          viewPort
+        );
+      }
+    }
   }
 
   // If we are recording responses and we also block on domain


### PR DESCRIPTION
Desktop Chrome enforces a hard ~500px minimum window width. When a user asks for a narrower viewport (e.g. --viewPort 360x640), Chrome silently clamps the window to 500x640 instead. browsertime keeps recording the filmstrip and video at the requested 360x640, so the captures end up cropped — Chrome's title bar visible at the top, page content cut off on the right. There's no way to make Chrome obey the request from the browsertime side, but we can tell the user up front and point them at mobile emulation, which doesn't hit the limit because it tells the renderer to lay out at the requested size while the OS window stays desktop-sized.

The warning is gated on --viewPort being set with width < 500 and on mobile emulation not also being configured, so users using mobile emulation (which already does the right thing) don't see the warning.

Issue #1222.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: Idab4e048276791e291399dd3c5f0ff53daff9a0b