### PR TITLE
Surface slow JS functions from the profile run (Chrome)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+* Per-function JS cost from the V8 sampling profiler (Chrome only): runs with the `disabled-by-default-v8.cpu_profiler` trace category (which `--enableProfileRun` already enables) now get `cpu.functionCosts` — the top functions by main-thread self time with total time and source position — so consumers can show *which function* is slow instead of stopping at "this script used 300 ms". Functions inside concatenated bundles (MediaWiki ResourceLoader) are attributed to the owning module, e.g. `scrollToActiveSection` → `skins.vector.js`.
+
+### Added
 * The `renderBlocking.recalculateStyle` summary (Chrome only) now includes `count` — the number of Recalculate Style events behind the existing element and duration totals — plus `maxElements` and `maxDurationInMillis` for the single largest event, both before FCP and before LCP. The totals alone can't distinguish one massive invalidation that cascades through most of the DOM (fix: narrow the selector/class-toggle scope) from thousands of small forced recalcs caused by JS interleaving style writes and layout reads (fix: batch reads and writes). The count tells you which regime you're in, and the max values show whether one monster event dominates the total. The fields land in `browsertime.json`, the statistics summary, and the `_renderBlocking.recalculateStyle` page summary in the HAR.
 
 ### Added

--- a/lib/chrome/trace/function-costs.js
+++ b/lib/chrome/trace/function-costs.js
@@ -1,0 +1,195 @@
+/**
+ * Per-function JS cost from the V8 sampling profiler
+ * (disabled-by-default-v8.cpu_profiler, enabled on --enableProfileRun).
+ * The task-based analyses (scriptCosts, moduleCosts) attribute
+ * main-thread time to a URL or module; the sampled stacks answer the
+ * next question — which function inside that script the time was
+ * spent in.
+ *
+ * The category emits one Profile event per profiled V8 thread and a
+ * stream of ProfileChunk events carrying incremental call-tree nodes,
+ * sampled node ids and µs deltas between samples. Only the profile
+ * started on the inspected tab's main thread is read: the Profile
+ * event is emitted on the profiled thread, while its chunks arrive on
+ * V8's sampling thread and are tied back via the shared profile id +
+ * pid.
+ *
+ * Each sample's delta is credited as self time to the sampled frame
+ * and as total time to every distinct frame on the sampled stack
+ * (recursion counted once) — the definitions DevTools' bottom-up view
+ * uses. Frames aggregate per function identity (name + script +
+ * source position), so a function called from many sites is one row.
+ *
+ * V8 meta frames ((root), (program), (idle), (garbage collector))
+ * carry codeType 'other' and are skipped — idle is not cost and GC is
+ * already in cpu.categories. Engine frames without a script URL
+ * (e.g. querySelectorAll) are kept: the cost is real, it just has no
+ * source position.
+ *
+ * When the optional `bundles` map (url → location resolver, built by
+ * the coverage path) knows a frame's URL, the frame's position is
+ * resolved to the owning module inside the concatenated bundle and
+ * reported as `module`. V8 call-frame positions are 0-based while the
+ * resolvers — and the reported line/column — are 1-based (the trace
+ * event / DevTools convention). Frame URLs longer than 1024 chars are
+ * truncated by V8; they are recovered via unique prefix match against
+ * the bundle map so the reported url matches cpu.urls / moduleCosts.
+ *
+ * Returns [{ functionName, url?, line?, column?, module?, selfTime,
+ * totalTime }, …] in ms rounded to one decimal, sorted by selfTime
+ * desc, noise-filtered to self time ≥ 1 ms and capped at 50 rows.
+ * Empty array when the trace carries no profiler data (the category
+ * is only enabled on profile runs).
+ */
+
+import { findMainFrameIds } from './tracing-processor.js';
+
+const REPORT_LIMIT_US = 1000;
+const MAX_FUNCTIONS = 50;
+// V8 truncates callFrame.url in the trace (observed at 1024 chars),
+// so long bundle URLs (MediaWiki load.php easily exceeds it) won't
+// exact-match the coverage-path bundle map or the rest of the result.
+const V8_URL_TRUNCATION_LIMIT = 1024;
+
+function round(ms) {
+  return Math.round(ms * 10) / 10;
+}
+
+function functionKey(callFrame) {
+  return `${callFrame.functionName}|${callFrame.scriptId}|${callFrame.lineNumber}|${callFrame.columnNumber}`;
+}
+
+function isMetaFrame(callFrame) {
+  return callFrame.codeType === 'other';
+}
+
+// Recover the full bundle URL + resolver for a (possibly truncated)
+// frame URL. Exact match first; for truncation-length URLs fall back
+// to a unique prefix match, skipping when ambiguous.
+function findBundle(bundles, url) {
+  if (!bundles || !url) return;
+  const exact = bundles.get(url);
+  if (exact) return { url, resolver: exact };
+  if (url.length < V8_URL_TRUNCATION_LIMIT) return;
+  let match;
+  for (const [bundleUrl, resolver] of bundles) {
+    if (bundleUrl.startsWith(url)) {
+      if (match) return;
+      match = { url: bundleUrl, resolver };
+    }
+  }
+  return match;
+}
+
+export function computeFunctionCosts(trace, bundles) {
+  const events = trace.traceEvents;
+  const { pid, tid } = findMainFrameIds(events);
+
+  const profileIds = new Set();
+  for (const event of events) {
+    if (event.name === 'Profile' && event.pid === pid && event.tid === tid) {
+      profileIds.add(event.id);
+    }
+  }
+  if (profileIds.size === 0) return [];
+
+  const nodes = new Map();
+  const samples = [];
+  const timeDeltas = [];
+  for (const event of events) {
+    if (
+      event.name !== 'ProfileChunk' ||
+      event.pid !== pid ||
+      !profileIds.has(event.id)
+    ) {
+      continue;
+    }
+    const data = event.args && event.args.data;
+    if (!data) continue;
+    const cpuProfile = data.cpuProfile;
+    if (cpuProfile && cpuProfile.nodes) {
+      for (const node of cpuProfile.nodes) nodes.set(node.id, node);
+    }
+    if (cpuProfile && cpuProfile.samples) samples.push(...cpuProfile.samples);
+    if (data.timeDeltas) timeDeltas.push(...data.timeDeltas);
+  }
+  if (samples.length === 0) return [];
+
+  // Lazily-named frames can miss their url; recover it from another
+  // node in the same script.
+  const scriptUrls = new Map();
+  for (const node of nodes.values()) {
+    const callFrame = node.callFrame;
+    if (callFrame.url && callFrame.scriptId) {
+      scriptUrls.set(callFrame.scriptId, callFrame.url);
+    }
+  }
+
+  // Distinct function keys on each node's stack, for total time.
+  const stackKeys = new Map();
+  function keysForNode(nodeId) {
+    const cached = stackKeys.get(nodeId);
+    if (cached) return cached;
+    const node = nodes.get(nodeId);
+    if (!node) return new Set();
+    const keys = new Set(node.parent ? keysForNode(node.parent) : undefined);
+    if (!isMetaFrame(node.callFrame)) keys.add(functionKey(node.callFrame));
+    stackKeys.set(nodeId, keys);
+    return keys;
+  }
+
+  const functions = new Map();
+  for (const node of nodes.values()) {
+    const callFrame = node.callFrame;
+    if (isMetaFrame(callFrame)) continue;
+    const key = functionKey(callFrame);
+    if (!functions.has(key)) {
+      functions.set(key, { callFrame, selfUs: 0, totalUs: 0 });
+    }
+  }
+
+  for (const [index, nodeId] of samples.entries()) {
+    const delta = timeDeltas[index];
+    // The first delta rebases against the profile start and can be
+    // negative or missing; skip rather than credit negative time.
+    if (!delta || delta <= 0) continue;
+    const node = nodes.get(nodeId);
+    if (!node) continue;
+    if (!isMetaFrame(node.callFrame)) {
+      functions.get(functionKey(node.callFrame)).selfUs += delta;
+    }
+    for (const key of keysForNode(nodeId)) {
+      functions.get(key).totalUs += delta;
+    }
+  }
+
+  const costs = [];
+  for (const { callFrame, selfUs, totalUs } of functions.values()) {
+    if (selfUs < REPORT_LIMIT_US) continue;
+    const url = callFrame.url || scriptUrls.get(callFrame.scriptId) || '';
+    const cost = {
+      functionName: callFrame.functionName || '(anonymous)',
+      selfTime: round(selfUs / 1000),
+      totalTime: round(totalUs / 1000)
+    };
+    const bundle = findBundle(bundles, url);
+    if (bundle) {
+      cost.url = bundle.url;
+    } else if (url) {
+      cost.url = url;
+    }
+    if (callFrame.lineNumber !== undefined) {
+      cost.line = callFrame.lineNumber + 1;
+      cost.column =
+        callFrame.columnNumber === undefined ? 1 : callFrame.columnNumber + 1;
+      if (bundle) {
+        const module_ = bundle.resolver.resolve(cost.line, cost.column);
+        if (module_) cost.module = module_.name;
+      }
+    }
+    costs.push(cost);
+  }
+
+  costs.sort((a, b) => b.selfTime - a.selfTime);
+  return costs.slice(0, MAX_FUNCTIONS);
+}

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -16,6 +16,7 @@ export { computeScriptCosts } from './script-costs.js';
 export { computeForcedReflows } from './forced-reflows.js';
 export { computeNonCompositedAnimations } from './non-composited-animations.js';
 export { computeFrameStability } from './frame-stability.js';
