### PR TITLE
Keep measured runs unaffected by --enableProfileRun

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -85,6 +85,15 @@ async function run(urls, options) {
       }
     }
 
+    // To the CLI, enableProfileRun means "make one extra profile run",
+    // but inside the engine it means "this run IS the profile run"
+    // (extra-run trace naming, suppressed result log line). Keep it
+    // away from the measured runs and hand it back to the extra
+    // engine below, so measured traces keep their trace-N.json names
+    // and the profile trace cannot overwrite the first iteration's.
+    const makeProfileRun = options.enableProfileRun;
+    options.enableProfileRun = false;
+
     let engine = new Engine(options);
 
     const scriptCategories = await allScriptCategories();
@@ -159,10 +168,11 @@ async function run(urls, options) {
       }
     }
 
-    if (options.enableProfileRun || options.enableVideoRun) {
+    if (makeProfileRun || options.enableVideoRun) {
       log.info('Make one extra run to collect trace/video information');
       options.iterations = 1;
-      if (options.enableProfileRun) {
+      if (makeProfileRun) {
+        options.enableProfileRun = true;
         if (options.browser === 'firefox') {
           options.firefox.geckoProfiler = true;
           options.firefox.collectMozLog = true;


### PR DESCRIPTION
To the CLI, enableProfileRun means "make one extra profile run", but inside the engine the same flag means "this run IS the profile run": it renames traces to trace-N-extra-run.json and suppresses the result log line. Because the flag leaked into the measured runs' engine, combining --cpu with --enableProfileRun misnamed every measured trace, silently overwrote the first iteration's trace with the profile trace (identical filenames), and hid the result summary. The flag is now cleared for the measured runs and set only for the extra engine, so measured traces keep their names and both trace sets survive side by side.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I817c3a7b664cf08578560fa7379b14781a1cb67e