### PR TITLE
Replace lodash.merge with a small local helper

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import merge from 'lodash.merge';
 import { getLogger } from '@sitespeed.io/log';
 import { existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -13,6 +12,7 @@ import { configure } from '../lib/support/logging.js';
 import { parseCommandLine } from '../lib/support/cli.js';
 import { StorageManager } from '../lib/support/storageManager.js';
 import { loadScript } from '../lib/support/engineUtils.js';
+import { merge } from '../lib/support/util.js';
 import { setProperty, getProperty } from '../lib/support/util.js';
 import { isAndroidConfigured } from '../lib/android/index.js';
 

--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import merge from 'lodash.merge';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { Engine } from '../lib/core/engine/index.js';
 import { configure as logging } from '../lib/support/logging.js';
+import { merge } from '../lib/support/util.js';
 
 async function runBrowsertime() {
   let yargsInstance = yargs(hideBin(process.argv));

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { getLogger } from '@sitespeed.io/log';
-import merge from 'lodash.merge';
 import { timestamp as _timestamp } from '../../../support/engineUtils.js';
 import { pathToFolder } from '../../../support/pathToFolder.js';
 import {
@@ -9,7 +8,7 @@ import {
 } from '../../../support/userTiming.js';
 import { isAndroidConfigured, Android } from '../../../android/index.js';
 import { TCPDump } from '../../../support/tcpdump.js';
-import { getProperty } from '../../../support/util.js';
+import { getProperty, merge } from '../../../support/util.js';
 import { MeasureScreenshots } from './measure/screenshots.js';
 import { MeasureVideo } from './measure/video.js';
 const log = getLogger('browsertime.command.measure');

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -1,6 +1,5 @@
 import { arch as _arch } from 'node:os';
 import { getLogger } from '@sitespeed.io/log';
-import merge from 'lodash.merge';
 import { execaCommand as command } from 'execa';
 import { StorageManager } from '../../support/storageManager.js';
 import { Firefox } from '../../firefox/webdriver/firefox.js';
@@ -10,7 +9,12 @@ import {
   addConnectivity,
   removeConnectivity
 } from '../../connectivity/index.js';
-import { logResultLogLine, getProperty, toArray } from '../../support/util.js';
+import {
+  logResultLogLine,
+  getProperty,
+  toArray,
+  merge
+} from '../../support/util.js';
 import {
   getFullyLoaded,
   getMainDocumentTimings,

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -1,5 +1,4 @@
 import { getLogger } from '@sitespeed.io/log';
-import merge from 'lodash.merge';
 import { Condition } from 'selenium-webdriver';
 import { isAndroidConfigured } from '../android/index.js';
 import { UrlLoadError, BrowserError, TimeoutError } from '../support/errors.js';
@@ -8,7 +7,7 @@ import { getViewPort } from '../support/getViewPort.js';
 import { defaultPageCompleteCheck } from './pageCompleteChecks/defaultPageCompleteCheck.js';
 import { pageCompleteCheckByInactivity } from './pageCompleteChecks/pageCompleteCheckByInactivity.js';
 import { spaInactivity as spaCheck } from './pageCompleteChecks/spaInactivity.js';
-import { getProperty } from '../support/util.js';
+import { getProperty, merge } from '../support/util.js';
 const log = getLogger('browsertime');
 
 const defaults = {

--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import merge from 'lodash.merge';
 import { getLogger } from '@sitespeed.io/log';
 import { screenshotDefaults } from './defaults.js';
 import {
@@ -8,6 +7,7 @@ import {
   saveJpg
 } from '../support/images/index.js';
 import { loadCustomJimp } from './loadCustomJimp.js';
+import { merge } from '../support/util.js';
 
 const SCREENSHOT_DIR = 'screenshots';
 const log = getLogger('browsertime.screenshot');

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -1,12 +1,11 @@
 import { createRequire } from 'node:module';
-import merge from 'lodash.merge';
 import { pathToFolder } from '../pathToFolder.js';
 import { localTime } from '../util.js';
 import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('browsertime');
 const require = createRequire(import.meta.url);
 const version = require('../../../package.json').version;
-import { pick, isEmpty, getProperty } from '../../support/util.js';
+import { pick, isEmpty, getProperty, merge } from '../../support/util.js';
 
 const sensitiveHeaders = new Set([
   'authorization',

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -388,3 +388,49 @@ export function getProperty(object, path, defaultValue) {
 
   return result === undefined ? defaultValue : result;
 }
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function canMergeInto(value) {
+  return value !== null && typeof value === 'object';
+}
+
+function mergeInto(target, source) {
+  for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+    const sourceValue = source[key];
+    const targetValue = target[key];
+    if (Array.isArray(sourceValue)) {
+      const into = Array.isArray(targetValue) ? targetValue : [];
+      mergeInto(into, sourceValue);
+      target[key] = into;
+    } else if (isPlainObject(sourceValue)) {
+      const into = canMergeInto(targetValue) ? targetValue : {};
+      mergeInto(into, sourceValue);
+      target[key] = into;
+    } else if (sourceValue === undefined) {
+      if (!(key in target)) target[key] = undefined;
+    } else {
+      target[key] = sourceValue;
+    }
+  }
+}
+
+/**
+ * A replacement for lodash.merge(target, ...sources).
+ *
+ */
+export function merge(target, ...sources) {
+  if (target === undefined || target === null) return target;
+  for (const source of sources) {
+    if (source === undefined || source === null) continue;
+    mergeInto(target, source);
+  }
+  return target;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "execa": "9.6.1",
         "fast-stats": "0.0.7",
         "ff-test-bidi-har-export": "0.0.22",
-        "lodash.merge": "4.6.2",
         "selenium-webdriver": "4.43.0",
         "yargs": "18.0.0"
       },
@@ -4603,7 +4602,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -10168,7 +10168,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lower-case": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "execa": "9.6.1",
     "fast-stats": "0.0.7",
     "ff-test-bidi-har-export": "0.0.22",
-    "lodash.merge": "4.6.2",
     "selenium-webdriver": "4.43.0",
     "yargs": "18.0.0"
   },

--- a/test/util/engine.js
+++ b/test/util/engine.js
@@ -1,5 +1,5 @@
 import { Engine } from '../../lib/core/engine/index.js';
-import merge from 'lodash.merge';
+import { merge } from '../../lib/support/util.js';
 
 export function getEngine(options) {
   const defaultOptions = {


### PR DESCRIPTION
  Finishes the lodash unbundling here the same way sitespeed.io did
  (soulgalore/sitespeed.io#4742): a 40-line merge() in
  lib/support/util.js alongside the existing getProperty/setProperty
  helpers, no new file. The helper matches lodash's actual semantics —
  arrays merged by index, undefined source values skipped unless the
  key is missing on the target, Date/RegExp/class instances passed by
  reference, prototype-pollution keys rejected — which were the
  behaviors any of the call sites here relied on (engine/seleniumRunner
  defaults, HAR log merge, screenshot config, measure result/extras,
  WebPageReplay options, bin/browsertime.js script discovery).

  Dropping the direct dep means browsertime no longer pulls lodash.merge
  itself; eslint still brings it in transitively, which is fine.

  Co-authored-by: Claude noreply@anthropic.com

Change-Id: I00e4737b05c626d56a5c90ae80fb544482141dad