### PR TITLE
Skip non-interaction event entries when computing INP

### DIFF
--- a/browserscripts/pageinfo/interactionToNextPaintInfo.js
+++ b/browserscripts/pageinfo/interactionToNextPaintInfo.js
@@ -106,6 +106,13 @@
   const longestInteractionList = [];
   const longestInteractionMap = {};
   for (let entry of entries) {
+    // web-vitals only counts entries the browser tagged as part of a
+    // discrete interaction; bare events like a `pointerover` fired by
+    // a stationary OS cursor get interactionId === 0 and must be
+    // skipped. Without this guard automated runs report a synthetic
+    // INP whenever the cursor happens to be over content as it paints.
+    // See https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/interactions.ts
+    if (!entry.interactionId) continue;
     var minLongestInteraction =
       longestInteractionList[longestInteractionList.length - 1];
     var existingInteraction = longestInteractionMap[entry.interactionId];

--- a/browserscripts/timings/interactionToNextPaint.js
+++ b/browserscripts/timings/interactionToNextPaint.js
@@ -9,6 +9,13 @@
   const longestInteractionList = [];
   const longestInteractionMap = {};
   for (let entry of entries) {
+    // web-vitals only counts entries the browser tagged as part of a
+    // discrete interaction; bare events like a `pointerover` fired by
+    // a stationary OS cursor get interactionId === 0 and must be
+    // skipped. Without this guard automated runs report a synthetic
+    // INP whenever the cursor happens to be over content as it paints.
+    // See https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/interactions.ts
+    if (!entry.interactionId) continue;
     var minLongestInteraction =
       longestInteractionList[longestInteractionList.length - 1];
     var existingInteraction = longestInteractionMap[entry.interactionId];


### PR DESCRIPTION
The two INP scripts (interactionToNextPaint.js and interactionToNextPaintInfo.js) walk the buffered `event` and `first-input` PerformanceObserver records, but unlike web-vitals' upstream `lib/interactions.ts` they don't filter to entries with `interactionId > 0`. The browser only assigns a non-zero interactionId to events that are part of a discrete user interaction (a click's pointerdown/up, keydown/up, etc.); a bare `pointerover` from a stationary OS cursor that happens to be over content as it paints gets `interactionId === 0`.

Without that guard automated runs regularly report INP from the cursor passing under freshly-rendered content during navigation. The hover entries land under `longestInteractionMap[0]`, are treated as a single "interaction" with ever-growing latency, and when no real user interaction happens during the iteration that synthetic value is what gets returned. The DevTools-trace variant of this code (`lib/chrome/webdriver/devtools/inp.js`) already has the `entry.interactionId > 0` guard, so the rest of the codebase already treats it as the right shape.

Add `if (!entry.interactionId) continue;` at the top of the processing loop in both scripts to match web-vitals.


Change-Id: Ia574f1d734f9b7d5b5b32174c580c9effd43f629