+export { computeFunctionCosts } from './function-costs.js';
 export { computeBlockingTime } from './blocking-time.js';
 export { computeDomainBreakdown } from './domain-breakdown.js';
 

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -8,6 +8,7 @@ const { Type } = logging;
 import { longTaskMetrics } from '../longTaskMetrics.js';
 import { parseCPUTrace } from '../parseCpuTrace.js';
 import { computeModuleCosts } from '../trace/module-costs.js';
+import { computeFunctionCosts } from '../trace/function-costs.js';
 import { labelForUrl } from '../mediawikiResourceLoader.js';
 import { getHar } from '../har.js';
 import { getEmptyHAR, mergeHars } from '../../support/har/index.js';
@@ -448,6 +449,27 @@ export class Chromium {
         } catch (error) {
           log.debug('computeModuleCosts failed: %s', error.message);
         }
+      }
+      // Per-function self/total time from the V8 sampling profiler —
+      // only produces output on runs with the cpu_profiler trace
+      // category (--enableProfileRun). Reuses the bundle resolvers so
+      // functions inside concatenated bundles get a module name.
+      try {
+        const functionCosts = computeFunctionCosts(
+          trace,
+          this.resourceLoaderBundles
+        );
+        if (functionCosts.length > 0) {
+          for (const functionCost of functionCosts) {
+            const label = labelForUrl(functionCost.url);
+            if (label) {
+              functionCost.label = label;
+            }
+          }
+          cpu.functionCosts = functionCosts;
+        }
+      } catch (error) {
+        log.debug('computeFunctionCosts failed: %s', error.message);
       }
       this.resourceLoaderBundles = undefined;
       result.cpu = cpu;

