### PR TITLE
Surface page-level renderBlocking summary in the HAR

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -415,6 +415,19 @@ export class Chromium {
               render.renderBlockingInfo[harRequest.request.url];
           }
         }
+        // Also stamp the page-level summary (recalculate-style
+        // elements + duration before FCP/LCP) onto the HAR's page
+        // object so HAR-only consumers can pick it up without
+        // needing browsertime.json. The per-request map is already
+        // projected onto each entry above, so we keep this payload
+        // to just the summary fields.
+        const harPage =
+          this.hars[index - 1].log.pages && this.hars[index - 1].log.pages[0];
+        if (harPage && render.renderBlocking.recalculateStyle) {
+          harPage._renderBlocking = {
+            recalculateStyle: render.renderBlocking.recalculateStyle
+          };
+        }
       }
 
       result.renderBlocking.requests = render.renderBlockingInfo;


### PR DESCRIPTION
  The recalculate-style summary that powers "Elements that needed
  recalculate style before FCP" in the HTML report has been
  trapped inside browsertime.json — every HAR-only consumer
  (compare.sitespeed.io, third-party tooling) has had to either
  crack open browsertime.json or do without. Per-request
  renderBlocking info is already projected onto each entry, but
  the page-level summary wasn't going anywhere.

  Stamp the recalculate-style block (beforeFCP / beforeLCP element
  counts + durations) onto the HAR's first page object as
  _renderBlocking.recalculateStyle. The per-request map stays
  where it already lives so the page payload stays small.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com

Change-Id: I35e1239c0912cbef42f1f5e3872869ae6ba8b784