### PR TITLE
Per-module coverage for MediaWiki ResourceLoader bundles

### DIFF
--- a/lib/chrome/coverage.js
+++ b/lib/chrome/coverage.js
@@ -1,5 +1,10 @@
 import { getLogger } from '@sitespeed.io/log';
 
+import {
+  isResourceLoaderBundle,
+  resourceLoaderModuleCoverage
+} from './mediawikiResourceLoader.js';
+
 const log = getLogger('browsertime.chrome.coverage');
 
 // Sum the union length of half-open [start, end) ranges. Used for the
@@ -25,8 +30,8 @@ function unionLength(ranges) {
   return total;
 }
 
-// Count used bytes for a script under detailed (block-level) V8
-// coverage. The CDP returns nested ranges: the outermost range is the
+// Paint a per-byte used/unused flag array for a script under detailed
+// (block-level) V8 coverage. The CDP returns nested ranges: the outermost range is the
 // function body and inner ranges are sub-blocks. An inner range with
 // count == 0 inside a containing range with count > 0 represents dead
 // code in an otherwise-executed function — those bytes must read as
@@ -38,25 +43,29 @@ function unionLength(ranges) {
 // length descending), painting a per-byte coverage flag; inner ranges
 // overwrite outer ones, so the final flag at each byte reflects the
 // innermost range's count.
-export function usedJsBytes(scriptCoverage, totalBytes) {
+export function paintJsCoverage(scriptCoverage, totalBytes) {
+  const used = new Uint8Array(totalBytes);
   const ranges = [];
   for (const fn of scriptCoverage.functions) {
     for (const r of fn.ranges) {
       if (r.endOffset > r.startOffset) ranges.push(r);
     }
   }
-  if (ranges.length === 0) return 0;
   ranges.sort((a, b) =>
     a.startOffset === b.startOffset
       ? b.endOffset - a.endOffset
       : a.startOffset - b.startOffset
   );
-  const used = new Uint8Array(totalBytes);
   for (const r of ranges) {
     const start = Math.max(0, r.startOffset);
     const end = Math.min(totalBytes, r.endOffset);
     if (end > start) used.fill(r.count > 0 ? 1 : 0, start, end);
   }
+  return used;
+}
+
+export function usedJsBytes(scriptCoverage, totalBytes) {
+  const used = paintJsCoverage(scriptCoverage, totalBytes);
   let count = 0;
   for (let i = 0; i < totalBytes; i++) {
     if (used[i] === 1) count++;
@@ -185,13 +194,21 @@ export class Coverage {
 
       const usedBytes = usedJsBytes(script, totalBytes);
       const unusedBytes = totalBytes - usedBytes;
-      files.push({
+      const file = {
         url: script.url,
         totalBytes,
         usedBytes,
         unusedBytes,
         unusedPercent: (unusedBytes / totalBytes) * 100
-      });
+      };
+      if (isResourceLoaderBundle(script.url, source)) {
+        const modules = resourceLoaderModuleCoverage(
+          source,
+          paintJsCoverage(script, totalBytes)
+        );
+        if (modules) file.modules = modules;
+      }
+      files.push(file);
     }
     return { ...summarize(files), files };
   }

--- a/lib/chrome/mediawikiResourceLoader.js
+++ b/lib/chrome/mediawikiResourceLoader.js
@@ -1,0 +1,64 @@
+// MediaWiki-specific: per-module coverage breakdown for ResourceLoader
+// bundles. MediaWiki serves many JS modules concatenated into a single
+// load.php response. Each module in the bundle is delimited by an
+// mw.loader.impl(...) call whose payload starts with "<name>@<versionHash>".
+// Observed format (en.wikipedia.org, MediaWiki 1.4x, July 2026), one call
+// per line:
+//
+//   mw.loader.impl(function(){return["ext.popups.main@4i3g7",function(...
+//   mw.loader.impl(function(){return["mediawiki.base@h9kwf",{"main":...
+//
+// The delimiter is anchored to the start of a line (ResourceLoader emits
+// each impl call on its own line), which keeps mw.loader.impl occurrences
+// inside string literals from creating phantom modules unless the literal
+// happens to reproduce the full delimiter at a line start — an accepted
+// limitation. Trailing bundle content after the last module (for example
+// mw.loader.state(...)) is attributed to the last module.
+const MODULE_DELIMITER =
+  /^mw\.loader\.impl\(function\(\)\{return\["([\w.-]+)@([^"]*)",/gm;
+
+export function isResourceLoaderBundle(url, source) {
+  return url.includes('load.php') || source.startsWith('mw.loader.impl(');
+}
+
+// Intersect the per-byte coverage flags (painted, a Uint8Array where 1 =
+// used) with the module boundaries in the bundle source. Module i spans
+// [start_i, start_i+1); the last module ends at the end of the source.
+// Bytes before the first delimiter go to a '(preamble)' bucket. Returns
+// undefined when the source contains no delimiters.
+export function resourceLoaderModuleCoverage(source, painted) {
+  const boundaries = [];
+  for (const match of source.matchAll(MODULE_DELIMITER)) {
+    boundaries.push({
+      name: match[1],
+      version: match[2],
+      start: match.index
+    });
+  }
+  if (boundaries.length === 0) return;
+
+  if (boundaries[0].start > 0) {
+    boundaries.unshift({ name: '(preamble)', version: '', start: 0 });
+  }
+
+  const modules = [];
+  for (const [i, boundary] of boundaries.entries()) {
+    const end =
+      i + 1 < boundaries.length ? boundaries[i + 1].start : source.length;
+    const totalBytes = end - boundary.start;
+    let usedBytes = 0;
+    for (let b = boundary.start; b < end; b++) {
+      if (painted[b] === 1) usedBytes++;
+    }
+    const unusedBytes = totalBytes - usedBytes;
+    modules.push({
+      name: boundary.name,
+      version: boundary.version,
+      totalBytes,
+      usedBytes,
+      unusedBytes,
+      unusedPercent: totalBytes > 0 ? (unusedBytes / totalBytes) * 100 : 0
+    });
+  }
+  return modules.toSorted((a, b) => b.unusedBytes - a.unusedBytes);
+}

--- a/test/unittests/mediawikiResourceLoaderTest.js
+++ b/test/unittests/mediawikiResourceLoaderTest.js
@@ -1,0 +1,128 @@
+import test from 'ava';
+import { paintJsCoverage } from '../../lib/chrome/coverage.js';
+import {
+  isResourceLoaderBundle,
+  resourceLoaderModuleCoverage
+} from '../../lib/chrome/mediawikiResourceLoader.js';
+
+const preamble = '/* preamble */\n';
+const moduleOne =
+  'mw.loader.impl(function(){return["module.one@abc12",function(){}];});\n';
+const moduleTwo =
+  'mw.loader.impl(function(){return["module.two@def34",function(){}];});\n';
+const moduleThree =
+  'mw.loader.impl(function(){return["module.three@gh567",function(){}];});';
+const bundle = preamble + moduleOne + moduleTwo + moduleThree;
+
+const oneStart = preamble.length;
+const twoStart = oneStart + moduleOne.length;
+const threeStart = twoStart + moduleTwo.length;
+
+function allUsed(totalBytes) {
+  return paintJsCoverage(
+    {
+      functions: [
+        { ranges: [{ startOffset: 0, endOffset: totalBytes, count: 1 }] }
+      ]
+    },
+    totalBytes
+  );
+}
+
+test('detects bundles by load.php URL or source sniff', t => {
+  t.true(isResourceLoaderBundle('https://en.wikipedia.org/w/load.php', ''));
+  t.true(isResourceLoaderBundle('https://example.com/a.js', bundle.slice(15)));
+  t.false(isResourceLoaderBundle('https://example.com/a.js', 'var a = 1;'));
+});
+
+test('splits a bundle into per-module byte buckets', t => {
+  // module.one fully used, module.two fully unused, module.three half
+  // used, preamble fully used.
+  const painted = paintJsCoverage(
+    {
+      functions: [
+        { ranges: [{ startOffset: 0, endOffset: twoStart, count: 1 }] },
+        {
+          ranges: [{ startOffset: twoStart, endOffset: threeStart, count: 0 }]
+        },
+        {
+          ranges: [
+            { startOffset: threeStart, endOffset: threeStart + 36, count: 2 },
+            { startOffset: threeStart + 36, endOffset: bundle.length, count: 0 }
+          ]
+        }
+      ]
+    },
+    bundle.length
+  );
+  const modules = resourceLoaderModuleCoverage(bundle, painted);
+  t.is(modules.length, 4);
+
+  const byName = new Map(modules.map(m => [m.name, m]));
+  t.deepEqual(byName.get('(preamble)'), {
+    name: '(preamble)',
+    version: '',
+    totalBytes: preamble.length,
+    usedBytes: preamble.length,
+    unusedBytes: 0,
+    unusedPercent: 0
+  });
+  t.deepEqual(byName.get('module.one'), {
+    name: 'module.one',
+    version: 'abc12',
+    totalBytes: moduleOne.length,
+    usedBytes: moduleOne.length,
+    unusedBytes: 0,
+    unusedPercent: 0
+  });
+  t.deepEqual(byName.get('module.two'), {
+    name: 'module.two',
+    version: 'def34',
+    totalBytes: moduleTwo.length,
+    usedBytes: 0,
+    unusedBytes: moduleTwo.length,
+    unusedPercent: 100
+  });
+  t.is(byName.get('module.three').version, 'gh567');
+  t.is(byName.get('module.three').totalBytes, moduleThree.length);
+  t.is(byName.get('module.three').usedBytes, 36);
+  t.is(byName.get('module.three').unusedBytes, moduleThree.length - 36);
+
+  const unused = modules.map(m => m.unusedBytes);
+  t.deepEqual(
+    unused,
+    unused.toSorted((a, b) => b - a)
+  );
+});
+
+test('module totals add up to the bundle size', t => {
+  const modules = resourceLoaderModuleCoverage(bundle, allUsed(bundle.length));
+  let total = 0;
+  for (const m of modules) total += m.totalBytes;
+  t.is(total, bundle.length);
+});
+
+test('bundle without a preamble gets no preamble bucket', t => {
+  const source = moduleOne + moduleTwo;
+  const modules = resourceLoaderModuleCoverage(source, allUsed(source.length));
+  t.deepEqual(modules.map(m => m.name).toSorted(), [
+    'module.one',
+    'module.two'
+  ]);
+});
+
+test('source without delimiters returns no modules', t => {
+  const source = 'var a = 1; console.log(a);';
+  t.is(resourceLoaderModuleCoverage(source, allUsed(source.length)), undefined);
+});
+
+test('delimiter inside a string literal mid-line is not a module', t => {
+  const source =
+    moduleOne +
+    'var s = "mw.loader.impl(function(){return[\\"phantom@xxxxx\\","; f(s);\n';
+  const modules = resourceLoaderModuleCoverage(source, allUsed(source.length));
+  t.deepEqual(
+    modules.map(m => m.name),
+    ['module.one']
+  );
+});


### PR DESCRIPTION
MediaWiki sites serve tens of JS modules concatenated into single load.php responses, so V8 coverage keyed everything on one giant bundle URL and a dead-code or size regression could never be traced to the module that caused it. Each module in the bundle is delimited by an mw.loader.impl call carrying the module name and version hash, so intersecting the existing per-byte coverage flags with those boundaries yields per-module used/unused bytes with no MediaWiki-side changes.

Detection is automatic and Chrome only. All MediaWiki-specific logic lives in lib/chrome/mediawikiResourceLoader.js; the generic coverage code only detects and delegates. Output is additive: an optional modules array on the existing per-file entry, so non-MediaWiki sites and existing consumers are unaffected.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I0d14728a881e3fc15ac5058ad4fa4fbd893ce67f