### PR TITLE
Always emit a HAR page per measure.start for SPA scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Browsertime changelog (we do [semantic versioning](https://semver.org))
 
+## Unreleased
+
+### Fixed
+* SPA scripts no longer drop a HAR page when Chrome's soft-navigation `PerformanceObserver` entry doesn't fire. [#2438](https://github.com/sitespeedio/browsertime/pull/2438) gated HAR-page creation on Chrome detecting all three soft-navigation criteria (interaction + URL change + visible paint within a short window), but real SPAs like Grafana sometimes paint too late and Chrome never emits the entry — chrome-har then sees only `Network.*` events for that measurement and emits zero pages, breaking downstream per-iteration page indexing in sitespeed.io. When the measurement was started without a URL (`commands.measure.start(alias)` form) and no soft-nav entry was detected, fall back to a synthetic page anchored at the current `location.href` so each `measure.start` produces exactly one HAR page.
+
 ## 27.0.1 - 2026-05-02
 
 ### Fixed

--- a/lib/chrome/har.js
+++ b/lib/chrome/har.js
@@ -23,10 +23,17 @@ export async function getHar(
   const logs = await runner.getLogs(Type.PERFORMANCE);
   const messages = logs.map(entry => JSON.parse(entry.message).message);
 
-  // Inject a SoftNavigation.detected event so chrome-har renames the
-  // current HAR page with the soft navigation URL. The PerformanceObserver
-  // API is the only reliable source that confirms all three soft navigation
-  // criteria (user interaction + URL change + visible paint).
+  // Inject a SoftNavigation.detected event so chrome-har emits/renames a
+  // HAR page for this measurement. Chrome's PerformanceObserver
+  // soft-navigation entry is the trustworthy signal (user interaction +
+  // URL change + visible paint), but it doesn't always fire — Grafana and
+  // similar SPAs can defer their post-route paint past Chrome's window —
+  // so when this measurement was started without a URL (the
+  // `commands.measure.start(alias)` form, signalling "the next page is a
+  // soft-navigation I'm about to drive") we fall back to the current
+  // location.href. Without the fallback, chrome-har silently emits zero
+  // pages for that measurement and downstream consumers (sitespeed.io's
+  // per-iteration page indexing) drift out of alignment.
   try {
     const softNavEntries = await runner.runScript(
       `const supported = PerformanceObserver.supportedEntryTypes;
@@ -44,6 +51,17 @@ export async function getHar(
         method: 'SoftNavigation.detected',
         params: { url: entry.url, startTime: entry.startTime }
       });
+    } else if (!result.url) {
+      const fallbackUrl = await runner.runScript(
+        'return window.location.href;',
+        'GET_URL_FOR_HAR_FALLBACK'
+      );
+      if (fallbackUrl) {
+        messages.push({
+          method: 'SoftNavigation.detected',
+          params: { url: fallbackUrl, startTime: 0 }
+        });
+      }
     }
   } catch {
     // Soft navigations not supported, ignore


### PR DESCRIPTION
PerformanceObserver firing. Real SPAs (Grafana, the dashboard tests that flagged this) sometimes paint past Chrome's heuristic window and the entry never arrives — chrome-har then emits zero pages for that measurement, and sitespeed.io's per-iteration page indexing drifts out of alignment, surfacing as "PageIndex out of range" / "Could not find the right index" / failed coach data.

When commands.measure.start(alias) was used (no URL, signalling "the next page is a soft-navigation I'll drive") and Chrome didn't detect a soft-nav, fall back to a synthetic SoftNavigation.detected event using the current location.href. The synthetic page won't carry soft-nav-derived FCP/LCP/INP, but it will carry the URL, network entries, and browser-script timings — enough for downstream consumers to align indexes and run their plugins. measure.start(URL) and detected-soft-nav cases are unchanged.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: I1e7c81bacb299d7d4307228900577230c1dee478