### PR TITLE
Surface main document response headers in the result JSON

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -136,6 +136,18 @@ export class Collector {
     }
   }
 
+  // Header values are strings so they are kept out of the statistics.
+  addMainDocument(url, mainDocument) {
+    const results =
+      this.allResults[url] || this.allResults[this.urlAndActualUrl[url]];
+    if (results) {
+      if (!results.mainDocument) {
+        results.mainDocument = [];
+      }
+      results.mainDocument.push(mainDocument);
+    }
+  }
+
   /**
    * Collect all individual runs, add it to the statistics, and store
    * data that needs to be on disk (trace logs, sceenshots etc).

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -18,6 +18,7 @@ import {
 import {
   getFullyLoaded,
   getMainDocumentTimings,
+  getMainDocuments,
   addExtraFieldsToHar
 } from '../../support/har/index.js';
 import { XVFB } from '../../support/xvfb.js';
@@ -373,6 +374,11 @@ export class Engine {
       const timings = getMainDocumentTimings(extras.har);
       for (let timing of timings) {
         collector.addMainDocumentTimings(timing.url, timing.timings);
+      }
+
+      const mainDocuments = getMainDocuments(extras.har);
+      for (let document of mainDocuments) {
+        collector.addMainDocument(document.url, document.mainDocument);
       }
     }
   }

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -269,6 +269,45 @@ export function getMainDocumentTimings(har) {
     return [];
   }
 }
+export function getMainDocuments(har) {
+  // Sometimes the HAR is dirty
+  try {
+    const mainDocuments = [];
+    for (let page of har.log.pages) {
+      const url = page._url;
+      if (url === undefined) continue;
+
+      const requests = getDocumentRequests(har.log.entries, page.id);
+      const finalEntry = requests.at(-1);
+      if (!finalEntry) continue;
+
+      const headers = {};
+      for (let header of finalEntry.response.headers || []) {
+        const name = header.name.toLowerCase();
+        // Always drop sensitive headers (the same list as
+        // --cleanSensitiveHeaders uses) since browsertime.json often ends
+        // up in dashboards even when the HAR stays local.
+        if (isSensitiveHeader(name)) continue;
+        headers[name] =
+          name in headers ? headers[name] + ', ' + header.value : header.value;
+      }
+
+      mainDocuments.push({
+        url,
+        mainDocument: {
+          url: finalEntry.request.url,
+          status: finalEntry.response.status,
+          redirects: requests.length - 1,
+          headers
+        }
+      });
+    }
+    return mainDocuments;
+  } catch (error) {
+    log.error('Could not get main document headers ' + error);
+    return [];
+  }
+}
 export function getFullyLoaded(har) {
   const fullyLoaded = [];
   const entries = [...har.log.entries];
@@ -464,8 +503,12 @@ export function addExtraFieldsToHar(totalResults, har, options) {
   }
 }
 
+export function isSensitiveHeader(name) {
+  return sensitiveHeaders.has(name.toLowerCase());
+}
+
 export function cleanSensitiveHeaders(name, value) {
-  if (sensitiveHeaders.has(name.toLowerCase())) {
+  if (isSensitiveHeader(name)) {
     return '[REMOVED]';
   }
   return value;

--- a/test/unittests/mainDocumentTest.js
+++ b/test/unittests/mainDocumentTest.js
@@ -1,0 +1,119 @@
+import test from 'ava';
+import { getMainDocuments } from '../../lib/support/har/index.js';
+
+function getHar() {
+  return {
+    log: {
+      version: '1.2',
+      pages: [
+        {
+          id: 'page_1',
+          _url: 'https://en.m.wikipedia.org/wiki/Sweden'
+        }
+      ],
+      entries: [
+        {
+          pageref: 'page_1',
+          request: { url: 'https://en.m.wikipedia.org/wiki/Sweden' },
+          response: {
+            status: 301,
+            redirectURL: 'https://en.wikipedia.org/wiki/Sweden',
+            headers: [
+              {
+                name: 'Location',
+                value: 'https://en.wikipedia.org/wiki/Sweden'
+              }
+            ]
+          }
+        },
+        {
+          pageref: 'page_1',
+          request: { url: 'https://en.wikipedia.org/wiki/Sweden' },
+          response: {
+            status: 200,
+            redirectURL: '',
+            headers: [
+              { name: 'X-Cache-Status', value: 'hit-front' },
+              { name: 'Age', value: '51265' },
+              { name: 'Set-Cookie', value: 'secret=1' },
+              { name: 'Server-Timing', value: 'cache;desc="hit-front"' }
+            ]
+          }
+        },
+        {
+          pageref: 'page_1',
+          request: { url: 'https://en.wikipedia.org/static/logo.png' },
+          response: {
+            status: 200,
+            redirectURL: '',
+            headers: [{ name: 'X-Cache-Status', value: 'miss' }]
+          }
+        }
+      ]
+    }
+  };
+}
+
+test('Follow the redirect chain to the main document', t => {
+  const documents = getMainDocuments(getHar());
+  t.is(documents.length, 1);
+  t.is(documents[0].url, 'https://en.m.wikipedia.org/wiki/Sweden');
+  t.deepEqual(documents[0].mainDocument, {
+    url: 'https://en.wikipedia.org/wiki/Sweden',
+    status: 200,
+    redirects: 1,
+    headers: {
+      'x-cache-status': 'hit-front',
+      age: '51265',
+      'server-timing': 'cache;desc="hit-front"'
+    }
+  });
+});
+
+test('Lowercase header names in the output', t => {
+  const documents = getMainDocuments(getHar());
+  t.true('x-cache-status' in documents[0].mainDocument.headers);
+  t.false('X-Cache-Status' in documents[0].mainDocument.headers);
+});
+
+test('Always drop sensitive headers', t => {
+  const har = getHar();
+  har.log.entries[1].response.headers.push({
+    name: 'Authorization',
+    value: 'Bearer secret'
+  });
+  const documents = getMainDocuments(har);
+  t.false('set-cookie' in documents[0].mainDocument.headers);
+  t.false('authorization' in documents[0].mainDocument.headers);
+});
+
+test('Report zero redirects when the first response is the document', t => {
+  const har = getHar();
+  har.log.entries.shift();
+  const documents = getMainDocuments(har);
+  t.is(documents[0].mainDocument.redirects, 0);
+  t.is(documents[0].mainDocument.url, 'https://en.wikipedia.org/wiki/Sweden');
+});
+
+test('Join multiple headers with the same name', t => {
+  const har = getHar();
+  har.log.entries[1].response.headers.push({
+    name: 'server-timing',
+    value: 'host;desc="cp1234"'
+  });
+  const documents = getMainDocuments(har);
+  t.is(
+    documents[0].mainDocument.headers['server-timing'],
+    'cache;desc="hit-front", host;desc="cp1234"'
+  );
+});
+
+test('Skip pages without an URL and handle empty entries', t => {
+  const har = getHar();
+  har.log.pages.push(
+    { id: 'page_2' },
+    { id: 'page_3', _url: 'https://example.com' }
+  );
+  const documents = getMainDocuments(har);
+  t.is(documents.length, 1);
+});


### PR DESCRIPTION
When testing CDN-fronted sites, response headers of the main HTML document decide how to interpret every metric of the run: x-cache / x-cache-status tells you whether the run was a front-cache hit, age how warm the object was, and server-timing often carries A/B experiment enrollment. Until now they were buried in the HAR entry of the main document, so dashboards could not tag or segment runs without HAR post-processing.

Whenever a HAR exists, a mainDocument field is now added per iteration with the final URL, status, redirect count and all response headers of the main document — following the redirect chain, since cross-origin redirects are invisible in navigation timing. It is on by default with zero configuration so runs can always be tagged by cache state or experiment enrollment. Sensitive headers (cookies, authorization) are always removed, using the same list as --cleanSensitiveHeaders so the two can never drift, which means there is no privacy footgun in enabling it unconditionally.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I3e090516b25bedf0fded49fb3ae4cf7c1aac97de