### PR TITLE
Add event count and largest event to recalculate style summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Browsertime changelog (we do [semantic versioning](https://semver.org))
 
-## 27.5.0 - 2026-06-07
+## Unreleased
+
+### Added
+* The `renderBlocking.recalculateStyle` summary (Chrome only) now includes `count` — the number of Recalculate Style events behind the existing element and duration totals — plus `maxElements` and `maxDurationInMillis` for the single largest event, both before FCP and before LCP. The totals alone can't distinguish one massive invalidation that cascades through most of the DOM (fix: narrow the selector/class-toggle scope) from thousands of small forced recalcs caused by JS interleaving style writes and layout reads (fix: batch reads and writes). The count tells you which regime you're in, and the max values show whether one monster event dominates the total. The fields land in `browsertime.json`, the statistics summary, and the `_renderBlocking.recalculateStyle` page summary in the HAR.
 
 ### Added
 * Bumped `chromedriver` and `edgedriver` to 149 [#2487](https://github.com/sitespeedio/browsertime/pull/2487).

--- a/lib/chrome/webdriver/traceUtilities.js
+++ b/lib/chrome/webdriver/traceUtilities.js
@@ -52,12 +52,22 @@ function getRecalculateStyleElementsAndTimeBefore(traceEvents, timestamp) {
   );
   let elements = 0;
   let duration = 0;
+  let maxElements = 0;
+  let maxDuration = 0;
   for (let a of updateLayoutTree) {
     elements += a.args.elementCount;
     duration += a.dur;
+    maxElements = Math.max(maxElements, a.args.elementCount);
+    maxDuration = Math.max(maxDuration, a.dur);
   }
 
-  return { elements, durationInMillis: duration / 1000 };
+  return {
+    count: updateLayoutTree.length,
+    elements,
+    durationInMillis: duration / 1000,
+    maxElements,
+    maxDurationInMillis: maxDuration / 1000
+  };
 }
 
 export async function getRenderBlocking(trace) {


### PR DESCRIPTION
The beforeFCP/beforeLCP totals (elements affected, time spent) can't distinguish one massive style invalidation cascading through most of the DOM from thousands of small forced recalcs caused by JS interleaving style reads and writes — two problems with opposite fixes. The number of events, and the size of the largest one, tell you which regime you're in without opening the trace.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I7a486ec382bf155fe3865b5ffc6a481c6c34807f