### PR TITLE
Only prime QuickTime once per Safari iOS session

### DIFF
--- a/lib/safari/webdriver/safari.js
+++ b/lib/safari/webdriver/safari.js
@@ -33,13 +33,23 @@ export class Safari {
         // open a new movie recording. cmiod only enumerates iOS devices
         // for CMIO when something triggers it (historically QuickTime),
         // so we drive QuickTime headlessly here to remove the manual step.
-        // Once ios-capture has grabbed the AVCaptureSession the device
-        // stays in mirror mode, so we quit QuickTime before safaridriver
-        // starts — leaving QT holding the device blocks safaridriver from
-        // opening a WebDriver session.
-        await this._primeIOSScreenCapture();
+        // Once cmiod has enumerated the device it stays enumerated for
+        // the rest of the session, so we only need to prime QT on the
+        // first iteration — the flag is stored on `options` (which is
+        // shared across iterations, the same way `_iosCaptureProcess` is)
+        // so multi-iteration / multi-page runs don't re-open QuickTime
+        // each time.
+        const firstIteration = !this.options._iosScreenCapturePrimed;
+        if (firstIteration) {
+          await this._primeIOSScreenCapture();
+          this.options._iosScreenCapturePrimed = true;
+        }
         await this._startIOSCaptureServer();
-        await this._unprimeIOSScreenCapture();
+        if (firstIteration) {
+          // Quit QT before safaridriver starts — leaving QT holding the
+          // device blocks safaridriver from opening a WebDriver session.
+          await this._unprimeIOSScreenCapture();
+        }
       }
 
       this.driverProcess = command(


### PR DESCRIPTION
The QuickTime "wake the iPhone for cmiod" step ran on every iteration and every page, which was noisy ("Opening QuickTime Player to wake the iPhone…" once per iteration) and did unnecessary work — once cmiod has enumerated the device it stays enumerated for the rest of the session, so iterations 2+ never needed it.

Gates the prime/unprime pair behind a flag stored on the shared options object (same approach as the existing _iosCaptureProcess handle), so multi-iteration and multi-page Safari iOS runs only open QuickTime once.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: I0734761484f157bf91b2ac94ad5143c6019ba44b