### PR TITLE
Tighten how Browsertime publishes its TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "27.2.0",
   "bin": "./bin/browsertime.js",
   "type": "module",
-  "types": "./types/scripting.d.ts",
+  "types": "./scripting.d.ts",
   "dependencies": {
     "@devicefarmer/adbkit": "3.3.8",
     "@sitespeed.io/chromedriver": "148.0.7778",
@@ -55,13 +55,14 @@
     "index.js",
     "lib",
     "package.json",
+    "scripting.d.ts",
     "vendor",
     "types"
   ],
   "exports": {
     ".": {
-      "import": "./index.js",
-      "types": "./types/scripting.d.ts"
+      "types": "./scripting.d.ts",
+      "import": "./index.js"
     }
   },
   "scripts": {
@@ -72,7 +73,7 @@
     "lint:fix": "eslint . --fix",
     "tsc": "tsc",
     "jsdoc": "jsdoc --configure jsdoc/jsdoc.json",
-    "prepublishOnly": "npm run lint && npm run tsc"
+    "prepublishOnly": "npm run lint && npm run tsc && npx -y publint"
   },
   "author": "Peter Hedenskog",
   "contributors": [

--- a/scripting.d.ts
+++ b/scripting.d.ts
@@ -1,8 +1,8 @@
-export { Context as BrowsertimeContext } from './core/engine/context';
-export { Commands as BrowsertimeCommands } from './core/engine/commands';
+import type { Context } from './types/core/engine/context.js';
+import type { Commands } from './types/core/engine/commands.js';
 
-import { Context as BrowsertimeContext } from './core/engine/context';
-import { Commands as BrowsertimeCommands } from './core/engine/commands';
+export { Context as BrowsertimeContext } from './types/core/engine/context.js';
+export { Commands as BrowsertimeCommands } from './types/core/engine/commands.js';
 
 /**
  * Signature of a Browsertime user script. Annotate the default export of
@@ -16,6 +16,6 @@ import { Commands as BrowsertimeCommands } from './core/engine/commands';
  * }
  */
 export type BrowsertimeScript = (
-  context: BrowsertimeContext,
-  commands: BrowsertimeCommands
+  context: Context,
+  commands: Commands
 ) => Promise<unknown>;


### PR DESCRIPTION
  Move scripting.d.ts to the repo root so it sits next to package.json
  instead of inside the tsc outDir, where a future include-glob change
  could clobber it. Swap the order under exports so "types" comes before
  "import", which matches TypeScript's documented resolution rules and
  removes a hazard flagged by package-typing audits. Wire publint into
  prepublishOnly so common package.json mistakes fail before a release
  goes out instead of being discovered by a user.

  Co-authored-by: Claude noreply@anthropic.com

Change-Id: I4bcc7cc7fdd604f6977b850dcfc9430bdf1daa92