### PR TITLE
Run harden-runner in audit mode on the Firefox Linux workflow

### DIFF
--- a/.github/workflows/linux-firefox.yml
+++ b/.github/workflows/linux-firefox.yml
@@ -13,11 +13,7 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        # Temporarily audit instead of block: the block agent holds the
-        # ingress qdisc slot on eth0, so the throttle connectivity test
-        # fails with "Exclusivity flag on, cannot modify". Restore block
-        # once the coexistence fix in sitespeedio/throttle is released.
-        egress-policy: audit
+        egress-policy: block
         allowed-endpoints: >
           api.github.com:443
           archive.mozilla.org:443
@@ -64,6 +60,12 @@ jobs:
         firefox --version
     - name: Start local HTTP server
       run: (npm run start-server&)
+    # Diagnostic for the "Exclusivity flag on" throttle failure: show what
+    # already occupies the ingress qdisc slot on the default interface.
+    - name: Show qdiscs
+      run: |
+        sudo tc qdisc show
+        sudo tc filter show dev eth0 ingress || true
     # - run: VTENV_OPTS="-p python3" make test
     - name: Test Firefox with throttle
       run: ./bin/browsertime.js -b firefox -n 1 http://127.0.0.1:3000/simple/ --connectivity.profile cable --connectivity.engine throttle --xvfb --firefox.collectMozLog

--- a/.github/workflows/linux-firefox.yml
+++ b/.github/workflows/linux-firefox.yml
@@ -13,7 +13,11 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
-        egress-policy: block
+        # Temporarily audit instead of block: the block agent holds the
+        # ingress qdisc slot on eth0, so the throttle connectivity test
+        # fails with "Exclusivity flag on, cannot modify". Restore block
+        # once the coexistence fix in sitespeedio/throttle is released.
+        egress-policy: audit
         allowed-endpoints: >
           api.github.com:443
           archive.mozilla.org:443


### PR DESCRIPTION
The throttle connectivity test started failing with "Exclusivity flag on, cannot modify" because the ingress qdisc slot on eth0 is already taken when browsertime runs. The prime suspect is harden-runner's block-mode agent, whose eBPF enforcement needs that slot. Switch to audit so the test can attach its own qdisc again; restore block once throttle can coexist with an occupied ingress slot.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ifd2b64c8b955b82caba4d331cfb55259708d6c1e