### PR TITLE
Stable labels for MediaWiki ResourceLoader URLs in CPU and coverage data

### DIFF
--- a/lib/chrome/coverage.js
+++ b/lib/chrome/coverage.js
@@ -2,6 +2,7 @@ import { getLogger } from '@sitespeed.io/log';
 
 import {
   isResourceLoaderBundle,
+  labelForUrl,
   resourceLoaderModuleCoverage
 } from './mediawikiResourceLoader.js';
 
@@ -201,6 +202,8 @@ export class Coverage {
         unusedBytes,
         unusedPercent: (unusedBytes / totalBytes) * 100
       };
+      const label = labelForUrl(script.url);
+      if (label) file.label = label;
       if (isResourceLoaderBundle(script.url, source)) {
         const modules = resourceLoaderModuleCoverage(
           source,
@@ -235,14 +238,18 @@ export class Coverage {
 
       const usedBytes = unionLength(usages.filter(u => u.used));
       const unusedBytes = totalBytes - usedBytes;
-      files.push({
-        url: this.styleSheetUrls.get(styleSheetId) || '',
+      const url = this.styleSheetUrls.get(styleSheetId) || '';
+      const file = {
+        url,
         styleSheetId,
         totalBytes,
         usedBytes,
         unusedBytes,
         unusedPercent: (unusedBytes / totalBytes) * 100
-      });
+      };
+      const label = labelForUrl(url);
+      if (label) file.label = label;
+      files.push(file);
     }
     return { ...summarize(files), files };
   }

--- a/lib/chrome/mediawikiResourceLoader.js
+++ b/lib/chrome/mediawikiResourceLoader.js
@@ -21,6 +21,90 @@ export function isResourceLoaderBundle(url, source) {
   return url.includes('load.php') || source.startsWith('mw.loader.impl(');
 }
 
+// MediaWiki-specific: stable, short labels for ResourceLoader load.php
+// URLs. The raw URLs are >1000 chars and carry a version= parameter
+// that changes on every deploy, so any dashboard keying a time series
+// on the URL gets a brand-new key every week. The label is derived
+// only from the request's role — the version, lang and skin parameters
+// are never read — so the same bundle keeps the same label across
+// deploys.
+//
+// Labeling rules (a URL qualifies when its path ends in /load.php):
+//   modules=startup                  -> load.php[startup]
+//   single module, only=styles       -> load.php[styles:<module>]
+//                                       (e.g. load.php[styles:site.styles])
+//   single module, otherwise         -> load.php[scripts:<module>]
+//   multi-module, only=styles        -> load.php[styles]
+//                                       (the top-queue stylesheet batch)
+//   multi-module, only=scripts       -> load.php[scripts:<first>]
+//                                       where <first> is the first name in
+//                                       the sorted expanded modules list
+//                                       (e.g. the base bundle
+//                                       jquery|mediawiki.base becomes
+//                                       load.php[scripts:jquery]); raw
+//                                       script batches are disambiguated
+//                                       this way so they never collide
+//                                       with the general bundle below
+//   multi-module, no only param      -> load.php[scripts]
+//                                       (the big general batch of packaged
+//                                       mw.loader.impl modules)
+//
+// Several combined (no `only`) batches on one page — the main queue
+// plus lazy-loaded batches — intentionally share load.php[scripts]:
+// they are the same kind of payload and label-keyed dashboards want
+// them summed. Exact identity always remains in the untouched url
+// field; the label is additive.
+const RESOURCE_LOADER_PATH = /\/load\.php$/;
+
+// Port of MediaWiki's ResourceLoader::expandModuleNames: groups are
+// pipe-separated; within a group, "foo.bar,baz" expands to foo.bar and
+// foo.baz (the packer only groups modules sharing the prefix before
+// their last dot, so suffixes never contain dots).
+function expandModuleNames(packed) {
+  const names = [];
+  for (const group of packed.split('|')) {
+    if (!group.includes(',')) {
+      if (group) names.push(group);
+      continue;
+    }
+    const pos = group.lastIndexOf('.');
+    if (pos === -1) {
+      names.push(...group.split(','));
+      continue;
+    }
+    const prefix = group.slice(0, pos);
+    for (const suffix of group.slice(pos + 1).split(',')) {
+      names.push(`${prefix}.${suffix}`);
+    }
+  }
+  return names.toSorted();
+}
+
+export function labelForUrl(url) {
+  if (typeof url !== 'string' || !url.includes('load.php')) return;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (!RESOURCE_LOADER_PATH.test(parsed.pathname)) return;
+
+  const only = parsed.searchParams.get('only');
+  const modules = expandModuleNames(parsed.searchParams.get('modules') || '');
+  if (modules.length === 1 && modules[0] === 'startup') {
+    return 'load.php[startup]';
+  }
+  const kind = only === 'styles' ? 'styles' : 'scripts';
+  if (modules.length === 1) {
+    return `load.php[${kind}:${modules[0]}]`;
+  }
+  if (modules.length > 1 && only === 'scripts') {
+    return `load.php[scripts:${modules[0]}]`;
+  }
+  return `load.php[${kind}]`;
+}
+
 // Intersect the per-byte coverage flags (painted, a Uint8Array where 1 =
 // used) with the module boundaries in the bundle source. Module i spans
 // [start_i, start_i+1); the last module ends at the end of the source.

--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -7,7 +7,19 @@ import {
   computeBlockingTime,
   computeDomainBreakdown
 } from './trace/index.js';
+import { labelForUrl } from './mediawikiResourceLoader.js';
 const log = getLogger('browsertime.chrome.cpu');
+
+// Additive label field for MediaWiki ResourceLoader URLs so per-bundle
+// time series survive the weekly version= churn. The url field is
+// untouched (browsertime.json shape is a public contract); non-MediaWiki
+// URLs get no label and the output stays byte-identical to before.
+function addResourceLoaderLabels(entries, urlField = 'url', field = 'label') {
+  for (const entry of entries) {
+    const label = labelForUrl(entry[urlField]);
+    if (label) entry[field] = label;
+  }
+}
 
 function round(number_, decimals = 3) {
   const pow = Math.pow(10, decimals);
@@ -120,6 +132,20 @@ export async function parseCPUTrace(tracelog, url) {
       domains = computeDomainBreakdown(tracelog, url);
     } catch (error) {
       log.debug('computeDomainBreakdown failed: %s', error.message);
+    }
+
+    addResourceLoaderLabels(cleanedUrls);
+    addResourceLoaderLabels(scriptCosts);
+    addResourceLoaderLabels(
+      forcedReflows,
+      'triggeredByUrl',
+      'triggeredByUrlLabel'
+    );
+    if (blocking) {
+      addResourceLoaderLabels(blocking.urls);
+      if (blocking.beforeLargestContentfulPaint) {
+        addResourceLoaderLabels(blocking.beforeLargestContentfulPaint.urls);
+      }
     }
 
     log.debug('Chrome trace log finished parsed and sorted.');

--- a/test/unittests/mediawikiResourceLoaderTest.js
+++ b/test/unittests/mediawikiResourceLoaderTest.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import { paintJsCoverage } from '../../lib/chrome/coverage.js';
 import {
   isResourceLoaderBundle,
+  labelForUrl,
   resourceLoaderModuleCoverage
 } from '../../lib/chrome/mediawikiResourceLoader.js';
 
@@ -114,6 +115,91 @@ test('bundle without a preamble gets no preamble bucket', t => {
 test('source without delimiters returns no modules', t => {
   const source = 'var a = 1; console.log(a);';
   t.is(resourceLoaderModuleCoverage(source, allUsed(source.length)), undefined);
+});
+
+const loadPhp = 'https://en.wikipedia.org/w/load.php';
+
+test('labels the startup request', t => {
+  t.is(
+    labelForUrl(`${loadPhp}?lang=en&modules=startup&only=scripts&raw=1`),
+    'load.php[startup]'
+  );
+});
+
+test('labels the top-queue styles batch', t => {
+  t.is(
+    labelForUrl(
+      `${loadPhp}?lang=en&modules=ext.cite.styles%7Cskins.vector.styles&only=styles&skin=vector-2022`
+    ),
+    'load.php[styles]'
+  );
+});
+
+test('labels a single-module styles request with the module name', t => {
+  t.is(
+    labelForUrl(`${loadPhp}?lang=en&modules=site.styles&only=styles`),
+    'load.php[styles:site.styles]'
+  );
+});
+
+test('labels the big general bundle', t => {
+  t.is(
+    labelForUrl(
+      `${loadPhp}?lang=en&modules=ext.centralNotice.startUp%2CchoiceData%7Cext.echo.centralauth%7Cmediawiki.page.ready&skin=vector-2022&version=1u4qz`
+    ),
+    'load.php[scripts]'
+  );
+});
+
+test('version, lang and skin parameters never affect the label', t => {
+  const before = labelForUrl(
+    `${loadPhp}?lang=en&modules=jquery%7Cmediawiki.base&only=scripts&skin=vector-2022&version=aaaaa`
+  );
+  const after = labelForUrl(
+    `${loadPhp}?lang=sv&modules=jquery%7Cmediawiki.base&only=scripts&skin=minerva&version=bbbbb`
+  );
+  t.is(before, after);
+  t.is(before, 'load.php[scripts:jquery]');
+});
+
+test('raw script batches are disambiguated from the general bundle', t => {
+  const base = labelForUrl(
+    `${loadPhp}?lang=en&modules=jquery%7Cmediawiki.base&only=scripts`
+  );
+  const general = labelForUrl(
+    `${loadPhp}?lang=en&modules=jquery%7Cmediawiki.base&skin=vector-2022`
+  );
+  t.is(base, 'load.php[scripts:jquery]');
+  t.is(general, 'load.php[scripts]');
+  t.not(base, general);
+});
+
+test('expands packed module lists when picking the first sorted name', t => {
+  t.is(
+    labelForUrl(
+      `${loadPhp}?modules=mediawiki.util%2Cbase%7Cext.popups.main&only=scripts`
+    ),
+    'load.php[scripts:ext.popups.main]'
+  );
+});
+
+test('single-module script request is labeled with the module name', t => {
+  t.is(
+    labelForUrl(`${loadPhp}?modules=ext.popups.main&skin=vector-2022`),
+    'load.php[scripts:ext.popups.main]'
+  );
+});
+
+test('non-ResourceLoader URLs get no label', t => {
+  t.is(labelForUrl('https://example.com/a.js'), undefined);
+  t.is(labelForUrl('https://example.com/load.php/other'), undefined);
+  t.is(
+    labelForUrl('https://example.com/download.php?modules=startup'),
+    undefined
+  );
+  t.is(labelForUrl('unknown'), undefined);
+  t.is(labelForUrl(''), undefined);
+  t.is(labelForUrl(), undefined);
 });
 
 test('delimiter inside a string literal mid-line is not a module', t => {

--- a/types/chrome/mediawikiResourceLoader.d.ts
+++ b/types/chrome/mediawikiResourceLoader.d.ts
@@ -1,0 +1,4 @@
+export function isResourceLoaderBundle(url: any, source: any): any;
+export function labelForUrl(url: any): string;
+export function resourceLoaderModuleCoverage(source: any, painted: any): any;
+//# sourceMappingURL=mediawikiResourceLoader.d.ts.map

--- a/types/chrome/mediawikiResourceLoader.d.ts.map
+++ b/types/chrome/mediawikiResourceLoader.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"mediawikiResourceLoader.d.ts","sourceRoot":"","sources":["../../lib/chrome/mediawikiResourceLoader.js"],"names":[],"mappings":"AAmBA,mEAEC;AA6DD,8CAuBC;AAOD,6EAmCC"}

--- a/types/chrome/parseCpuTrace.d.ts.map
+++ b/types/chrome/parseCpuTrace.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"parseCpuTrace.d.ts","sourceRoot":"","sources":["../../lib/chrome/parseCpuTrace.js"],"names":[],"mappings":"AAoBA,oEA2HC"}
+{"version":3,"file":"parseCpuTrace.d.ts","sourceRoot":"","sources":["../../lib/chrome/parseCpuTrace.js"],"names":[],"mappings":"AAgCA,oEAyIC"}


### PR DESCRIPTION
On MediaWiki sites every URL-keyed metric (cpu.urls, cpu.blocking, scriptCosts, forcedReflows, coverage files) keys on load.php URLs that are over a thousand characters long and embed a version= parameter that changes on every deploy. A dashboard trending a per-bundle series gets a brand-new key every week, so long-term trends per bundle are impossible to follow.

Each ResourceLoader request now also carries a short deterministic label (load.php[startup], load.php[styles], load.php[scripts], plus a module-name suffix for single-module and raw script batches) derived only from the request's role — version, lang and skin never affect it. The field is purely additive: the url field is untouched and non-MediaWiki sites produce byte-identical output. All MediaWiki-specific logic stays isolated in lib/chrome/mediawikiResourceLoader.js.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ib655d37d9b11067d957024415d542a85c894af61