### PR TITLE
Mark profile run coverage as a single sample, not an iteration array

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -202,14 +202,24 @@ async function run(urls, options) {
       // the main iterations didn't collect any (--enableProfileRun
       // without --chrome.coverage). Otherwise the main run's
       // per-iteration samples are what the user asked for.
+      // The profile run is a single side iteration, so its sample is
+      // published as one object marked with source instead of a
+      // one-element array pretending to be keyed by iteration.
       let mergedCoverage = false;
       for (const [i, pr] of profileResult.entries()) {
         const main = result[i];
         if (!main || !pr.coverage) continue;
+        if (pr.coverage.js.length === 0 && pr.coverage.css.length === 0) {
+          continue;
+        }
         if (main.coverage.js.length > 0 || main.coverage.css.length > 0) {
           continue;
         }
-        main.coverage = pr.coverage;
+        main.coverage = {
+          source: 'profileRun',
+          js: pr.coverage.js[0],
+          css: pr.coverage.css[0]
+        };
         mergedCoverage = true;
       }
       if (mergedCoverage) {


### PR DESCRIPTION
When --enableProfileRun fills in coverage, the sample comes from one extra side iteration and is not tied to any measured run. Publishing it as a one-element array made it look keyed by iteration, and consumers indexing by run number (like the sitespeed.io coverage tab picking the median run) read undefined and reported no coverage. The sample is now a single object marked with source: 'profileRun' so consumers can tell the two cases apart. Per-iteration coverage from --chrome.coverage keeps its array shape.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I8c9ff3810895cd9ec2d5b374abb3b5e7f049e402