--- a/test/unittests/functionCostsTest.js
+++ b/test/unittests/functionCostsTest.js
@@ -1,0 +1,224 @@
+import test from 'ava';
+import { computeFunctionCosts } from '../../lib/chrome/trace/function-costs.js';
+import { resourceLoaderLocationResolver } from '../../lib/chrome/mediawikiResourceLoader.js';
+
+const PID = 1;
+const TID = 2;
+const FRAME = 'FRAME0';
+const PROFILE_ID = '0x1';
+
+const BUNDLE_URL = 'https://en.example.org/w/load.php?modules=a|b';
+const PLAIN_URL = 'https://en.example.org/w/plain.js';
+
+// line 1: preamble, line 2: module.one, line 3: module.two
+const bundleSource =
+  '/* preamble */\n' +
+  'mw.loader.impl(function(){return["module.one@abc12",function(){}];});\n' +
+  'mw.loader.impl(function(){return["module.two@def34",function(){}];});';
+
+function metadataEvents() {
+  return [
+    {
+      name: 'TracingStartedInBrowser',
+      cat: 'disabled-by-default-devtools.timeline',
+      ph: 'I',
+      pid: 100,
+      tid: 100,
+      ts: 900_000,
+      args: { data: { frames: [{ frame: FRAME, processId: PID }] } }
+    },
+    {
+      name: 'thread_name',
+      cat: '__metadata',
+      ph: 'M',
+      pid: PID,
+      tid: TID,
+      ts: 0,
+      args: { name: 'CrRendererMain' }
+    }
+  ];
+}
+
+// Call tree: (root) → outer (bundle, module.one) → inner (plain.js)
+//            (root) → (garbage collector)
+// V8 callFrame positions are 0-based: line 1 col 0 is bundle line 2.
+function profileEvents() {
+  return [
+    {
+      name: 'Profile',
+      cat: 'disabled-by-default-v8.cpu_profiler',
+      ph: 'P',
+      id: PROFILE_ID,
+      pid: PID,
+      tid: TID,
+      ts: 1_000_000,
+      args: { data: { startTime: 1_000_000 } }
+    },
+    {
+      name: 'ProfileChunk',
+      cat: 'disabled-by-default-v8.cpu_profiler',
+      ph: 'P',
+      id: PROFILE_ID,
+      pid: PID,
+      tid: 999, // chunks arrive on the sampling thread
+      ts: 1_000_100,
+      args: {
+        data: {
+          cpuProfile: {
+            nodes: [
+              {
+                id: 1,
+                callFrame: {
+                  functionName: '(root)',
+                  scriptId: 0,
+                  codeType: 'other'
+                }
+              },
+              {
+                id: 2,
+                parent: 1,
+                callFrame: {
+                  functionName: 'outer',
+                  scriptId: 5,
+                  codeType: 'JS',
+                  url: BUNDLE_URL,
+                  lineNumber: 1,
+                  columnNumber: 0
+                }
+              },
+              {
+                id: 3,
+                parent: 2,
+                callFrame: {
+                  functionName: 'inner',
+                  scriptId: 6,
+                  codeType: 'JS',
+                  url: PLAIN_URL,
+                  lineNumber: 9,
+                  columnNumber: 4
+                }
+              },
+              {
+                id: 4,
+                parent: 1,
+                callFrame: {
+                  functionName: '(garbage collector)',
+                  scriptId: 0,
+                  codeType: 'other'
+                }
+              }
+            ],
+            samples: [2, 3, 3, 4]
+          },
+          timeDeltas: [1000, 2000, 1500, 800]
+        }
+      }
+    },
+    {
+      name: 'ProfileChunk',
+      cat: 'disabled-by-default-v8.cpu_profiler',
+      ph: 'P',
+      id: PROFILE_ID,
+      pid: PID,
+      tid: 999,
+      ts: 1_001_000,
+      args: {
+        data: {
+          cpuProfile: { samples: [2, 3] },
+          timeDeltas: [500, 1200]
+        }
+      }
+    }
+  ];
+}
+
+function syntheticTrace(extraEvents = []) {
+  return {
+    traceEvents: [...metadataEvents(), ...profileEvents(), ...extraEvents]
+  };
+}
+
+test('aggregates self and total time per function across chunks', t => {
+  const costs = computeFunctionCosts(syntheticTrace());
+
+  // inner: samples 2000 + 1500 + 1200 = 4.7 ms self, no children so
+  // total equals self. outer: 1000 + 500 = 1.5 ms self; total adds
+  // inner's stacks = 6.2 ms. GC and (root) are meta frames → skipped.
+  t.deepEqual(
+    costs.map(c => ({
+      functionName: c.functionName,
+      selfTime: c.selfTime,
+      totalTime: c.totalTime
+    })),
+    [
+      { functionName: 'inner', selfTime: 4.7, totalTime: 4.7 },
+      { functionName: 'outer', selfTime: 1.5, totalTime: 6.2 }
+    ]
+  );
+
+  // Positions are reported 1-based (trace event / DevTools convention).
+  const inner = costs.find(c => c.functionName === 'inner');
+  t.is(inner.url, PLAIN_URL);
+  t.is(inner.line, 10);
+  t.is(inner.column, 5);
+});
+
+test('resolves bundle frames to the owning module', t => {
+  const bundles = new Map([
+    [BUNDLE_URL, resourceLoaderLocationResolver(bundleSource)]
+  ]);
+  const costs = computeFunctionCosts(syntheticTrace(), bundles);
+
+  const outer = costs.find(c => c.functionName === 'outer');
+  t.is(outer.module, 'module.one');
+  t.is(costs.find(c => c.functionName === 'inner').module, undefined);
+});
+
+test('recovers bundle URLs truncated by V8', t => {
+  const longBundleUrl = BUNDLE_URL + '&modules=' + 'x'.repeat(1200);
+  const truncated = longBundleUrl.slice(0, 1024);
+  const trace = syntheticTrace();
+  for (const event of trace.traceEvents) {
+    for (const node of event.args?.data?.cpuProfile?.nodes || []) {
+      if (node.callFrame.url === BUNDLE_URL) {
+        node.callFrame.url = truncated;
+      }
+    }
+  }
+  const bundles = new Map([
+    [longBundleUrl, resourceLoaderLocationResolver(bundleSource)]
+  ]);
+  const costs = computeFunctionCosts(trace, bundles);
+
+  const outer = costs.find(c => c.functionName === 'outer');
+  t.is(outer.url, longBundleUrl);
+  t.is(outer.module, 'module.one');
+});
+
+test('drops functions below the 1 ms noise limit', t => {
+  const trace = syntheticTrace();
+  // Rewrite the deltas so outer only collects 0.9 ms of self time
+  // (negative deltas are skipped, not credited).
+  trace.traceEvents.at(-2).args.data.timeDeltas = [900, 2000, 1500, 800];
+  trace.traceEvents.at(-1).args.data.timeDeltas = [-100, 1200];
+  const costs = computeFunctionCosts(trace);
+  t.deepEqual(
+    costs.map(c => c.functionName),
+    ['inner']
+  );
+});
+
+test('ignores profiles from other processes', t => {
+  const trace = syntheticTrace();
+  for (const event of trace.traceEvents) {
+    if (event.name === 'Profile' || event.name === 'ProfileChunk') {
+      event.pid = 55;
+    }
+  }
+  t.deepEqual(computeFunctionCosts(trace), []);
+});
+
+test('returns empty when the trace has no profiler data', t => {
+  const trace = { traceEvents: metadataEvents() };
+  t.deepEqual(computeFunctionCosts(trace), []);
+});

