### PR TITLE
Show --firefox.env in help

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -495,14 +495,12 @@ export function parseCommandLine() {
         'To add multiple arguments to Firefox, repeat --firefox.args once per argument.',
       group: 'firefox'
     })
-    /* -- Remove from the help until we have the new Geckodriver > 0.26
     .option('firefox.env', {
       describe:
         'Extra environment variables to set in the format name=value. ' +
         'To add multiple environment variables, repeat --firefox.env once per environment variable.',
       group: 'firefox'
     })
-    */
     .option('firefox.includeResponseBodies', {
       describe: 'Include response bodies in HAR',
       default: 'none',


### PR DESCRIPTION
Correct me if I am wrong but I think it's okay to uncomment this now as Geckodriver is well past 0.26 now :) 

(I was looking to see if Browsertime had this feature...checked `--help-all` but couldn't find it...turns out it was hidden!)