### PR TITLE
Write long-task ranges and user timings into the HAR

### DIFF
--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -131,24 +131,25 @@ function addExtrasToHAR(
       timings.pageTimings.domContentLoadedTime;
   }
 
-  // HAR 1.2 §5.3 — long-task ranges as a `_longTasks` extension on
-  // pageTimings. Each entry is `[startMs, endMs]`, the format consumed by
-  // WebPageTest-derived waterfall viewers.
-  if (
-    pageinfo &&
-    Array.isArray(pageinfo.longTask) &&
-    pageinfo.longTask.length > 0
-  ) {
+  // Long-task ranges as a `_longTasks` extension on pageTimings. Each
+  // entry is `[startMs, endMs]`, the format consumed by WebPageTest-derived
+  // waterfall viewers (e.g. waterfall-tools). Tri-state presence semantic:
+  // a non-empty array draws individual blocked spans; an empty array
+  // signals "instrumented, observed nothing"; field absent means "parser
+  // can't instrument". Browsertime always instruments via PerformanceObserver
+  // when the page-info script runs, so always emit the array (possibly
+  // empty) when `pageinfo.longTask` exists.
+  if (pageinfo && Array.isArray(pageinfo.longTask)) {
     harPageTimings._longTasks = pageinfo.longTask.map(t => [
       Number(t.startTime),
       Number(t.startTime + t.duration)
     ]);
   }
 
-  // HAR 1.2 §5.3 — user-timing marks + measures as a `_userTimings`
-  // extension on pageTimings. Object keyed by entry name so a downstream
-  // waterfall renderer can paint each as a vertical line. Measures
-  // override marks on name collision.
+  // User-timing marks + measures as a `_userTimings` extension on
+  // pageTimings. Object keyed by entry name so a downstream waterfall
+  // renderer can paint each as a vertical line. Measures override marks
+  // on name collision.
   const userTimings = timings && timings.userTimings;
   if (
     userTimings &&

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -61,7 +61,8 @@ function addExtrasToHAR(
   visualMetricsData,
   timings,
   cpu,
-  googleWebVitals
+  googleWebVitals,
+  pageinfo
 ) {
   const harPageTimings = harPage.pageTimings;
 
@@ -128,6 +129,40 @@ function addExtrasToHAR(
     harPageTimings._domInteractiveTime = timings.pageTimings.domInteractiveTime;
     harPageTimings._domContentLoadedTime =
       timings.pageTimings.domContentLoadedTime;
+  }
+
+  // HAR 1.2 §5.3 — long-task ranges as a `_longTasks` extension on
+  // pageTimings. Each entry is `[startMs, endMs]`, the format consumed by
+  // WebPageTest-derived waterfall viewers.
+  if (
+    pageinfo &&
+    Array.isArray(pageinfo.longTask) &&
+    pageinfo.longTask.length > 0
+  ) {
+    harPageTimings._longTasks = pageinfo.longTask.map(t => [
+      Number(t.startTime),
+      Number(t.startTime + t.duration)
+    ]);
+  }
+
+  // HAR 1.2 §5.3 — user-timing marks + measures as a `_userTimings`
+  // extension on pageTimings. Object keyed by entry name so a downstream
+  // waterfall renderer can paint each as a vertical line. Measures
+  // override marks on name collision.
+  const userTimings = timings && timings.userTimings;
+  if (
+    userTimings &&
+    ((userTimings.marks && userTimings.marks.length > 0) ||
+      (userTimings.measures && userTimings.measures.length > 0))
+  ) {
+    const map = {};
+    for (const mark of userTimings.marks || []) {
+      if (mark && mark.name) map[mark.name] = mark.startTime;
+    }
+    for (const measure of userTimings.measures || []) {
+      if (measure && measure.name) map[measure.name] = measure.startTime;
+    }
+    if (Object.keys(map).length > 0) harPageTimings._userTimings = map;
   }
 }
 
@@ -354,7 +389,8 @@ export function addExtraFieldsToHar(totalResults, har, options) {
             visualMetric,
             browserScript.timings,
             cpu,
-            googleWebVitals
+            googleWebVitals,
+            browserScript.pageinfo
           );
         }
         harPageNumber++;
@@ -392,7 +428,8 @@ export function addExtraFieldsToHar(totalResults, har, options) {
               visualMetric,
               browserScript.timings,
               cpu,
-              googleWebVitals
+              googleWebVitals,
+              browserScript.pageinfo
             );
           }
         }

--- a/test/unittests/harBuilderTest.js
+++ b/test/unittests/harBuilderTest.js
@@ -266,7 +266,10 @@ test('Add user-timing marks and measures to pageTimings', t => {
   });
 });
 
