### PR TITLE
Attribute main-thread blocking time to scripts and domains

### DIFF
--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -3,7 +3,9 @@ import {
   computeMainThreadTasks,
   computeScriptCosts,
   computeForcedReflows,
-  computeNonCompositedAnimations
+  computeNonCompositedAnimations,
+  computeBlockingTime,
+  computeDomainBreakdown
 } from './trace/index.js';
 const log = getLogger('browsertime.chrome.cpu');
 
@@ -105,6 +107,20 @@ export async function parseCPUTrace(tracelog, url) {
     } catch (error) {
       log.debug('computeNonCompositedAnimations failed: %s', error.message);
     }
+    // These two return objects with summary totals, so on failure the
+    // key is omitted instead of publishing a misleading zero total.
+    let blocking;
+    try {
+      blocking = computeBlockingTime(tracelog);
+    } catch (error) {
+      log.debug('computeBlockingTime failed: %s', error.message);
+    }
+    let domains;
+    try {
+      domains = computeDomainBreakdown(tracelog, url);
+    } catch (error) {
+      log.debug('computeDomainBreakdown failed: %s', error.message);
+    }
 
     log.debug('Chrome trace log finished parsed and sorted.');
     return {
@@ -113,7 +129,9 @@ export async function parseCPUTrace(tracelog, url) {
       urls: cleanedUrls,
       scriptCosts,
       forcedReflows,
-      nonCompositedAnimations
+      nonCompositedAnimations,
+      ...(blocking ? { blocking } : {}),
+      ...(domains ? { domains } : {})
     };
   } catch (error) {
     log.error(

--- a/lib/chrome/trace/blocking-time.js
+++ b/lib/chrome/trace/blocking-time.js
@@ -1,0 +1,141 @@
+/**
+ * Blocking-time attribution per URL.
+ *
+ * A top-level main-thread task longer than 50 ms blocks input for
+ * (duration - 50) ms — the same definition Lighthouse's Total
+ * Blocking Time uses. Knowing the page's TBT is one thing; knowing
+ * WHICH script produced it is what tells you what to fix first, so
+ * each blocking task is attributed to a URL:
+ *
+ * Top-level tasks are often anonymous wrappers (RunTask et al.) whose
+ * own attributableURLs is empty while the real work sits in child
+ * tasks. So instead of only looking at the top-level task's own URL
+ * chain, the whole subtree is walked and the task is attributed to
+ * the URL that contributed the most self-time (each node credited to
+ * its most-specific URL, attributableURLs.at(-1), the same choice
+ * script-costs.js makes). Tasks where no node carries a URL go to the
+ * 'unknown' bucket — that's browser-internal work (GC, style, layout
+ * without a JS trigger) no script owns.
+ *
+ * Two windows are reported: the whole trace, and navigationStart →
+ * the last largestContentfulPaint::Candidate event (blocking time in
+ * that window is what delayed LCP). Task times from
+ * main-thread-tasks.js are ms rebased to the first task, while the
+ * navigationStart / LCP timestamps are raw trace µs — the window
+ * check therefore uses the task's raw event.ts instead of converting
+ * back and forth. When the trace has no LCP candidate the LCP window
+ * is omitted rather than guessed.
+ *
+ * Returns:
+ *   { totalBlockingTime, tasks, urls: [{ url, value, tasks }, …],
+ *     beforeLargestContentfulPaint?: { totalBlockingTime, tasks,
+ *                                      urls: [...] } }
+ * Times in ms rounded to one decimal; url lists sorted by value desc
+ * and noise-filtered to entries above 10 ms, matching cpu.urls.
+ */
+
+import { getMainThreadTasks } from './main-thread-tasks.js';
+import { computeTraceOfTab } from './trace-of-tab.js';
+
+const BLOCKING_THRESHOLD_MS = 50;
+const REPORT_LIMIT_MS = 10;
+const UNKNOWN = 'unknown';
+
+function round(ms) {
+  return Math.round(ms * 10) / 10;
+}
+
+function dominantUrl(task) {
+  const selfTimeByUrl = new Map();
+  const stack = [task];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    const url = node.attributableURLs.at(-1);
+    if (url) {
+      selfTimeByUrl.set(url, (selfTimeByUrl.get(url) || 0) + node.selfTime);
+    }
+    stack.push(...node.children);
+  }
+  let bestUrl;
+  let bestTime = 0;
+  for (const [url, time] of selfTimeByUrl) {
+    if (time > bestTime) {
+      bestUrl = url;
+      bestTime = time;
+    }
+  }
+  return bestUrl || UNKNOWN;
+}
+
+function newWindow() {
+  return { totalBlockingTime: 0, tasks: 0, byUrl: new Map() };
+}
+
+function addToWindow(window, url, blocking) {
+  window.totalBlockingTime += blocking;
+  window.tasks += 1;
+  let entry = window.byUrl.get(url);
+  if (!entry) {
+    entry = { url, value: 0, tasks: 0 };
+    window.byUrl.set(url, entry);
+  }
+  entry.value += blocking;
+  entry.tasks += 1;
+}
+
+function finishWindow(window) {
+  const urls = [];
+  for (const entry of window.byUrl.values()) {
+    if (entry.value > REPORT_LIMIT_MS) {
+      entry.value = round(entry.value);
+      urls.push(entry);
+    }
+  }
+  urls.sort((a, b) => b.value - a.value);
+  return {
+    totalBlockingTime: round(window.totalBlockingTime),
+    tasks: window.tasks,
+    urls
+  };
+}
+
+export function computeBlockingTime(trace) {
+  const { mainThreadEvents, timestamps } = computeTraceOfTab(trace);
+  const tasks = getMainThreadTasks(mainThreadEvents, timestamps.traceEnd);
+
+  let lcpEvent;
+  for (const event of trace.traceEvents) {
+    if (
+      event.name === 'largestContentfulPaint::Candidate' &&
+      (!lcpEvent || event.ts > lcpEvent.ts)
+    ) {
+      lcpEvent = event;
+    }
+  }
+
+  const total = newWindow();
+  const beforeLcp = newWindow();
+
+  for (const task of tasks) {
+    if (task.parent) continue;
+    if (task.duration <= BLOCKING_THRESHOLD_MS) continue;
+
+    const blocking = task.duration - BLOCKING_THRESHOLD_MS;
+    const url = dominantUrl(task);
+    addToWindow(total, url, blocking);
+
+    if (
+      lcpEvent &&
+      task.event.ts >= timestamps.navigationStart &&
+      task.event.ts < lcpEvent.ts
+    ) {
+      addToWindow(beforeLcp, url, blocking);
+    }
+  }
+
+  const result = finishWindow(total);
+  if (lcpEvent) {
+    result.beforeLargestContentfulPaint = finishWindow(beforeLcp);
+  }
+  return result;
+}

--- a/lib/chrome/trace/domain-breakdown.js
+++ b/lib/chrome/trace/domain-breakdown.js
@@ -1,0 +1,86 @@
+/**
+ * First-party vs third-party main-thread rollup.
+ *
+ * cpu.urls answers "which URL costs the most main-thread time";
+ * this answers the level above it — how much of the main thread the
+ * site's own code uses versus embedded third parties, and which
+ * domains those third parties are. Each task's self-time is credited
+ * to its most-specific attributable URL (attributableURLs.at(-1),
+ * same choice as script-costs.js) so a task counts once — cpu.urls
+ * deliberately credits the full URL chain, which would double-count
+ * across domains here. Tasks with no attributable URL are
+ * browser-internal work no domain owns and are skipped.
+ *
+ * First-party is decided by registrable domain: the last two labels
+ * of the hostname, so every subdomain of the tested page's domain is
+ * first-party (en.wikipedia.org and upload.wikimedia.org roll up to
+ * wikipedia.org / wikimedia.org). Deliberately NOT a full public
+ * suffix list — two-level public suffixes (co.uk, com.au, …) group
+ * one label too high, which is acceptable for a rollup and avoids
+ * carrying an eTLD+1 dependency.
+ *
+ * Returns:
+ *   { firstPartyDomain, firstParty, thirdParty,
+ *     domains: [{ domain, value, firstParty }, …] }
+ * Times in ms rounded to one decimal; domains sorted by value desc
+ * and noise-filtered to entries above 10 ms, matching cpu.urls. The
+ * firstParty / thirdParty totals include the filtered-out remainder.
+ */
+
+import { compute } from './main-thread-tasks.js';
+
+const REPORT_LIMIT_MS = 10;
+
+function round(ms) {
+  return Math.round(ms * 10) / 10;
+}
+
+function registrableDomain(hostname) {
+  const labels = hostname.split('.');
+  return labels.length <= 2 ? hostname : labels.slice(-2).join('.');
+}
+
+function domainOf(url) {
+  try {
+    const { hostname } = new URL(url);
+    return hostname ? registrableDomain(hostname) : undefined;
+  } catch {
+    return;
+  }
+}
+
+export function computeDomainBreakdown(trace, pageUrl) {
+  const firstPartyDomain = registrableDomain(new URL(pageUrl).hostname);
+  const byDomain = new Map();
+
+  for (const task of compute(trace)) {
+    const url = task.attributableURLs.at(-1);
+    if (!url) continue;
+    const domain = domainOf(url);
+    if (!domain) continue;
+    byDomain.set(domain, (byDomain.get(domain) || 0) + task.selfTime);
+  }
+
+  let firstParty = 0;
+  let thirdParty = 0;
+  const domains = [];
+  for (const [domain, value] of byDomain) {
+    const isFirstParty = domain === firstPartyDomain;
+    if (isFirstParty) {
+      firstParty += value;
+    } else {
+      thirdParty += value;
+    }
+    if (value > REPORT_LIMIT_MS) {
+      domains.push({ domain, value: round(value), firstParty: isFirstParty });
+    }
+  }
+  domains.sort((a, b) => b.value - a.value);
+
+  return {
+    firstPartyDomain,
+    firstParty: round(firstParty),
+    thirdParty: round(thirdParty),
+    domains
+  };
+}

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -15,6 +15,8 @@ import { compute } from './main-thread-tasks.js';
 export { computeScriptCosts } from './script-costs.js';
 export { computeForcedReflows } from './forced-reflows.js';
 export { computeNonCompositedAnimations } from './non-composited-animations.js';
+export { computeBlockingTime } from './blocking-time.js';
+export { computeDomainBreakdown } from './domain-breakdown.js';
 
 /**
  * Compute the hierarchical main-thread task tree for a trace.

--- a/test/unittests/traceAnalysisTest.js
+++ b/test/unittests/traceAnalysisTest.js
@@ -1,0 +1,152 @@
+import test from 'ava';
+import { computeBlockingTime } from '../../lib/chrome/trace/blocking-time.js';
+import { computeDomainBreakdown } from '../../lib/chrome/trace/domain-breakdown.js';
+
+const PID = 1;
+const TID = 2;
+const FRAME = 'FRAME0';
+
+// Minimal-but-valid Chrome trace: enough metadata for trace-of-tab to
+// resolve pid/tid/frame, a navigationStart, three top-level tasks
+// longer than 50 ms (one attributed via a nested child, one after the
+// LCP candidate, one with no attributable URL) and one short task.
+function syntheticTrace({ withLcp = true } = {}) {
+  const traceEvents = [
+    {
+      name: 'TracingStartedInBrowser',
+      cat: 'disabled-by-default-devtools.timeline',
+      ph: 'I',
+      pid: 100,
+      tid: 100,
+      ts: 900_000,
+      args: { data: { frames: [{ frame: FRAME, processId: PID }] } }
+    },
+    {
+      name: 'thread_name',
+      cat: '__metadata',
+      ph: 'M',
+      pid: PID,
+      tid: TID,
+      ts: 0,
+      args: { name: 'CrRendererMain' }
+    },
+    {
+      name: 'navigationStart',
+      cat: 'blink.user_timing',
+      ph: 'R',
+      pid: PID,
+      tid: TID,
+      ts: 1_000_000,
+      args: {
+        frame: FRAME,
+        data: { documentLoaderURL: 'https://en.first.example/page' }
+      }
+    },
+    {
+      name: 'EvaluateScript',
+      cat: 'devtools.timeline',
+      ph: 'X',
+      pid: PID,
+      tid: TID,
+      ts: 1_050_000,
+      dur: 30_000,
+      args: { data: { url: 'https://cdn.third.example/lib.js' } }
+    },
+    {
+      name: 'RunTask',
+      cat: 'disabled-by-default-devtools.timeline',
+      ph: 'X',
+      pid: PID,
+      tid: TID,
+      ts: 1_100_000,
+      dur: 200_000,
+      args: {}
+    },
+    {
+      name: 'EvaluateScript',
+      cat: 'devtools.timeline',
+      ph: 'X',
+      pid: PID,
+      tid: TID,
+      ts: 1_110_000,
+      dur: 150_000,
+      args: { data: { url: 'https://sub.first.example/app.js' } }
+    },
+    {
+      name: 'EvaluateScript',
+      cat: 'devtools.timeline',
+      ph: 'X',
+      pid: PID,
+      tid: TID,
+      ts: 1_500_000,
+      dur: 130_000,
+      args: { data: { url: 'https://cdn.third.example/lib.js' } }
+    },
+    {
+      name: 'Layout',
+      cat: 'devtools.timeline',
+      ph: 'X',
+      pid: PID,
+      tid: TID,
+      ts: 1_700_000,
+      dur: 90_000,
+      args: {}
+    }
+  ];
+  if (withLcp) {
+    traceEvents.push({
+      name: 'largestContentfulPaint::Candidate',
+      cat: 'loading,rail,devtools.timeline',
+      ph: 'R',
+      pid: PID,
+      tid: TID,
+      ts: 1_400_000,
+      args: { frame: FRAME, data: {} }
+    });
+  }
+  return { traceEvents };
+}
+
+test('blocking time is attributed to the dominant URL in the task subtree', t => {
+  const result = computeBlockingTime(syntheticTrace());
+
+  t.is(result.totalBlockingTime, 270);
+  t.is(result.tasks, 3);
+  t.deepEqual(result.urls, [
+    { url: 'https://sub.first.example/app.js', value: 150, tasks: 1 },
+    { url: 'https://cdn.third.example/lib.js', value: 80, tasks: 1 },
+    { url: 'unknown', value: 40, tasks: 1 }
+  ]);
+});
+
+test('blocking time before LCP only counts tasks in the navigationStart to LCP window', t => {
+  const result = computeBlockingTime(syntheticTrace());
+
+  t.deepEqual(result.beforeLargestContentfulPaint, {
+    totalBlockingTime: 150,
+    tasks: 1,
+    urls: [{ url: 'https://sub.first.example/app.js', value: 150, tasks: 1 }]
+  });
+});
+
+test('the LCP window is omitted when the trace has no LCP candidate', t => {
+  const result = computeBlockingTime(syntheticTrace({ withLcp: false }));
+
+  t.is(result.totalBlockingTime, 270);
+  t.false('beforeLargestContentfulPaint' in result);
+});
+
+test('domain breakdown separates first-party subdomains from third parties', t => {
+  const result = computeDomainBreakdown(
+    syntheticTrace(),
+    'https://en.first.example/page'
+  );
+
+  t.is(result.firstPartyDomain, 'first.example');
+  t.is(result.firstParty, 150);
+  t.is(result.thirdParty, 160);
+  t.deepEqual(result.domains, [
+    { domain: 'third.example', value: 160, firstParty: false },
+    { domain: 'first.example', value: 150, firstParty: true }
+  ]);
+});

--- a/types/chrome/parseCpuTrace.d.ts
+++ b/types/chrome/parseCpuTrace.d.ts
@@ -1,27 +1,2 @@
-export function parseCPUTrace(tracelog: any, url: any): Promise<{
-    categories: {
-        parseHTML: number;
-        styleLayout: number;
-        paintCompositeRender: number;
-        scriptParseCompile: number;
-        scriptEvaluation: number;
-        garbageCollection: number;
-        other: number;
-    };
-    events: {};
-    urls: {
-        url: string;
-        value: number;
-    }[];
-    scriptCosts: any[];
-    forcedReflows: any[];
-    nonCompositedAnimations: any[];
-} | {
-    categories?: undefined;
-    events?: undefined;
-    urls?: undefined;
-    scriptCosts?: undefined;
-    forcedReflows?: undefined;
-    nonCompositedAnimations?: undefined;
-}>;
+export function parseCPUTrace(tracelog: any, url: any): Promise<{}>;
 //# sourceMappingURL=parseCpuTrace.d.ts.map

--- a/types/chrome/parseCpuTrace.d.ts.map
+++ b/types/chrome/parseCpuTrace.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"parseCpuTrace.d.ts","sourceRoot":"","sources":["../../lib/chrome/parseCpuTrace.js"],"names":[],"mappings":"AAkBA;;;;;;;;;;;;;;;;;;;;;;;;;GA2GC"}
+{"version":3,"file":"parseCpuTrace.d.ts","sourceRoot":"","sources":["../../lib/chrome/parseCpuTrace.js"],"names":[],"mappings":"AAoBA,oEA2HC"}

--- a/types/chrome/trace/blocking-time.d.ts
+++ b/types/chrome/trace/blocking-time.d.ts
@@ -1,0 +1,6 @@
+export function computeBlockingTime(trace: any): {
+    totalBlockingTime: number;
+    tasks: any;
+    urls: any[];
+};
+//# sourceMappingURL=blocking-time.d.ts.map

--- a/types/chrome/trace/blocking-time.d.ts.map
+++ b/types/chrome/trace/blocking-time.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"blocking-time.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/blocking-time.js"],"names":[],"mappings":"AAqGA;;;;EAuCC"}

--- a/types/chrome/trace/domain-breakdown.d.ts
+++ b/types/chrome/trace/domain-breakdown.d.ts
@@ -1,0 +1,11 @@
+export function computeDomainBreakdown(trace: any, pageUrl: any): {
+    firstPartyDomain: any;
+    firstParty: number;
+    thirdParty: number;
+    domains: {
+        domain: any;
+        value: number;
+        firstParty: boolean;
+    }[];
+};
+//# sourceMappingURL=domain-breakdown.d.ts.map

--- a/types/chrome/trace/domain-breakdown.d.ts.map
+++ b/types/chrome/trace/domain-breakdown.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"domain-breakdown.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/domain-breakdown.js"],"names":[],"mappings":"AAmDA;;;;;;;;;EAkCC"}

--- a/types/chrome/trace/index.d.ts
+++ b/types/chrome/trace/index.d.ts
@@ -16,4 +16,6 @@ export function computeMainThreadTasks(trace: any, options?: {
 export { computeScriptCosts } from "./script-costs.js";
 export { computeForcedReflows } from "./forced-reflows.js";
 export { computeNonCompositedAnimations } from "./non-composited-animations.js";
+export { computeBlockingTime } from "./blocking-time.js";
+export { computeDomainBreakdown } from "./domain-breakdown.js";
 //# sourceMappingURL=index.d.ts.map

--- a/types/chrome/trace/index.d.ts.map
+++ b/types/chrome/trace/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/index.js"],"names":[],"mappings":"AAkBA;;;;;;;;;;;GAWG;AACH,6DAJG;IAA0B,OAAO,GAAzB,OAAO;CAEf,GAAU,KAAK,KAAQ,CAYzB"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/index.js"],"names":[],"mappings":"AAoBA;;;;;;;;;;;GAWG;AACH,6DAJG;IAA0B,OAAO,GAAzB,OAAO;CAEf,GAAU,KAAK,KAAQ,CAYzB"}


### PR DESCRIPTION
cpu.urls says which script uses the most main-thread time overall, but not which one blocks the page when it matters. The new cpu.blocking key answers "which script should I fix first" by attributing long-task blocking time (the over-50 ms portion) per URL, both for the whole trace and inside the navigationStart-to-LCP window. cpu.domains rolls the per-URL cost up into first-party vs third-party totals so a creeping third-party budget is visible as one number. Both are additive keys under result.cpu, Chrome/Edge only, derived from the trace already collected with --cpu.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ib308398c5c4d0286eee669983b8ec0e63860b9a0