### PR TITLE
Add frame stability metrics from the Chrome trace

### DIFF
--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -5,7 +5,8 @@ import {
   computeForcedReflows,
   computeNonCompositedAnimations,
   computeBlockingTime,
-  computeDomainBreakdown
+  computeDomainBreakdown,
+  computeFrameStability
 } from './trace/index.js';
 import { labelForUrl } from './mediawikiResourceLoader.js';
 const log = getLogger('browsertime.chrome.cpu');
@@ -119,7 +120,7 @@ export async function parseCPUTrace(tracelog, url) {
     } catch (error) {
       log.debug('computeNonCompositedAnimations failed: %s', error.message);
     }
-    // These two return objects with summary totals, so on failure the
+    // These return objects with summary totals, so on failure the
     // key is omitted instead of publishing a misleading zero total.
     let blocking;
     try {
@@ -132,6 +133,12 @@ export async function parseCPUTrace(tracelog, url) {
       domains = computeDomainBreakdown(tracelog, url);
     } catch (error) {
       log.debug('computeDomainBreakdown failed: %s', error.message);
+    }
+    let frames;
+    try {
+      frames = computeFrameStability(tracelog);
+    } catch (error) {
+      log.debug('computeFrameStability failed: %s', error.message);
     }
 
     addResourceLoaderLabels(cleanedUrls);
@@ -157,7 +164,8 @@ export async function parseCPUTrace(tracelog, url) {
       forcedReflows,
       nonCompositedAnimations,
       ...(blocking ? { blocking } : {}),
-      ...(domains ? { domains } : {})
+      ...(domains ? { domains } : {}),
+      ...(frames ? { frames } : {})
     };
   } catch (error) {
     log.error(

--- a/lib/chrome/trace/frame-stability.js
+++ b/lib/chrome/trace/frame-stability.js
@@ -1,0 +1,135 @@
+/**
+ * Frame stability — how smoothly the compositor produced frames
+ * during the traced window. Jank (dropped frames, long gaps between
+ * visual updates) is invisible in load metrics; this surfaces it
+ * from the trace browsertime already records.
+ *
+ * Event shapes sampled from Chrome 150.0.7871.115 with the default
+ * browsertime trace categories. The frame pipeline shows up as
+ * `PipelineReporter` async events (cat
+ * `cc,benchmark,disabled-by-default-devtools.timeline.frame`), one
+ * b/e pair per frame attempt, paired via `id2.local` within a
+ * process. The `b` event carries `args.frame_reporter` with the
+ * final outcome: `state` (STATE_PRESENTED_ALL /
+ * STATE_PRESENTED_PARTIAL / STATE_DROPPED / STATE_NO_UPDATE_DESIRED),
+ * `affects_smoothness`, and `frame_sequence`. The `e` timestamp is
+ * when the frame reached the screen (presentation) for presented
+ * frames. The same frame_sequence can have several reporters
+ * (forked / main + impl), so outcomes are merged per sequence. The
+ * legacy instant events (BeginFrame, DrawFrame, DroppedFrame) are
+ * still emitted and were used to cross-check: DroppedFrame instants
+ * match STATE_DROPPED reporters with affects_smoothness=true.
+ *
+ * Only STATE_DROPPED frames flagged `affects_smoothness` are counted
+ * as dropped — Chrome also marks no-damage idle frames STATE_DROPPED
+ * and counting those would alarm on every static page.
+ *
+ * Returns: { presented, partial, dropped, effectiveFps, longestGap }
+ *   presented    — frames that reached the screen after
+ *                  navigationStart
+ *   partial      — subset of presented where the compositor
+ *                  presented without the main-thread update
+ *                  (STATE_PRESENTED_PARTIAL only)
+ *   dropped      — frames Chrome flags as dropped AND affecting
+ *                  smoothness (its own jank signal)
+ *   effectiveFps — presented frames over the first→last
+ *                  presentation span; omitted with <2 presentations
+ *   longestGap   — { duration, startTime } in ms relative to
+ *                  navigationStart, the longest time between two
+ *                  consecutive presented frames. On mostly-static
+ *                  pages this includes idle time (nothing to draw),
+ *                  so read it as "longest time between visual
+ *                  updates", not proof of jank; omitted with <2
+ *                  presentations
+ */
+
+import { computeTraceOfTab } from './trace-of-tab.js';
+
+const PRESENTED_STATES = new Set([
+  'STATE_PRESENTED_ALL',
+  'STATE_PRESENTED_PARTIAL'
+]);
+
+function round1(number_) {
+  return Math.round(number_ * 10) / 10;
+}
+
+export function computeFrameStability(trace) {
+  const { mainFrameIds, timestamps } = computeTraceOfTab(trace);
+  const navStart = timestamps.navigationStart;
+
+  const open = new Map();
+  const bySequence = new Map();
+  for (const event of trace.traceEvents) {
+    if (event.name !== 'PipelineReporter' || event.pid !== mainFrameIds.pid)
+      continue;
+    const id = (event.id2 && event.id2.local) || event.id;
+    if (event.ph === 'b') {
+      open.set(id, event);
+    } else if (event.ph === 'e') {
+      const begin = open.get(id);
+      if (!begin) continue;
+      open.delete(id);
+      if (event.ts < navStart) continue;
+      const reporter = (begin.args && begin.args.frame_reporter) || {};
+      if (reporter.frame_sequence === undefined) continue;
+      let frame = bySequence.get(reporter.frame_sequence);
+      if (!frame) {
+        frame = { presentedAll: false, presentedPartial: false };
+        bySequence.set(reporter.frame_sequence, frame);
+      }
+      if (PRESENTED_STATES.has(reporter.state)) {
+        if (reporter.state === 'STATE_PRESENTED_ALL') frame.presentedAll = true;
+        else frame.presentedPartial = true;
+        frame.presentationTs = Math.min(
+          frame.presentationTs ?? Number.POSITIVE_INFINITY,
+          event.ts
+        );
+      } else if (
+        reporter.state === 'STATE_DROPPED' &&
+        reporter.affects_smoothness === true
+      ) {
+        frame.dropped = true;
+      }
+    }
+  }
+
+  let presented = 0;
+  let partial = 0;
+  let dropped = 0;
+  const presentationTimes = [];
+  for (const frame of bySequence.values()) {
+    if (frame.presentedAll || frame.presentedPartial) {
+      presented++;
+      if (!frame.presentedAll) partial++;
+      presentationTimes.push(frame.presentationTs);
+    } else if (frame.dropped) {
+      dropped++;
+    }
+  }
+  presentationTimes.sort((a, b) => a - b);
+
+  let effectiveFps;
+  let longestGap;
+  if (presentationTimes.length >= 2) {
+    const spanSeconds = (presentationTimes.at(-1) - presentationTimes[0]) / 1e6;
+    if (spanSeconds > 0) {
+      effectiveFps = round1((presentationTimes.length - 1) / spanSeconds);
+    }
+    let worst = 0;
+    let worstStart = presentationTimes[0];
+    for (let index = 1; index < presentationTimes.length; index++) {
+      const gap = presentationTimes[index] - presentationTimes[index - 1];
+      if (gap > worst) {
+        worst = gap;
+        worstStart = presentationTimes[index - 1];
+      }
+    }
+    longestGap = {
+      duration: round1(worst / 1000),
+      startTime: round1((worstStart - navStart) / 1000)
+    };
+  }
+
+  return { presented, partial, dropped, effectiveFps, longestGap };
+}

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -15,6 +15,7 @@ import { compute } from './main-thread-tasks.js';
 export { computeScriptCosts } from './script-costs.js';
 export { computeForcedReflows } from './forced-reflows.js';
 export { computeNonCompositedAnimations } from './non-composited-animations.js';
+export { computeFrameStability } from './frame-stability.js';
 export { computeBlockingTime } from './blocking-time.js';
 export { computeDomainBreakdown } from './domain-breakdown.js';
 

--- a/test/unittests/frameStabilityTest.js
+++ b/test/unittests/frameStabilityTest.js
@@ -1,0 +1,185 @@
+import test from 'ava';
+import { computeFrameStability } from '../../lib/chrome/trace/frame-stability.js';
+
+const PID = 1;
+const TID = 2;
+const NAV_START = 10_000;
+
+function makeTrace(pipelineEvents) {
+  return {
+    traceEvents: [
+      {
+        name: 'TracingStartedInBrowser',
+        cat: 'disabled-by-default-devtools.timeline',
+        ph: 'I',
+        pid: 9,
+        tid: 9,
+        ts: 1000,
+        args: { data: { frames: [{ frame: 'F1', processId: PID }] } }
+      },
+      {
+        name: 'thread_name',
+        cat: '__metadata',
+        ph: 'M',
+        pid: PID,
+        tid: TID,
+        ts: 0,
+        args: { name: 'CrRendererMain' }
+      },
+      {
+        name: 'navigationStart',
+        cat: 'blink.user_timing',
+        ph: 'R',
+        pid: PID,
+        tid: TID,
+        ts: NAV_START,
+        args: {
+          frame: 'F1',
+          data: {
+            documentLoaderURL: 'https://example.com',
+            isLoadingMainFrame: true
+          }
+        }
+      },
+      ...pipelineEvents
+    ]
+  };
+}
+
+function reporter(
+  id,
+  state,
+  { sequence, beginTs, endTs, affectsSmoothness = false, pid = PID } = {}
+) {
+  const cat = 'cc,benchmark,disabled-by-default-devtools.timeline.frame';
+  return [
+    {
+      name: 'PipelineReporter',
+      cat,
+      ph: 'b',
+      pid,
+      tid: 3,
+      ts: beginTs,
+      id2: { local: id },
+      args: {
+        frame_reporter: {
+          frame_sequence: sequence,
+          state,
+          affects_smoothness: affectsSmoothness
+        }
+      }
+    },
+    {
+      name: 'PipelineReporter',
+      cat,
+      ph: 'e',
+      pid,
+      tid: 3,
+      ts: endTs,
+      id2: { local: id },
+      args: {}
+    }
+  ];
+}
+
+test('counts presented frames, fps and the longest gap', t => {
+  const trace = makeTrace([
+    ...reporter('0x1', 'STATE_PRESENTED_ALL', {
+      sequence: 1,
+      beginTs: 100_000,
+      endTs: 110_000
+    }),
+    ...reporter('0x2', 'STATE_PRESENTED_ALL', {
+      sequence: 2,
+      beginTs: 116_000,
+      endTs: 126_667
+    }),
+    ...reporter('0x3', 'STATE_PRESENTED_ALL', {
+      sequence: 3,
+      beginTs: 200_000,
+      endTs: 210_000
+    })
+  ]);
+  const result = computeFrameStability(trace);
+  t.is(result.presented, 3);
+  t.is(result.partial, 0);
+  t.is(result.dropped, 0);
+  t.is(result.effectiveFps, 20);
+  t.deepEqual(result.longestGap, { duration: 83.3, startTime: 116.7 });
+});
+
+test('only dropped frames affecting smoothness count as dropped', t => {
+  const trace = makeTrace([
+    ...reporter('0x1', 'STATE_DROPPED', {
+      sequence: 1,
+      beginTs: 100_000,
+      endTs: 110_000,
+      affectsSmoothness: true
+    }),
+    ...reporter('0x2', 'STATE_DROPPED', {
+      sequence: 2,
+      beginTs: 116_000,
+      endTs: 126_000
+    }),
+    ...reporter('0x3', 'STATE_NO_UPDATE_DESIRED', {
+      sequence: 3,
+      beginTs: 132_000,
+      endTs: 142_000
+    })
+  ]);
+  const result = computeFrameStability(trace);
+  t.is(result.presented, 0);
+  t.is(result.dropped, 1);
+  t.is(result.effectiveFps, undefined);
+  t.is(result.longestGap, undefined);
+});
+
+test('forked reporters for the same frame sequence are merged', t => {
+  const trace = makeTrace([
+    ...reporter('0x1', 'STATE_DROPPED', {
+      sequence: 1,
+      beginTs: 100_000,
+      endTs: 108_000,
+      affectsSmoothness: true
+    }),
+    ...reporter('0x2', 'STATE_PRESENTED_ALL', {
+      sequence: 1,
+      beginTs: 100_000,
+      endTs: 110_000
+    }),
+    ...reporter('0x3', 'STATE_PRESENTED_PARTIAL', {
+      sequence: 2,
+      beginTs: 116_000,
+      endTs: 126_000
+    })
+  ]);
+  const result = computeFrameStability(trace);
+  t.is(result.presented, 2);
+  t.is(result.partial, 1);
+  t.is(result.dropped, 0);
+});
+
+test('frames presented before navigationStart or in other processes are ignored', t => {
+  const trace = makeTrace([
+    ...reporter('0x1', 'STATE_PRESENTED_ALL', {
+      sequence: 1,
+      beginTs: 2000,
+      endTs: 9000
+    }),
+    ...reporter('0x2', 'STATE_PRESENTED_ALL', {
+      sequence: 2,
+      beginTs: 100_000,
+      endTs: 110_000,
+      pid: 9
+    }),
+    ...reporter('0x3', 'STATE_PRESENTED_ALL', {
+      sequence: 3,
+      beginTs: 100_000,
+      endTs: 110_000
+    })
+  ]);
+  const result = computeFrameStability(trace);
+  t.is(result.presented, 1);
+  t.is(result.effectiveFps, undefined);
+  t.is(result.longestGap, undefined);
+});

--- a/types/chrome/parseCpuTrace.d.ts.map
+++ b/types/chrome/parseCpuTrace.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"parseCpuTrace.d.ts","sourceRoot":"","sources":["../../lib/chrome/parseCpuTrace.js"],"names":[],"mappings":"AAgCA,oEAyIC"}
+{"version":3,"file":"parseCpuTrace.d.ts","sourceRoot":"","sources":["../../lib/chrome/parseCpuTrace.js"],"names":[],"mappings":"AAiCA,oEAgJC"}

--- a/types/chrome/trace/frame-stability.d.ts
+++ b/types/chrome/trace/frame-stability.d.ts
@@ -1,0 +1,11 @@
+export function computeFrameStability(trace: any): {
+    presented: number;
+    partial: number;
+    dropped: number;
+    effectiveFps: number;
+    longestGap: {
+        duration: number;
+        startTime: number;
+    };
+};
+//# sourceMappingURL=frame-stability.d.ts.map

--- a/types/chrome/trace/frame-stability.d.ts.map
+++ b/types/chrome/trace/frame-stability.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"frame-stability.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/frame-stability.js"],"names":[],"mappings":"AAwDA;;;;;;;;;EA8EC"}

