### PR TITLE
Stamp stable labels on cpu.moduleCosts bundles

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -8,6 +8,7 @@ const { Type } = logging;
 import { longTaskMetrics } from '../longTaskMetrics.js';
 import { parseCPUTrace } from '../parseCpuTrace.js';
 import { computeModuleCosts } from '../trace/module-costs.js';
+import { labelForUrl } from '../mediawikiResourceLoader.js';
 import { getHar } from '../har.js';
 import { getEmptyHAR, mergeHars } from '../../support/har/index.js';
 import { toArray } from '../../support/util.js';
@@ -436,6 +437,12 @@ export class Chromium {
             this.resourceLoaderBundles
           );
           if (moduleCosts.length > 0) {
+            for (const bundle of moduleCosts) {
+              const label = labelForUrl(bundle.url);
+              if (label) {
+                bundle.label = label;
+              }
+            }
             cpu.moduleCosts = moduleCosts;
           }
         } catch (error) {


### PR DESCRIPTION
Every other URL-keyed surface (cpu.urls, cpu.blocking, scriptCosts, coverage files) carries the deploy-stable ResourceLoader label, but the per-module CPU bundles did not, so consumers had to rebuild display names by cross-referencing cpu.urls for the same URL. The bundles now get the same additive label field from the same labeler.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Iced4e721c511c8fa7426589d636b285f2edb4202