-test('Skip long-task and user-timing extensions when empty', t => {
+test('Emit empty `_longTasks` when instrumented but no tasks observed', t => {
+  // Tri-state presence contract used by downstream waterfall viewers:
+  // an empty array means "instrumented, observed none" — distinct from
+  // a missing field, which signals "this producer can't instrument".
   const totalResults = [
     {
       googleWebVitals: {},
@@ -283,6 +286,27 @@ test('Skip long-task and user-timing extensions when empty', t => {
   ];
   har.log.pages[0].pageTimings = {};
   addExtraFieldsToHar(totalResults, har, { iterations: 1 });
-  t.is(har.log.pages[0].pageTimings._longTasks, undefined);
+  t.deepEqual(har.log.pages[0].pageTimings._longTasks, []);
   t.is(har.log.pages[0].pageTimings._userTimings, undefined);
+});
+
+test('Omit `_longTasks` entirely when pageinfo has no longTask field', t => {
+  // Field absent = parser couldn't instrument — distinct from `[]`.
+  const totalResults = [
+    {
+      googleWebVitals: {},
+      visualMetrics: [],
+      info: { url: 'https://example.com' },
+      cpu: [{}],
+      browserScripts: [
+        {
+          timings: {},
+          pageinfo: {}
+        }
+      ]
+    }
+  ];
+  har.log.pages[0].pageTimings = {};
+  addExtraFieldsToHar(totalResults, har, { iterations: 1 });
+  t.is(har.log.pages[0].pageTimings._longTasks, undefined);
 });

--- a/test/unittests/harBuilderTest.js
+++ b/test/unittests/harBuilderTest.js
@@ -204,3 +204,85 @@ test('Gracefully handle missing cpu and visual metrics', t => {
     }
   });
 });
+
+test('Add long-task ranges to pageTimings', t => {
+  const totalResults = [
+    {
+      googleWebVitals: {},
+      visualMetrics: [],
+      info: { url: 'https://example.com' },
+      cpu: [{}],
+      browserScripts: [
+        {
+          timings: {},
+          pageinfo: {
+            longTask: [
+              { startTime: 100, duration: 80 },
+              { startTime: 250, duration: 60 }
+            ]
+          }
+        }
+      ]
+    }
+  ];
+  har.log.pages[0].pageTimings = {};
+  addExtraFieldsToHar(totalResults, har, { iterations: 1 });
+  t.deepEqual(har.log.pages[0].pageTimings._longTasks, [
+    [100, 180],
+    [250, 310]
+  ]);
+});
+
+test('Add user-timing marks and measures to pageTimings', t => {
+  const totalResults = [
+    {
+      googleWebVitals: {},
+      visualMetrics: [],
+      info: { url: 'https://example.com' },
+      cpu: [{}],
+      browserScripts: [
+        {
+          timings: {
+            userTimings: {
+              marks: [
+                { name: 'app-init', startTime: 50 },
+                { name: 'app-ready', startTime: 250 }
+              ],
+              measures: [
+                { name: 'init-to-ready', startTime: 50, duration: 200 }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ];
+  har.log.pages[0].pageTimings = {};
+  addExtraFieldsToHar(totalResults, har, { iterations: 1 });
+  t.deepEqual(har.log.pages[0].pageTimings._userTimings, {
+    'app-init': 50,
+    'app-ready': 250,
+    'init-to-ready': 50
+  });
+});
+
+test('Skip long-task and user-timing extensions when empty', t => {
+  const totalResults = [
+    {
+      googleWebVitals: {},
+      visualMetrics: [],
+      info: { url: 'https://example.com' },
+      cpu: [{}],
+      browserScripts: [
+        {
+          timings: { userTimings: { marks: [], measures: [] } },
+          pageinfo: { longTask: [] }
+        }
+      ]
+    }
+  ];
+  har.log.pages[0].pageTimings = {};
+  addExtraFieldsToHar(totalResults, har, { iterations: 1 });
+  t.is(har.log.pages[0].pageTimings._longTasks, undefined);
+  t.is(har.log.pages[0].pageTimings._userTimings, undefined);
+});


### PR DESCRIPTION
The HAR was emitting only summary CPU stats and dropping per-task ranges entirely; user-timing marks and measures captured by the browser script never reached the HAR at all. Downstream waterfall viewers therefore couldn't show what the browser was actually doing between requests.

Both extensions go under pages[].pageTimings per HAR 1.2 §5.3 — long tasks as _longTasks (array of [startMs, endMs] tuples, the format WebPageTest-derived viewers consume) and marks plus measures as _userTimings (object keyed by entry name → startTime). Both are skipped when empty so HARs without these signals stay compact.

Co-authored-by: Claude noreply@anthropic.com
Change-Id: I137e20f18759ca3869345f46fa5145baa9ff774b