### PR TITLE
Stop calling afterBrowserStopped twice per iteration

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -82,6 +82,7 @@ export class Iteration {
     const batteryTemperature = {};
 
     const engineDelegate = this.engineDelegate;
+    let afterBrowserStoppedRan = false;
 
     try {
       await this._startBrowser(browser, engineDelegate, options);
@@ -153,6 +154,7 @@ export class Iteration {
         index,
         commands
       );
+      afterBrowserStoppedRan = true;
 
       if (isAndroidConfigured(options)) {
         batteryTemperature.stop = await this.android.getTemperature();
@@ -206,10 +208,16 @@ export class Iteration {
       }
       // Ensure delegate cleanup runs even on failure paths so that
       // long-lived helpers (e.g. ios-capture, safaridriver) are released.
-      try {
-        await engineDelegate.afterBrowserStopped();
-      } catch {
-        // Idempotent — may have already run via _stopBrowser
+      // Skip when _stopBrowser already reached afterBrowserStopped on the
+      // happy path — running the cleanup twice surfaced as ENOENT noise on
+      // the Chrome user-data dir cleanup and could double-kill processes
+      // on Safari.
+      if (!afterBrowserStoppedRan) {
+        try {
+          await engineDelegate.afterBrowserStopped();
+        } catch {
+          // best-effort — helpers may already have been released
+        }
       }
     }
   }


### PR DESCRIPTION
in the iteration finally block so failure paths still release the long-lived helpers iOS Safari testing depends on (ios-capture, safaridriver). The intent was right, but on the happy path _stopBrowser had already invoked the cleanup, so it ran twice.

Most-visible symptom on Chrome: the second cleanUserDataDir attempt logged a spurious ENOENT because the first call had just removed the directory. Quieter risks elsewhere — Safari's cleanup terminates the simulator and kills processes, not all of which are guarded for repeat invocation.

Track whether _stopBrowser reached the cleanup and skip the safety-net when it did. The safety net still fires whenever _stopBrowser threw before getting that far, which is the case

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: I52a8ede7e5578c2c27a01a5c23ec649328c517be