--- a/types/chrome/trace/index.d.ts
+++ b/types/chrome/trace/index.d.ts
@@ -16,6 +16,7 @@ export function computeMainThreadTasks(trace: any, options?: {
 export { computeScriptCosts } from "./script-costs.js";
 export { computeForcedReflows } from "./forced-reflows.js";
 export { computeNonCompositedAnimations } from "./non-composited-animations.js";
+export { computeFrameStability } from "./frame-stability.js";
 export { computeBlockingTime } from "./blocking-time.js";
 export { computeDomainBreakdown } from "./domain-breakdown.js";
 //# sourceMappingURL=index.d.ts.map

--- a/types/chrome/trace/index.d.ts.map
+++ b/types/chrome/trace/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/index.js"],"names":[],"mappings":"AAoBA;;;;;;;;;;;GAWG;AACH,6DAJG;IAA0B,OAAO,GAAzB,OAAO;CAEf,GAAU,KAAK,KAAQ,CAYzB"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/index.js"],"names":[],"mappings":"AAqBA;;;;;;;;;;;GAWG;AACH,6DAJG;IAA0B,OAAO,GAAzB,OAAO;CAEf,GAAU,KAAK,KAAQ,CAYzB"}


### PR DESCRIPTION
Jank and smoothness regressions are invisible in load metrics: a page can hold its LCP while starting to drop frames. The frame events were already in the trace (disabled-by-default-devtools.timeline.frame) but never parsed. The new cpu.frames key reports presented/partial/dropped frame counts, effective FPS and the longest gap between presented frames, based on Chrome's PipelineReporter events — counting only drops Chrome itself flags as smoothness-affecting, since raw dropped-frame counts are dominated by harmless no-damage frames. Additive, Chrome/Edge only.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I1908504c3b3253cdc4fb0e6dcdeb94741229e6bd