### PR TITLE
Use setup-ffmpeg action in Linux CI instead of fetching from johnvans…

### DIFF
--- a/.github/workflows/browser-beta.yml
+++ b/.github/workflows/browser-beta.yml
@@ -30,6 +30,10 @@ jobs:
         chrome-version: beta
     - name: Install Browsertime
       run: npm ci
+    - name: Install ffmpeg
+      uses: AnimMouse/setup-ffmpeg@ae28d57dabbb148eff63170b6bf7f2b60062cbae # v1.2.3
+      with:
+        version: '7.1'
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
@@ -38,11 +42,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
-        # Static ffmpeg from johnvansickle.com — replaces `snap install ffmpeg`,
-        # which has been flaky against the snap store from CI runners.
-        curl -fsSL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | sudo tar -xJ -C /opt/
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffmpeg /usr/local/bin/ffmpeg
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ffprobe
         python -m pip install --upgrade pip setuptools==70.0.0 pyssim virtualenv
         sudo modprobe ifb numifbs=1
     - name: Browser versions

--- a/.github/workflows/browser-dev.yml
+++ b/.github/workflows/browser-dev.yml
@@ -30,6 +30,10 @@ jobs:
         chrome-version: dev
     - name: Install Browsertime
       run: npm ci
+    - name: Install ffmpeg
+      uses: AnimMouse/setup-ffmpeg@ae28d57dabbb148eff63170b6bf7f2b60062cbae # v1.2.3
+      with:
+        version: '7.1'
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
@@ -38,11 +42,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
-        # Static ffmpeg from johnvansickle.com — replaces `snap install ffmpeg`,
-        # which has been flaky against the snap store from CI runners.
-        curl -fsSL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | sudo tar -xJ -C /opt/
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffmpeg /usr/local/bin/ffmpeg
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ffprobe
         python -m pip install --upgrade pip setuptools==70.0.0 pyssim OpenCV-Python Numpy virtualenv
         sudo modprobe ifb numifbs=1
     - name: Browser versions

--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -17,6 +17,7 @@ jobs:
         allowed-endpoints: >
           accounts.google.com:443
           android.clients.google.com:443
+          api.github.com:443
           azure.archive.ubuntu.com:80
           clients2.google.com:80
           dl-ssl.google.com:443
@@ -88,6 +89,7 @@ jobs:
         allowed-endpoints: >
           accounts.google.com:443
           android.clients.google.com:443
+          api.github.com:443
           azure.archive.ubuntu.com:80
           clients2.google.com:80
           dl-ssl.google.com:443
@@ -186,6 +188,7 @@ jobs:
         allowed-endpoints: >
           accounts.google.com:443
           android.clients.google.com:443
+          api.github.com:443
           azure.archive.ubuntu.com:80
           clients2.google.com:80
           dl-ssl.google.com:443

--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -18,7 +18,6 @@ jobs:
           accounts.google.com:443
           android.clients.google.com:443
           azure.archive.ubuntu.com:80
-          johnvansickle.com:443
           clients2.google.com:80
           dl-ssl.google.com:443
           dl.google.com:80
@@ -90,7 +89,6 @@ jobs:
           accounts.google.com:443
           android.clients.google.com:443
           azure.archive.ubuntu.com:80
-          johnvansickle.com:443
           clients2.google.com:80
           dl-ssl.google.com:443
           dl.google.com:80
@@ -189,7 +187,6 @@ jobs:
           accounts.google.com:443
           android.clients.google.com:443
           azure.archive.ubuntu.com:80
-          johnvansickle.com:443
           clients2.google.com:80
           dl-ssl.google.com:443
           dl.google.com:80
@@ -223,6 +220,10 @@ jobs:
         google-chrome --version
     - name: Install Browsertime
       run: npm ci
+    - name: Install ffmpeg
+      uses: AnimMouse/setup-ffmpeg@ae28d57dabbb148eff63170b6bf7f2b60062cbae # v1.2.3
+      with:
+        version: '7.1'
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
@@ -231,12 +232,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
-        # Static ffmpeg from johnvansickle.com — replaces `snap install ffmpeg`,
-        # which fails under harden-runner because api.snapcraft.io IP-rotates
-        # and the iptables egress block pins to the IP resolved at job start.
-        curl -fsSL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | sudo tar -xJ -C /opt/
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffmpeg /usr/local/bin/ffmpeg
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ffprobe
         python -m pip install --upgrade pip setuptools==70.0.0 pyssim OpenCV-Python Numpy virtualenv
         sudo modprobe ifb numifbs=1
     - name: Start local HTTP server

--- a/.github/workflows/linux-firefox.yml
+++ b/.github/workflows/linux-firefox.yml
@@ -16,7 +16,6 @@ jobs:
         egress-policy: block
         allowed-endpoints: >
           archive.mozilla.org:443
-          johnvansickle.com:443
           content-signature-2.cdn.mozilla.net:443
           files.pythonhosted.org:443
           firefox-settings-attachments.cdn.mozilla.net:443
@@ -41,6 +40,10 @@ jobs:
         firefox-version: '149.0'
     - name: Install Browsertime
       run: npm ci
+    - name: Install ffmpeg
+      uses: AnimMouse/setup-ffmpeg@ae28d57dabbb148eff63170b6bf7f2b60062cbae # v1.2.3
+      with:
+        version: '7.1'
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
@@ -49,12 +52,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install net-tools -y
-        # Static ffmpeg from johnvansickle.com — replaces `snap install ffmpeg`,
-        # which fails under harden-runner because api.snapcraft.io IP-rotates
-        # and the iptables egress block pins to the IP resolved at job start.
-        curl -fsSL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | sudo tar -xJ -C /opt/
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffmpeg /usr/local/bin/ffmpeg
-        sudo ln -sf /opt/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ffprobe
         python -m pip install --upgrade pip setuptools==70.0.0 pyssim OpenCV-Python Numpy virtualenv
         sudo modprobe ifb numifbs=1
     - name: Browser versions

--- a/.github/workflows/linux-firefox.yml
+++ b/.github/workflows/linux-firefox.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          api.github.com:443
           archive.mozilla.org:443
           content-signature-2.cdn.mozilla.net:443
           files.pythonhosted.org:443


### PR DESCRIPTION
…ickle

  The static ffmpeg binary fetched from johnvansickle.com was a workaround
  from when newer ffmpeg releases broke browsertime's video pipeline. That
  compatibility issue is resolved now, and the third-party download has
  been failing intermittently and blocking otherwise-green CI runs.

  Switching to AnimMouse/setup-ffmpeg matches what windows.yml already
  uses (same pinned commit, same ffmpeg 7.1), so all platforms share a
  single, maintained source for the ffmpeg binary.

  Co-authored-by: Claude noreply@anthropic.com

Change-Id: Id1f5477ecb48b3e6133b971056a895ea99d109e9