### PR TITLE
Require Node.js 22

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -51,7 +51,7 @@ function hasbin(bin) {
 function validateInput(argv) {
   // Check NodeJS major version
   const fullVersion = process.versions.node;
-  const minVersion = 20;
+  const minVersion = 22;
   const majorVersion = fullVersion.split('.')[0];
   if (majorVersion < minVersion) {
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "jimp": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "5.9.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
Node 20 reaches end of life and the TypeScript scripting support already needs a newer runtime, so the floor moves to 22: the engines field, the CLI's runtime version check and the lockfile's root entry. CI already tests on 22 and 24, so the matrix is unchanged.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ib345e8d4f532014d9122664a238dbe17ecc71e60