### PR TITLE
Inline the trace parser, modernise the event classifier, add three new analyses

### DIFF
--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -1,5 +1,10 @@
 import { getLogger } from '@sitespeed.io/log';
-import { computeMainThreadTasks } from '@sitespeed.io/tracium';
+import {
+  computeMainThreadTasks,
+  computeScriptCosts,
+  computeForcedReflows,
+  computeNonCompositedAnimations
+} from './trace/index.js';
 const log = getLogger('browsertime.chrome.cpu');
 
 function round(number_, decimals = 3) {
@@ -77,8 +82,39 @@ export async function parseCPUTrace(tracelog, url) {
 
     cleanedUrls.sort(slowestFirst);
 
+    // New analyses derived from the same trace. Each is independent
+    // of the others and won't produce noise on pages where the
+    // signal isn't present (empty arrays). Wrapped in a try so a
+    // bug in one analysis can't poison the existing categories /
+    // events / urls payload.
+    let scriptCosts = [];
+    let forcedReflows = [];
+    let nonCompositedAnimations = [];
+    try {
+      scriptCosts = computeScriptCosts(tracelog);
+    } catch (error) {
+      log.debug('computeScriptCosts failed: %s', error.message);
+    }
+    try {
+      forcedReflows = computeForcedReflows(tracelog);
+    } catch (error) {
+      log.debug('computeForcedReflows failed: %s', error.message);
+    }
+    try {
+      nonCompositedAnimations = computeNonCompositedAnimations(tracelog);
+    } catch (error) {
+      log.debug('computeNonCompositedAnimations failed: %s', error.message);
+    }
+
     log.debug('Chrome trace log finished parsed and sorted.');
-    return { categories, events, urls: cleanedUrls };
+    return {
+      categories,
+      events,
+      urls: cleanedUrls,
+      scriptCosts,
+      forcedReflows,
+      nonCompositedAnimations
+    };
   } catch (error) {
     log.error(
       'Could not parse the trace log from Chrome for url %s',

--- a/lib/chrome/trace/forced-reflows.js
+++ b/lib/chrome/trace/forced-reflows.js
@@ -1,0 +1,78 @@
+/**
+ * Forced reflow / synchronous layout detection.
+ *
+ * A forced reflow happens when JavaScript reads a layout-triggering
+ * property (offsetTop, getBoundingClientRect, …) inside an event /
+ * timer / animation-frame handler. The browser must synchronously
+ * recompute layout to answer, blocking the main thread until it's
+ * done. Classic perf-bug pattern; expensive on long DOM trees.
+ *
+ * In the trace this shows up as a Layout / UpdateLayoutTree event
+ * nested inside a JS-driven task (EventDispatch, FunctionCall,
+ * TimerFire, FireAnimationFrame, …). The unforced version of the
+ * same event happens at the top level between tasks. So the rule is:
+ * if the Layout's chain of ancestors includes any JS-driven task,
+ * call it forced.
+ *
+ * Returns: [{ eventName, duration, startTime, triggeredBy,
+ *             triggeredByUrl }, …]
+ *   eventName       — Layout or UpdateLayoutTree
+ *   duration / startTime — task timing in ms (already navstart-
+ *                          relative from main-thread-tasks.js)
+ *   triggeredBy     — the closest JS-driven ancestor's event name
+ *                     (e.g. EventDispatch, FunctionCall)
+ *   triggeredByUrl  — most-specific attributable URL of that
+ *                     ancestor; the script the user can open and fix
+ */
+
+import { compute } from './main-thread-tasks.js';
+
+const JS_DRIVEN = new Set([
+  'EventDispatch',
+  'EvaluateScript',
+  'v8.evaluateModule',
+  'FunctionCall',
+  'TimerFire',
+  'FireIdleCallback',
+  'FireAnimationFrame',
+  'RunMicrotasks',
+  'V8.Execute'
+]);
+
+const LAYOUT_EVENTS = new Set(['Layout', 'UpdateLayoutTree']);
+
+function urlFor(task) {
+  if (!task || !task.attributableURLs) return '';
+  return task.attributableURLs.at(-1) || '';
+}
+
+export function computeForcedReflows(trace) {
+  const allTasks = compute(trace);
+  const reflows = [];
+
+  // Walk every task — `compute()` returns the flat list with
+  // `.parent` linkage. For each Layout / UpdateLayoutTree, walk up
+  // the parent chain to find the nearest JS-driven ancestor. If we
+  // find one, the layout was forced.
+  for (const task of allTasks) {
+    if (!LAYOUT_EVENTS.has(task.event.name)) continue;
+
+    let ancestor = task.parent;
+    while (ancestor) {
+      if (JS_DRIVEN.has(ancestor.event.name)) break;
+      ancestor = ancestor.parent;
+    }
+    if (!ancestor) continue;
+
+    reflows.push({
+      eventName: task.event.name,
+      duration: Math.round(task.duration * 10) / 10,
+      startTime: Math.round(task.startTime * 10) / 10,
+      triggeredBy: ancestor.event.name,
+      triggeredByUrl: urlFor(ancestor)
+    });
+  }
+
+  reflows.sort((a, b) => b.duration - a.duration);
+  return reflows;
+}

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -1,0 +1,41 @@
+/**
+ * Chrome trace.json analyses, used by parseCpuTrace.js to produce
+ * the cpu/categories/events/urls payload that flows into the result
+ * JSON. Replaces the legacy `@sitespeed.io/tracium` dependency
+ * (extracted from Lighthouse 2017, unmaintained) with an in-tree
+ * ESM port of the same algorithm. Kept byte-equivalent for
+ * `computeMainThreadTasks` so existing consumers see the same task
+ * tree; new analyses (script costs, layout shift attribution,
+ * forced layouts, frame stability) will land here as additional
+ * exports rather than a separate package.
+ */
+
+import { compute } from './main-thread-tasks.js';
+
+export { computeScriptCosts } from './script-costs.js';
+export { computeForcedReflows } from './forced-reflows.js';
+export { computeNonCompositedAnimations } from './non-composited-animations.js';
+
+/**
+ * Compute the hierarchical main-thread task tree for a trace.
+ * Each task has its kind classified into one of:
+ *   parseHTML | styleLayout | paintCompositeRender |
+ *   scriptParseCompile | scriptEvaluation | garbageCollection | other
+ *
+ * @param {Object} trace  Parsed Chrome trace.json (with .traceEvents).
+ * @param {Object} [options]
+ * @param {boolean} [options.flatten=false]  When true, return all
+ *   tasks flat (parents and children); when false, only top-level.
+ * @returns {Array<Object>}
+ */
+export function computeMainThreadTasks(trace, options = {}) {
+  const { flatten = false } = options;
+  const allTasks = compute(trace);
+  const result = [];
+  for (const task of allTasks) {
+    task.kind = task.group.id;
+    delete task.group;
+    if (!task.parent || flatten) result.push(task);
+  }
+  return result;
+}

--- a/lib/chrome/trace/main-thread-tasks.js
+++ b/lib/chrome/trace/main-thread-tasks.js
@@ -1,0 +1,196 @@
+/**
+ * Trace events → hierarchical task list. Ported verbatim from
+ * @sitespeed.io/tracium 0.3.3 (Lighthouse 2017 lineage). Each
+ * resulting `TaskNode` carries:
+ *   { event, startTime, endTime, duration, selfTime,
+ *     attributableURLs, parent, children, group }
+ *
+ * Times are returned in ms, rebased to the first task's startTime.
+ *
+ * Reference (Lighthouse upstream this file came from):
+ *   https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/lib/tracehouse/main-thread-tasks.js
+ *
+ * Trace event format:
+ *   https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+ */
+
+import { taskGroups, groupForEvent } from './task-groups.js';
+import { computeTraceOfTab } from './trace-of-tab.js';
+
+function createNewTaskNode(event, parent) {
+  const newTask = {
+    event,
+    startTime: event.ts,
+    endTime: event.ph === 'X' ? event.ts + Number(event.dur || 0) : Number.NaN,
+    parent,
+    children: [],
+    // Filled in later
+    attributableURLs: [],
+    group: taskGroups.other,
+    duration: Number.NaN,
+    selfTime: Number.NaN
+  };
+  if (parent) {
+    parent.children.push(newTask);
+  }
+  return newTask;
+}
+
+function createTasksFromEvents(mainThreadEvents, priorTaskData, traceEndTs) {
+  const tasks = [];
+  let currentTask;
+
+  for (const event of mainThreadEvents) {
+    // TimerInstall is an instant event (ph === 'I') — process it
+    // first so timer→task attribution works for subsequent TimerFire.
+    if (event.name === 'TimerInstall' && currentTask) {
+      const timerId = event.args.data.timerId;
+      priorTaskData.timers.set(timerId, currentTask);
+    }
+
+    // Only X (Complete), B (Begin), E (End) carry the data we need.
+    if (event.ph !== 'X' && event.ph !== 'B' && event.ph !== 'E') continue;
+
+    // Walk up the stack until we're inside a task that hasn't ended.
+    while (
+      currentTask &&
+      Number.isFinite(currentTask.endTime) &&
+      currentTask.endTime <= event.ts
+    ) {
+      currentTask = currentTask.parent;
+    }
+
+    if (!currentTask) {
+      // Can't start a task with an end event — real-world traces
+      // sometimes have a stray E without a matching B. Skip rather
+      // than throw so a partly-malformed trace still produces output.
+      if (event.ph === 'E') continue;
+      currentTask = createNewTaskNode(event);
+      tasks.push(currentTask);
+      continue;
+    }
+
+    if (event.ph === 'X' || event.ph === 'B') {
+      // Nested event — child of currentTask.
+      const newTask = createNewTaskNode(event, currentTask);
+      tasks.push(newTask);
+      currentTask = newTask;
+    } else {
+      // event.ph === 'E' — close the current task. If currentTask
+      // wasn't a B (e.g. the previous event was an X), the trace is
+      // malformed; tolerate by skipping rather than throwing.
+      if (currentTask.event.ph !== 'B') continue;
+      currentTask.endTime = event.ts;
+      currentTask = currentTask.parent;
+    }
+  }
+
+  // Any tasks still open at the end of the trace end at traceEndTs.
+  while (currentTask && !Number.isFinite(currentTask.endTime)) {
+    currentTask.endTime = traceEndTs;
+    currentTask = currentTask.parent;
+  }
+
+  return tasks;
+}
+
+function computeRecursiveSelfTime(task, parent) {
+  if (parent && task.endTime > parent.endTime) {
+    // Real-world traces occasionally produce children that report an
+    // endTime past the parent's. Tolerate by treating the duration
+    // as zero rather than throwing — the rest of the analysis stays
+    // useful.
+    return 0;
+  }
+  const childTime = task.children
+    .map(child => computeRecursiveSelfTime(child, task))
+    .reduce((sum, child) => sum + child, 0);
+  task.duration = task.endTime - task.startTime;
+  task.selfTime = task.duration - childTime;
+  return task.duration;
+}
+
+function computeRecursiveAttributableURLs(task, parentURLs, priorTaskData) {
+  const argsData = task.event.args.data || {};
+  const stackFrameURLs = (argsData.stackTrace || []).map(entry => entry.url);
+
+  let taskURLs = [];
+  switch (task.event.name) {
+    case 'v8.compile':
+    case 'EvaluateScript':
+    case 'FunctionCall': {
+      taskURLs = [argsData.url, ...stackFrameURLs];
+      break;
+    }
+    case 'v8.compileModule': {
+      taskURLs = [task.event.args.fileName, ...stackFrameURLs];
+      break;
+    }
+    case 'TimerFire': {
+      const timerId = task.event.args.data.timerId;
+      const timerInstallerTaskNode = priorTaskData.timers.get(timerId);
+      if (!timerInstallerTaskNode) break;
+      taskURLs = [
+        ...timerInstallerTaskNode.attributableURLs,
+        ...stackFrameURLs
+      ];
+      break;
+    }
+    default: {
+      taskURLs = stackFrameURLs;
+      break;
+    }
+  }
+
+  const attributableURLs = [...parentURLs];
+  for (const url of taskURLs) {
+    if (!url) continue; // empty URL
+    if (attributableURLs.at(-1) === url) continue; // dedupe consecutive
+    attributableURLs.push(url);
+  }
+  task.attributableURLs = attributableURLs;
+  for (const child of task.children)
+    computeRecursiveAttributableURLs(child, attributableURLs, priorTaskData);
+}
+
+function computeRecursiveTaskGroup(task, parentGroup) {
+  const group = groupForEvent(task.event.name);
+  task.group = group || parentGroup || taskGroups.other;
+  for (const child of task.children)
+    computeRecursiveTaskGroup(child, task.group);
+}
+
+export function getMainThreadTasks(traceEvents, traceEndTs) {
+  const timers = new Map();
+  const priorTaskData = { timers };
+  const tasks = createTasksFromEvents(traceEvents, priorTaskData, traceEndTs);
+
+  for (const task of tasks) {
+    if (task.parent) continue;
+    computeRecursiveSelfTime(task);
+    computeRecursiveAttributableURLs(task, [], priorTaskData);
+    computeRecursiveTaskGroup(task);
+  }
+
+  // Rebase all the times to be relative to start of trace in ms.
+  const firstTs = (tasks[0] || { startTime: 0 }).startTime;
+  for (const task of tasks) {
+    task.startTime = (task.startTime - firstTs) / 1000;
+    task.endTime = (task.endTime - firstTs) / 1000;
+    task.duration /= 1000;
+    task.selfTime /= 1000;
+    if (!Number.isFinite(task.selfTime)) {
+      // Real-world tolerance — see computeRecursiveSelfTime. If a
+      // task slipped through with NaN selfTime, treat it as zero so
+      // downstream summing doesn't poison every category.
+      task.selfTime = 0;
+    }
+  }
+
+  return tasks;
+}
+
+export function compute(trace) {
+  const { mainThreadEvents, timestamps } = computeTraceOfTab(trace);
+  return getMainThreadTasks(mainThreadEvents, timestamps.traceEnd);
+}

--- a/lib/chrome/trace/non-composited-animations.js
+++ b/lib/chrome/trace/non-composited-animations.js
@@ -1,0 +1,55 @@
+/**
+ * Non-composited animations — animations that triggered Layout or
+ * Paint instead of running entirely on the compositor thread.
+ *
+ * Compositor-only animations (transform, opacity) hand off to the
+ * GPU and don't block the main thread. Anything that touches
+ * `top` / `left` / `width` / `box-shadow` / non-transformable
+ * filters / etc. forces a per-frame layout or paint, which means
+ * jank on busy main threads.
+ *
+ * Chrome marks these in the trace via `Animation` events whose
+ * `args.data.compositeFailed` bitmask is non-zero, plus a list of
+ * `unsupportedProperties` strings. We surface the raw values; the
+ * consumer can map the bitmask to human reasons (see Lighthouse's
+ * non-composited-animations audit for the canonical mapping).
+ *
+ * Returns: [{ name, id, compositeFailed, unsupportedProperties,
+ *             startTime }, …]
+ *   name            — args.data.nodeName when present (rare)
+ *   id              — args.data.id (compositor-internal)
+ *   compositeFailed — bitmask of failure reasons
+ *   unsupportedProperties — array of property names that blocked
+ *                           composite (e.g. ['top','box-shadow'])
+ *   startTime       — event ts in microseconds (raw trace timestamp)
+ */
+
+export function computeNonCompositedAnimations(trace) {
+  const seen = new Set();
+  const animations = [];
+
+  for (const event of trace.traceEvents) {
+    if (event.name !== 'Animation') continue;
+    // Animation events fire at multiple phases; the compositeFailed
+    // bitmask is set once per animation lifecycle. Dedupe by id so we
+    // don't list the same failed animation N times.
+    const data = (event.args && event.args.data) || {};
+    const failed = data.compositeFailed || 0;
+    const unsupported = data.unsupportedProperties || [];
+    if (!failed && unsupported.length === 0) continue;
+
+    const id = data.id || `${event.ts}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    animations.push({
+      name: data.nodeName || '',
+      id: data.id || '',
+      compositeFailed: failed,
+      unsupportedProperties: unsupported,
+      startTime: event.ts
+    });
+  }
+
+  return animations;
+}

--- a/lib/chrome/trace/script-costs.js
+++ b/lib/chrome/trace/script-costs.js
@@ -1,0 +1,88 @@
+/**
+ * Per-script JS cost breakdown — the same data Lighthouse's
+ * `bootup-time` audit computes, surfaced as a structured array so
+ * downstream consumers can render a "top scripts by main-thread
+ * time" table without re-deriving it from raw tasks.
+ *
+ * For each attributable URL we sum the self-time of every main-thread
+ * task that's classified as parse / compile / execute, and return:
+ *   [{ url, parse, compile, execute, total }, …]
+ *
+ * Reference: Lighthouse `lighthouse-core/audits/bootup-time.js`.
+ *
+ * Times are in ms, rounded to one decimal. Sorted by `total` desc so
+ * the worst offenders are at index 0.
+ */
+
+import { compute } from './main-thread-tasks.js';
+
+// Trace event name → cost bucket. Built once at module-load time so
+// the inner hot loop is a single Map.get per task.
+const PARSE_EVENTS = new Set(['v8.parseOnBackground']);
+const COMPILE_EVENTS = new Set(['v8.compile', 'v8.compileModule']);
+const EXECUTE_EVENTS = new Set([
+  'EvaluateScript',
+  'v8.evaluateModule',
+  'FunctionCall',
+  'TimerFire',
+  'FireIdleCallback',
+  'FireAnimationFrame',
+  'RunMicrotasks',
+  'V8.Execute',
+  'EventDispatch'
+]);
+
+function bucketFor(eventName) {
+  if (PARSE_EVENTS.has(eventName)) return 'parse';
+  if (COMPILE_EVENTS.has(eventName)) return 'compile';
+  if (EXECUTE_EVENTS.has(eventName)) return 'execute';
+  return;
+}
+
+function round(ms) {
+  return Math.round(ms * 10) / 10;
+}
+
+/**
+ * @param {Object} trace  Parsed Chrome trace.json (with .traceEvents).
+ * @returns {Array<{url:string, parse:number, compile:number,
+ *                  execute:number, total:number}>}
+ *   Per-URL JS cost in ms, sorted by total desc.
+ */
+export function computeScriptCosts(trace) {
+  const allTasks = compute(trace);
+  const byUrl = new Map();
+
+  for (const task of allTasks) {
+    const bucket = bucketFor(task.event.name);
+    if (!bucket) continue;
+
+    // Lighthouse credits the most-specific URL in the attributable
+    // chain (the innermost stack frame / target script). For an event
+    // like EvaluateScript this is the URL of the script being
+    // evaluated; for FunctionCall it's the script the function lives
+    // in. attributableURLs is built bottom-up so the last element is
+    // the right one.
+    const url = task.attributableURLs.at(-1);
+    if (!url) continue;
+
+    let entry = byUrl.get(url);
+    if (!entry) {
+      entry = { url, parse: 0, compile: 0, execute: 0, total: 0 };
+      byUrl.set(url, entry);
+    }
+    entry[bucket] += task.selfTime;
+    entry.total += task.selfTime;
+  }
+
+  const result = [];
+  for (const entry of byUrl.values()) {
+    entry.parse = round(entry.parse);
+    entry.compile = round(entry.compile);
+    entry.execute = round(entry.execute);
+    entry.total = round(entry.total);
+    result.push(entry);
+  }
+  result.sort((a, b) => b.total - a.total);
+  return result;
+}

--- a/lib/chrome/trace/task-groups.js
+++ b/lib/chrome/trace/task-groups.js
@@ -1,0 +1,196 @@
+/**
+ * Trace-event → group classifier.
+ *
+ * The original list (from @sitespeed.io/tracium 0.3.3, extracted from
+ * Lighthouse circa 2017) is too narrow for modern Chrome traces — it
+ * only knew about ~30 event names, so half the trace fell through to
+ * "other" on a busy 2026-era page. This expanded list adds the
+ * events we actually see today, drawing from:
+ *
+ *   - Modern Lighthouse `core/lib/tracehouse/task-groups.js`
+ *   - WebPageTest's `MAIN_THREAD_CATEGORY_MAP` in waterfall-tools
+ *     (`src/core/mainthread-categories.js`, mirroring the reference
+ *     PHP implementation at Sample/Implementations/webpagetest/
+ *     www/waterfall.inc#L437-L491)
+ *   - Direct sampling of trace.json from real cnet / theverge runs
+ *
+ * The seven-bucket structure is unchanged so the existing UI
+ * categories keep working. Append-only when adding events for
+ * future Chrome versions — don't move events between groups
+ * without checking how it affects the rollups in
+ * `parseCpuTrace.js`.
+ */
+
+export const taskGroups = {
+  parseHTML: {
+    id: 'parseHTML',
+    label: 'Parse HTML & CSS',
+    traceEventNames: [
+      'ParseHTML',
+      'ParseAuthorStyleSheet',
+      // Document parsing / navigation pipeline — these fire during
+      // the initial HTML/CSS parse phase, even though they're not
+      // strictly "parse" events. Counting them as parse-time gives
+      // a more honest "time spent loading the document" signal.
+      'CommitLoad',
+      'DocumentLoader::CommitNavigation',
+      'DecodedDataDocumentParser::AppendBytes',
+      // Resource lifecycle events emitted on the main thread for
+      // the document and its sub-resources. waterfall-tools groups
+      // them with parsing for the same reason — they're part of the
+      // page-load critical path, not arbitrary "other" work.
+      'ResourceSendRequest',
+      'ResourceReceiveResponse',
+      'ResourceReceivedData',
+      'ResourceReceivedResponse',
+      'ResourceFinish'
+    ]
+  },
+  styleLayout: {
+    id: 'styleLayout',
+    label: 'Style & Layout',
+    traceEventNames: [
+      'ScheduleStyleRecalculation',
+      'UpdateLayoutTree', // previously RecalculateStyles
+      'RecalculateStyles', // older Chrome name
+      'InvalidateLayout',
+      'Layout',
+      // IntersectionObserver callbacks query layout to compute
+      // which observed elements have crossed their thresholds; on
+      // ad-heavy pages this can be hundreds of ms.
+      'IntersectionObserverController::computeIntersections'
+    ]
+  },
+  paintCompositeRender: {
+    id: 'paintCompositeRender',
+    label: 'Rendering',
+    traceEventNames: [
+      'Animation',
+      'HitTest',
+      'PaintSetup',
+      'Paint',
+      'PaintImage',
+      'RasterTask', // Previously Rasterize
+      'Rasterize',
+      'ScrollLayer',
+      'UpdateLayer',
+      'UpdateLayerTree',
+      'CompositeLayers',
+      // Modern compositor pipeline phases (Chrome ~M100+) that
+      // didn't exist when the original list was written.
+      'PrePaint',
+      'Commit',
+      'Layerize',
+      'BeginFrame',
+      'BeginMainThreadFrame',
+      'DrawFrame',
+      // Image decode work happens on the main thread when the
+      // off-thread decoder can't keep up.
+      'DecodeImage',
+      'Decode Image',
+      'ImageDecodeTask',
+      'GPUTask',
+      'SetLayerTreeId'
+    ]
+  },
+  scriptParseCompile: {
+    id: 'scriptParseCompile',
+    label: 'Script Parsing & Compilation',
+    traceEventNames: [
+      'v8.compile',
+      'v8.compileModule',
+      'v8.parseOnBackground',
+      'v8.parseFunction',
+      // Context creation + V8 snapshot deserialization — these are
+      // the V8 startup costs that fire before any user JS runs.
+      'V8.DeserializeContext',
+      'LocalWindowProxy::CreateContext'
+    ]
+  },
+  scriptEvaluation: {
+    id: 'scriptEvaluation',
+    label: 'Script Evaluation',
+    traceEventNames: [
+      'EventDispatch',
+      'EvaluateScript',
+      'v8.evaluateModule',
+      'FunctionCall',
+      'TimerFire',
+      'TimerInstall',
+      'TimerRemove',
+      'FireIdleCallback',
+      'FireAnimationFrame',
+      'RunMicrotasks',
+      'V8.Execute',
+      // Modern V8 entry points (Chrome ~M115+) — `v8.run` and
+      // `v8.callFunction` are the wrappers Chrome added when V8
+      // reorganized its tracing categories.
+      'v8.run',
+      'v8.callFunction',
+      'v8.callModuleMethod',
+      'XHRLoad',
+      'XHRReadyStateChange'
+    ]
+  },
+  garbageCollection: {
+    id: 'garbageCollection',
+    label: 'Garbage Collection',
+    traceEventNames: [
+      'MinorGC', // Previously GCEvent
+      'MajorGC',
+      'BlinkGC.AtomicPhase',
+      'BlinkGCMarking',
+      'ThreadState::performIdleLazySweep',
+      'ThreadState::completeSweep',
+      'Heap::collectGarbage',
+      // V8 GC events — there are many specific phase names but they
+      // all share the `V8.GC` prefix (V8.GCScavenger, V8.GCFinalizeMC,
+      // V8.GC_SCAVENGER_SCAVENGE_PARALLEL_PHASE, etc.). Specific
+      // names are listed for fast exact-match; the prefix fallback
+      // in groupForEvent() catches the rest.
+      'V8.GCScavenger',
+      'V8.GCFinalizeMC',
+      'V8.GCMarkCompact',
+      'V8.GCIncrementalMarking',
+      'V8.GCCompactor',
+      'V8.GC_SCAVENGER_SCAVENGE_PARALLEL_PHASE'
+    ]
+  },
+  other: {
+    id: 'other',
+    label: 'Other',
+    traceEventNames: [
+      'MessageLoop::RunTask',
+      'TaskQueueManager::ProcessTaskFromWorkQueue',
+      'ThreadControllerImpl::DoWork',
+      // The top-level scheduler wrapper. Its self-time is the
+      // residual after children run — the "Chrome scheduling
+      // overhead" portion. Was missing from the old list and
+      // dominated the "other" bucket on busy pages.
+      'RunTask',
+      'ThreadControllerImpl::RunTask'
+    ]
+  }
+};
+
+export const taskNameToGroup = {};
+for (const group of Object.values(taskGroups)) {
+  for (const traceEventName of group.traceEventNames) {
+    taskNameToGroup[traceEventName] = group;
+  }
+}
+
+/**
+ * Look up the group for a trace event by name. Falls through to
+ * prefix matching for event-name families that share a structural
+ * pattern (`V8.GC*` for any V8 GC phase) so we don't have to
+ * enumerate every phase name Chrome ships. Returns undefined when
+ * no group matches; callers should fall back to `taskGroups.other`.
+ */
+export function groupForEvent(name) {
+  const exact = taskNameToGroup[name];
+  if (exact) return exact;
+  if (typeof name === 'string' && name.startsWith('V8.GC')) {
+    return taskGroups.garbageCollection;
+  }
+}

--- a/lib/chrome/trace/trace-of-tab.js
+++ b/lib/chrome/trace/trace-of-tab.js
@@ -1,0 +1,168 @@
+/**
+ * Trace → tab-of-interest extractor. Ported from @sitespeed.io/tracium
+ * 0.3.3. Picks the renderer pid/tid/frameId, locates navigation/paint
+ * landmark events, and returns the chronologically-stable subset of
+ * events that belong to the inspected tab plus its main-thread
+ * subset that the task-builder consumes.
+ */
+
+import { getLogger } from '@sitespeed.io/log';
+import { findMainFrameIds } from './tracing-processor.js';
+
+const log = getLogger('browsertime.chrome.trace');
+
+const ACCEPTABLE_NAVIGATION_URL_REGEX = /^(chrome|https?|file):/;
+
+function getTimestamp(event) {
+  return event && event.ts;
+}
+
+function isNavigationStartOfInterest(event) {
+  return (
+    event.name === 'navigationStart' &&
+    (!event.args.data ||
+      !event.args.data.documentLoaderURL ||
+      ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL))
+  );
+}
+
+/**
+ * Stable sort by `ts`. JavaScript's Array.prototype.sort isn't
+ * guaranteed stable across engines historically, and trace event
+ * order matters when ts collides (B/E pairing breaks otherwise).
+ * The implementation sorts an indices array first, breaking ties by
+ * source index, so equal-ts events keep their original ordering.
+ */
+function filteredStableSort(traceEvents, filter) {
+  const indices = [];
+  for (const [srcIndex, traceEvent] of traceEvents.entries()) {
+    if (filter(traceEvent)) {
+      indices.push(srcIndex);
+    }
+  }
+  indices.sort((indexA, indexB) => {
+    const result = traceEvents[indexA].ts - traceEvents[indexB].ts;
+    return result || indexA - indexB;
+  });
+  const sorted = [];
+  for (const index of indices) {
+    sorted.push(traceEvents[index]);
+  }
+  return sorted;
+}
+
+export function computeTraceOfTab(trace) {
+  // Parse the trace for our key events and sort them by timestamp.
+  // The sort *must* be stable to keep events correctly nested.
+  const keyEvents = filteredStableSort(trace.traceEvents, e => {
+    return (
+      e.cat.includes('blink.user_timing') ||
+      e.cat.includes('loading') ||
+      e.cat.includes('devtools.timeline') ||
+      e.cat === '__metadata'
+    );
+  });
+
+  const mainFrameIds = findMainFrameIds(keyEvents);
+
+  // Filter to just events matching the frame ID for sanity.
+  const frameEvents = keyEvents.filter(
+    e => e.args.frame === mainFrameIds.frameId
+  );
+
+  // Our navStart will be the last frame navigation in the trace.
+  const navigationStart = frameEvents.findLast(e =>
+    isNavigationStartOfInterest(e)
+  );
+  if (!navigationStart) throw new Error('NO_NAVSTART');
+
+  // Find our first paint of this frame.
+  const firstPaint = frameEvents.find(
+    e => e.name === 'firstPaint' && e.ts > navigationStart.ts
+  );
+
+  // fMP follows at/after the FP.
+  let firstMeaningfulPaint = frameEvents.find(
+    e => e.name === 'firstMeaningfulPaint' && e.ts > navigationStart.ts
+  );
+  let fmpFellBack = false;
+
+  // If there was no firstMeaningfulPaint event found in the trace,
+  // network-idle detection may have not been triggered before the
+  // capture finished. Use the last firstMeaningfulPaintCandidate.
+  if (!firstMeaningfulPaint) {
+    const fmpCand = 'firstMeaningfulPaintCandidate';
+    fmpFellBack = true;
+    log.debug(
+      'trace-of-tab',
+      `No firstMeaningfulPaint found, falling back to last ${fmpCand}`
+    );
+    const lastCandidate = frameEvents.findLast(e => e.name === fmpCand);
+    if (!lastCandidate) {
+      log.debug(
+        'trace-of-tab',
+        'No `firstMeaningfulPaintCandidate` events found in trace'
+      );
+    }
+    firstMeaningfulPaint = lastCandidate;
+  }
+
+  const load = frameEvents.find(
+    e => e.name === 'loadEventEnd' && e.ts > navigationStart.ts
+  );
+  const domContentLoaded = frameEvents.find(
+    e => e.name === 'domContentLoadedEventEnd' && e.ts > navigationStart.ts
+  );
+
+  // Subset all trace events to just our tab's process (incl threads
+  // other than main). Stable-sort to keep events correctly nested.
+  const processEvents = filteredStableSort(
+    trace.traceEvents,
+    e => e.pid === mainFrameIds.pid
+  );
+
+  const mainThreadEvents = processEvents.filter(
+    e => e.tid === mainFrameIds.tid
+  );
+
+  // traceEnd must exist since at least navigationStart was verified.
+  let traceEnd = trace.traceEvents[0];
+  for (const evt of trace.traceEvents) {
+    if (evt.ts > traceEnd.ts) traceEnd = evt;
+  }
+  const fakeEndOfTraceEvt = { ts: traceEnd.ts + (traceEnd.dur || 0) };
+
+  const timestamps = {
+    navigationStart: navigationStart.ts,
+    firstPaint: getTimestamp(firstPaint),
+    firstMeaningfulPaint: getTimestamp(firstMeaningfulPaint),
+    traceEnd: fakeEndOfTraceEvt.ts,
+    load: getTimestamp(load),
+    domContentLoaded: getTimestamp(domContentLoaded)
+  };
+
+  const getTiming = ts => (ts - navigationStart.ts) / 1000;
+  const maybeGetTiming = ts => (ts === undefined ? undefined : getTiming(ts));
+  const timings = {
+    navigationStart: 0,
+    firstPaint: maybeGetTiming(timestamps.firstPaint),
+    firstMeaningfulPaint: maybeGetTiming(timestamps.firstMeaningfulPaint),
+    traceEnd: getTiming(timestamps.traceEnd),
+    load: maybeGetTiming(timestamps.load),
+    domContentLoaded: maybeGetTiming(timestamps.domContentLoaded)
+  };
+
+  return {
+    timings,
+    timestamps,
+    processEvents,
+    mainThreadEvents,
+    mainFrameIds,
+    navigationStartEvt: navigationStart,
+    firstPaintEvt: firstPaint,
+    firstMeaningfulPaintEvt: firstMeaningfulPaint,
+    loadEvt: load,
+    domContentLoadedEvt: domContentLoaded,
+    fmpFellBack
+  };
+}

--- a/lib/chrome/trace/tracing-processor.js
+++ b/lib/chrome/trace/tracing-processor.js
@@ -1,0 +1,95 @@
+/**
+ * Trace pid/tid/frameId resolver, ported from @sitespeed.io/tracium
+ * 0.3.3 (Lighthouse 2018 lineage). Only `findMainFrameIds` is kept —
+ * the original module also exposed `getRiskToResponsiveness` and
+ * the `_riskPercentiles` math used by Lighthouse's TBT, but those
+ * aren't called from Browsertime's pipeline so they're dropped to
+ * keep the surface tight.
+ */
+
+/**
+ * Locate the main renderer's pid/tid/frameId via three fallbacks, in
+ * order of how recent the trace events are: the modern
+ * TracingStartedInBrowser event (with a frames[] payload), the legacy
+ * TracingStartedInPage event, and finally pairing the first
+ * navigationStart with the first ResourceSendRequest. Throws when
+ * none of the three apply — which means the trace doesn't contain
+ * a renderable tab and the caller (parseCpuTrace) will degrade
+ * gracefully via its outer try/catch.
+ */
+export function findMainFrameIds(events) {
+  // Prefer the newer TracingStartedInBrowser event first, if it exists.
+  const startedInBrowserEvt = events.find(
+    e => e.name === 'TracingStartedInBrowser'
+  );
+  if (
+    startedInBrowserEvt &&
+    startedInBrowserEvt.args.data &&
+    startedInBrowserEvt.args.data.frames
+  ) {
+    const mainFrame = startedInBrowserEvt.args.data.frames.find(
+      frame => !frame.parent
+    );
+    const frameId = mainFrame && mainFrame.frame;
+    const pid = mainFrame && mainFrame.processId;
+
+    const threadNameEvt = events.find(
+      e =>
+        e.pid === pid &&
+        e.ph === 'M' &&
+        e.cat === '__metadata' &&
+        e.name === 'thread_name' &&
+        e.args.name === 'CrRendererMain'
+    );
+    const tid = threadNameEvt && threadNameEvt.tid;
+
+    if (pid && tid && frameId) {
+      return { pid, tid, frameId };
+    }
+  }
+
+  // Support legacy browser versions that do not emit
+  // TracingStartedInBrowser. The first TracingStartedInPage in the
+  // trace is the renderer thread of interest. Beware: the
+  // TracingStartedInPage event can appear slightly after a
+  // navigationStart, so the order of fallbacks matters.
+  const startedInPageEvt = events.find(e => e.name === 'TracingStartedInPage');
+  if (startedInPageEvt && startedInPageEvt.args && startedInPageEvt.args.data) {
+    const frameId = startedInPageEvt.args.data.page;
+    if (frameId) {
+      return { pid: startedInPageEvt.pid, tid: startedInPageEvt.tid, frameId };
+    }
+  }
+
+  // Last resort: pair the first navigationStart that's loading the
+  // main frame with the first ResourceSendRequest from the same
+  // pid/tid. If those agree the renderer is whatever pid/tid they
+  // share.
+  const navStartEvt = events.find(e =>
+    Boolean(
+      e.name === 'navigationStart' &&
+      e.args &&
+      e.args.data &&
+      e.args.data.isLoadingMainFrame &&
+      e.args.data.documentLoaderURL
+    )
+  );
+  const firstResourceSendEvt = events.find(
+    e => e.name === 'ResourceSendRequest'
+  );
+  if (
+    navStartEvt &&
+    navStartEvt.args &&
+    navStartEvt.args.data &&
+    firstResourceSendEvt &&
+    firstResourceSendEvt.pid === navStartEvt.pid &&
+    firstResourceSendEvt.tid === navStartEvt.tid
+  ) {
+    const frameId = navStartEvt.args.frame;
+    if (frameId) {
+      return { pid: navStartEvt.pid, tid: navStartEvt.tid, frameId };
+    }
+  }
+
+  throw new Error('NO_TRACING_STARTED');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@sitespeed.io/geckodriver": "0.36.0",
         "@sitespeed.io/log": "1.0.0",
         "@sitespeed.io/throttle": "5.0.1",
-        "@sitespeed.io/tracium": "0.3.3",
         "chrome-har": "1.2.1",
         "chrome-remote-interface": "0.33.3",
         "execa": "9.6.1",
@@ -1454,17 +1453,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      }
-    },
-    "node_modules/@sitespeed.io/tracium": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sitespeed.io/tracium/-/tracium-0.3.3.tgz",
-      "integrity": "sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==",
-      "dependencies": {
-        "debug": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@tokenizer/inflate": {
@@ -7973,14 +7961,6 @@
       "integrity": "sha512-7d+tr34D05if/2vnKHEDOOlkTuZJFrgBjd2JrDO5co37tbbQa1ULfGsi4DZt0SiCnoOUWT9wcjM3ac/fNZK/yA==",
       "requires": {
         "minimist": "1.2.6"
-      }
-    },
-    "@sitespeed.io/tracium": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sitespeed.io/tracium/-/tracium-0.3.3.tgz",
-      "integrity": "sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==",
-      "requires": {
-        "debug": "^4.1.1"
       }
     },
     "@tokenizer/inflate": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@sitespeed.io/geckodriver": "0.36.0",
     "@sitespeed.io/log": "1.0.0",
     "@sitespeed.io/throttle": "5.0.1",
-    "@sitespeed.io/tracium": "0.3.3",
     "chrome-har": "1.2.1",
     "chrome-remote-interface": "0.33.3",
     "execa": "9.6.1",


### PR DESCRIPTION
- Replace the unmaintained @sitespeed.io/tracium dependency (extracted from Lighthouse circa 2017, last release 0.3.3) with an in-tree ESM port at lib/chrome/trace/. computeMainThreadTasks is byte-equivalent so existing result.cpu.{categories,events,urls} consumers see no change.
 - Modernise the event classifier. The original list only knew about ~30 event names, so on busy 2026-era pages roughly half the trace fell through to "other" — on a sample cnet run that meant 1.3 s of "other" hiding RunTask, v8.run, IntersectionObserverController::computeIntersections, PrePaint, Commit, Layerize, v8.callFunction, V8.DeserializeContext and friends. The expanded list (drawing from modern Lighthouse + the WebPageTest-derived map in waterfall-tools + direct sampling of real traces) reclassifies ~1.5 s of that "other" into the right buckets. A new groupForEvent() lookup adds prefix matching for V8.GC* so future V8 GC phases auto-classify without enumeration.
  - Add three new analyses on result.cpu, each independently computed and wrapped in its own try/catch so a bug in one can't poison the existing payload:
    - scriptCosts — Lighthouse-style per-URL parse / compile / execute / total breakdown.
    - forcedReflows — Layout / UpdateLayoutTree events nested under JS-driven tasks (EventDispatch, FunctionCall, TimerFire, FireAnimationFrame, …) with the script that triggered each.
    - nonCompositedAnimations — Animation events whose compositeFailed bitmask is non-zero, with the unsupported properties.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
Change-Id: I085d3ef2bd32bcf663c6b764d1551c59a544a165