--- a/types/chrome/trace/function-costs.d.ts
+++ b/types/chrome/trace/function-costs.d.ts
@@ -1,0 +1,6 @@
+export function computeFunctionCosts(trace: any, bundles: any): {
+    functionName: any;
+    selfTime: number;
+    totalTime: number;
+}[];
+//# sourceMappingURL=function-costs.d.ts.map

--- a/types/chrome/trace/function-costs.d.ts.map
+++ b/types/chrome/trace/function-costs.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"function-costs.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/function-costs.js"],"names":[],"mappings":"AAmFA;;;;IA+GC"}

--- a/types/chrome/trace/index.d.ts
+++ b/types/chrome/trace/index.d.ts
@@ -17,6 +17,7 @@ export { computeScriptCosts } from "./script-costs.js";
 export { computeForcedReflows } from "./forced-reflows.js";
 export { computeNonCompositedAnimations } from "./non-composited-animations.js";
 export { computeFrameStability } from "./frame-stability.js";
+export { computeFunctionCosts } from "./function-costs.js";
 export { computeBlockingTime } from "./blocking-time.js";
 export { computeDomainBreakdown } from "./domain-breakdown.js";
 //# sourceMappingURL=index.d.ts.map

--- a/types/chrome/trace/index.d.ts.map
+++ b/types/chrome/trace/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/index.js"],"names":[],"mappings":"AAqBA;;;;;;;;;;;GAWG;AACH,6DAJG;IAA0B,OAAO,GAAzB,OAAO;CAEf,GAAU,KAAK,KAAQ,CAYzB"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/index.js"],"names":[],"mappings":"AAsBA;;;;;;;;;;;GAWG;AACH,6DAJG;IAA0B,OAAO,GAAzB,OAAO;CAEf,GAAU,KAAK,KAAQ,CAYzB"}


### PR DESCRIPTION
The extra run made by --enableProfileRun has always collected V8 sampling-profiler data in the trace, but the only way to use it was to open the trace by hand in DevTools. Parsing it into cpu.functionCosts lets consumers like sitespeed.io answer the question the existing per-URL and per-module numbers stop short of: which function inside the slow script the time actually went to.

On MediaWiki pages the sampled frames are additionally attributed to the owning ResourceLoader module via the coverage-path bundle resolvers. V8 truncates stack-frame URLs at 1024 characters, which silently broke that join for load.php URLs; truncated URLs are recovered by unique prefix match so the output stays consistent weCosts.

Co-authored-by: Fable 5 noreply@anthropic.com
Change-Id: I290ea518d6ac295d5eb9ee5602c2dbce85a6b367