### PR TITLE
Add _documentURL to the first entry of each HAR page

### DIFF
--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -359,6 +359,17 @@ export function getEmptyHAR(url, browser) {
     }
   };
 }
+// Tag the first entry of a page with the document URL it navigated to.
+// Downstream consumers (waterfall-tools) read `entries[0]._documentURL`
+// to flag cross-origin requests in the rendered waterfall — the first
+// entry's own URL would also work for the no-redirect case, but breaks
+// the moment the document follows a redirect chain to a different host.
+function addDocumentURLToFirstEntry(harPage, entries, url) {
+  if (!harPage || !entries || !url) return;
+  const first = entries.find(entry => entry.pageref === harPage.id);
+  if (first) first._documentURL = url;
+}
+
 export function addExtraFieldsToHar(totalResults, har, options) {
   if (har) {
     let harPageNumber = 0;
@@ -382,6 +393,12 @@ export function addExtraFieldsToHar(totalResults, har, options) {
           totalResults[pageNumber].info.url,
           browserScript,
           options
+        );
+
+        addDocumentURLToFirstEntry(
+          harPage,
+          har.log.entries,
+          totalResults[pageNumber].info.url
         );
 
         if (browserScript) {
@@ -416,6 +433,11 @@ export function addExtraFieldsToHar(totalResults, har, options) {
               totalResults[page].info.url,
               browserScript,
               options
+            );
+            addDocumentURLToFirstEntry(
+              harPage,
+              har.log.entries,
+              totalResults[page].info.url
             );
           } else {
             log.error(

--- a/test/unittests/harBuilderTest.js
+++ b/test/unittests/harBuilderTest.js
@@ -310,3 +310,13 @@ test('Omit `_longTasks` entirely when pageinfo has no longTask field', t => {
   addExtraFieldsToHar(totalResults, har, { iterations: 1 });
   t.is(har.log.pages[0].pageTimings._longTasks, undefined);
 });
+
+test('Tag the first entry of each page with `_documentURL`', t => {
+  // Cross-origin tinting in waterfall-tools reads `entries[0]._documentURL`
+  // to decide which request labels are third-party — without this, the
+  // viewer falls back to a no-op (every request looks same-origin).
+  const totalResults = totalResultsBase;
+  har.log.pages[0].pageTimings = {};
+  addExtraFieldsToHar(totalResults, har, { iterations: 1 });
+  t.is(har.log.entries[0]._documentURL, 'https://example.com');
+});


### PR DESCRIPTION
waterfall-tools and other downstream HAR consumers tint cross-origin request labels by comparing each entry's URL origin against the document URL of the page. The signal they read is entries[0]._documentURL, which the renderer needs in order to know what counts as same-origin in the first place. Until now Browsertime never wrote that field, so every consumer fell back to "every request looks same-origin" and the third-party highlight in the waterfall view stayed dark. This change tags the first entry of each page (the navigation request, post-redirects, identified by pageref) with the URL the iteration was asked to load, which is what consumers expect.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: I464b018cf5cf5be2e2e89c43437b3e32a8ebeb0c