### PR TITLE
Attribute inline CSS coverage to MediaWiki TemplateStyles

### DIFF
--- a/lib/chrome/coverage.js
+++ b/lib/chrome/coverage.js
@@ -2,6 +2,7 @@ import { getLogger } from '@sitespeed.io/log';
 
 import {
   isResourceLoaderBundle,
+  labelForStyleAttributes,
   labelForUrl,
   resourceLoaderModuleCoverage,
   resourceLoaderLocationResolver
@@ -95,20 +96,21 @@ export class Coverage {
   constructor(cdp) {
     this.rawClient = cdp.getRawClient();
     this.started = false;
-    this.styleSheetUrls = new Map();
+    this.styleSheets = new Map();
     this.disposeStyleSheetListener = undefined;
   }
 
   async start() {
     const client = this.rawClient;
-    this.styleSheetUrls.clear();
+    this.styleSheets.clear();
     this.disposeStyleSheetListener = client.CSS.styleSheetAdded(
       ({ header }) => {
         if (header && header.styleSheetId) {
-          this.styleSheetUrls.set(
-            header.styleSheetId,
-            header.sourceURL || header.sourceMapURL || ''
-          );
+          this.styleSheets.set(header.styleSheetId, {
+            url: header.sourceURL || header.sourceMapURL || '',
+            ownerNode: header.ownerNode,
+            isInline: header.isInline
+          });
         }
       }
     );
@@ -237,6 +239,11 @@ export class Coverage {
       list.push(u);
       byStylesheet.set(u.styleSheetId, list);
     }
+    // Inline stylesheets are only worth attributing on MediaWiki pages
+    // (TemplateStyles); ordinary pages skip the extra DOM roundtrips.
+    const mediaWiki = [...this.styleSheets.values()].some(sheet =>
+      labelForUrl(sheet.url)
+    );
     const files = [];
     for (const [styleSheetId, usages] of byStylesheet) {
       let text;
@@ -251,7 +258,8 @@ export class Coverage {
 
       const usedBytes = unionLength(usages.filter(u => u.used));
       const unusedBytes = totalBytes - usedBytes;
-      const url = this.styleSheetUrls.get(styleSheetId) || '';
+      const sheet = this.styleSheets.get(styleSheetId) || {};
+      const url = sheet.url || '';
       const file = {
         url,
         styleSheetId,
@@ -260,10 +268,35 @@ export class Coverage {
         unusedBytes,
         unusedPercent: (unusedBytes / totalBytes) * 100
       };
-      const label = labelForUrl(url);
+      let label = labelForUrl(url);
+      if (!label && mediaWiki) {
+        label = await this.#inlineStyleLabel(sheet);
+      }
       if (label) file.label = label;
       files.push(file);
     }
     return { ...summarize(files), files };
+  }
+
+  // Inline stylesheets have no URL of their own: parser-inserted
+  // <style> sheets report the document URL as sourceURL (isInline is
+  // true) and JS-injected <style> sheets report an empty string. The
+  // owning <style> element's attributes are the only identity they
+  // carry — MediaWiki TemplateStyles stamps data-mw-deduplicate there —
+  // so resolve them via the DOM domain. header.ownerNode is a backend
+  // node id, which DOM.describeNode accepts directly.
+  async #inlineStyleLabel({ ownerNode, isInline, url }) {
+    if (ownerNode === undefined || (!isInline && url)) return;
+    try {
+      const { node } = await this.rawClient.DOM.describeNode({
+        backendNodeId: ownerNode
+      });
+      return labelForStyleAttributes(node && node.attributes);
+    } catch (error) {
+      log.debug(
+        'Could not resolve inline stylesheet owner node: %s',
+        error.message
+      );
+    }
   }
 }

--- a/lib/chrome/mediawikiResourceLoader.js
+++ b/lib/chrome/mediawikiResourceLoader.js
@@ -105,6 +105,30 @@ export function labelForUrl(url) {
   return `load.php[${kind}]`;
 }
 
+// MediaWiki-specific: TemplateStyles. Each templated style block is
+// emitted as <style data-mw-deduplicate="TemplateStyles:rNNNNNNN">, so
+// the deduplication key is the only stable, human-actionable identity
+// an inline stylesheet has — it points straight at the template
+// revision that ships the CSS. Keys may carry a /suffix when the same
+// revision is re-emitted under a different wrapper class (observed on
+// en.wikipedia.org: "TemplateStyles:r1349637415/mw-parser-output/.tmulti");
+// the full value is kept as the label. `attributes` is the flat
+// [name, value, name, value, ...] array that CDP DOM.describeNode
+// returns for the owning <style> element.
+const TEMPLATE_STYLES_KEY = /^TemplateStyles:r\d+(\/|$)/;
+
+export function labelForStyleAttributes(attributes) {
+  if (!Array.isArray(attributes)) return;
+  for (let index = 0; index + 1 < attributes.length; index += 2) {
+    if (
+      attributes[index] === 'data-mw-deduplicate' &&
+      TEMPLATE_STYLES_KEY.test(attributes[index + 1])
+    ) {
+      return attributes[index + 1];
+    }
+  }
+}
+
 function moduleBoundaries(source) {
   const boundaries = [];
   for (const match of source.matchAll(MODULE_DELIMITER)) {

--- a/test/unittests/mediawikiResourceLoaderTest.js
+++ b/test/unittests/mediawikiResourceLoaderTest.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import { paintJsCoverage } from '../../lib/chrome/coverage.js';
 import {
   isResourceLoaderBundle,
+  labelForStyleAttributes,
   labelForUrl,
   resourceLoaderModuleCoverage,
   resourceLoaderLocationResolver
@@ -212,6 +213,56 @@ test('delimiter inside a string literal mid-line is not a module', t => {
     modules.map(m => m.name),
     ['module.one']
   );
+});
+
+test('TemplateStyles dedup key labels an inline stylesheet', t => {
+  t.is(
+    labelForStyleAttributes([
+      'data-mw-deduplicate',
+      'TemplateStyles:r981673959'
+    ]),
+    'TemplateStyles:r981673959'
+  );
+});
+
+test('suffixed TemplateStyles keys keep the full value as label', t => {
+  t.is(
+    labelForStyleAttributes([
+      'data-mw-deduplicate',
+      'TemplateStyles:r1349637415/mw-parser-output/.tmulti'
+    ]),
+    'TemplateStyles:r1349637415/mw-parser-output/.tmulti'
+  );
+});
+
+test('dedup key is found among other attributes', t => {
+  t.is(
+    labelForStyleAttributes([
+      'typeof',
+      'mw:Extension/templatestyles',
+      'data-mw-deduplicate',
+      'TemplateStyles:r1043282317',
+      'about',
+      '#mwt42'
+    ]),
+    'TemplateStyles:r1043282317'
+  );
+});
+
+test('non-TemplateStyles attributes get no style label', t => {
+  t.is(labelForStyleAttributes([]), undefined);
+  t.is(labelForStyleAttributes(['class', 'my-style']), undefined);
+  t.is(labelForStyleAttributes(['data-mw-deduplicate', 'other:r1']), undefined);
+  t.is(
+    labelForStyleAttributes(['data-mw-deduplicate', 'TemplateStyles:rabc']),
+    undefined
+  );
+  t.is(
+    labelForStyleAttributes(['data-mw-deduplicate', 'TemplateStyles:r123x']),
+    undefined
+  );
+  t.is(labelForStyleAttributes(), undefined);
+  t.is(labelForStyleAttributes('TemplateStyles:r1'), undefined);
 });
 
 // Location resolver: maps a 1-based line/column (as carried by Chrome

--- a/types/chrome/mediawikiResourceLoader.d.ts
+++ b/types/chrome/mediawikiResourceLoader.d.ts
@@ -1,5 +1,6 @@
 export function isResourceLoaderBundle(url: any, source: any): any;
 export function labelForUrl(url: any): string;
+export function labelForStyleAttributes(attributes: any): any;
 export function resourceLoaderLocationResolver(source: any): {
     resolve(lineNumber: any, columnNumber: any): {
         name: any;

--- a/types/chrome/mediawikiResourceLoader.d.ts.map
+++ b/types/chrome/mediawikiResourceLoader.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"mediawikiResourceLoader.d.ts","sourceRoot":"","sources":["../../lib/chrome/mediawikiResourceLoader.js"],"names":[],"mappings":"AAmBA,mEAEC;AA6DD,8CAuBC;AAwBD;;;;;EAkCC;AAOD,6EA4BC"}
+{"version":3,"file":"mediawikiResourceLoader.d.ts","sourceRoot":"","sources":["../../lib/chrome/mediawikiResourceLoader.js"],"names":[],"mappings":"AAmBA,mEAEC;AA6DD,8CAuBC;AAcD,8DAUC;AAwBD;;;;;EAkCC;AAOD,6EA4BC"}


### PR DESCRIPTION
CSS coverage keyed inline stylesheets by whatever sourceURL Chrome reported: parser-inserted style tags carry the document's own URL and JS-injected ones an empty string, so on Wikipedia the report collapsed into two anonymous buckets and nobody could see which template ships the dead CSS. The owning style element's attributes are the only real identity those sheets have — MediaWiki stamps data-mw-deduplicate="TemplateStyles:rNNNNNNN" there, which points straight at the template revision to fix.

Coverage now resolves the owner node's attributes over CDP at collect time and adds an additive label field (mirroring the JS entries) when the sheet is TemplateStyles. Resolution only happens on pages that loaded ResourceLoader stylesheets, so ordinary pages pay no extra CDP roundtrips; url and styleSheetId are untouched. JS-injected ResourceLoader style batches carry no attributes and stay unlabeled.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Idaf1e42e222becf1ceaa19910457626d41a227ea