### PR TITLE
Split blocking time by kind of work and name the HTML document

### DIFF
--- a/lib/chrome/trace/blocking-time.js
+++ b/lib/chrome/trace/blocking-time.js
@@ -1,5 +1,5 @@
 /**
- * Blocking-time attribution per URL.
+ * Blocking-time attribution per URL and per kind of work.
  *
  * A top-level main-thread task longer than 50 ms blocks input for
  * (duration - 50) ms — the same definition Lighthouse's Total
@@ -13,9 +13,22 @@
  * chain, the whole subtree is walked and the task is attributed to
  * the URL that contributed the most self-time (each node credited to
  * its most-specific URL, attributableURLs.at(-1), the same choice
- * script-costs.js makes). Tasks where no node carries a URL go to the
- * 'unknown' bucket — that's browser-internal work (GC, style, layout
- * without a JS trigger) no script owns.
+ * script-costs.js makes). ParseHTML nodes carry no attributable URL
+ * (main-thread-tasks.js only reads URLs from script events and stack
+ * frames, and stays byte-equivalent for cpu.urls consumers), so here
+ * they fall back to the document URL in args.beginData.url — a page
+ * blocked by parsing its own big HTML gets attributed to that
+ * document instead of disappearing. Tasks where no node carries any
+ * URL go to the 'unknown' bucket — browser-internal work (GC, style,
+ * layout without a JS trigger) no script owns.
+ *
+ * Blocking time is also split by KIND of work: each blocking task's
+ * subtree self-time per task group (parseHTML, styleLayout,
+ * scriptEvaluation, …) is scaled to the task's blocking share and
+ * summed per window into `kinds`. The per-URL list says who to blame;
+ * the kinds split says what kind of fix applies — script blocking
+ * needs code changes, parse/style blocking needs a smaller document
+ * or cheaper CSS.
  *
  * Two windows are reported: the whole trace, and navigationStart →
  * the last largestContentfulPaint::Candidate event (blocking time in
@@ -28,10 +41,12 @@
  *
  * Returns:
  *   { totalBlockingTime, tasks, urls: [{ url, value, tasks }, …],
+ *     kinds: { styleLayout: ms, … },
  *     beforeLargestContentfulPaint?: { totalBlockingTime, tasks,
- *                                      urls: [...] } }
+ *                                      urls: [...], kinds: {...} } }
  * Times in ms rounded to one decimal; url lists sorted by value desc
  * and noise-filtered to entries above 10 ms, matching cpu.urls.
+ * Kinds that round to 0 ms are omitted.
  */
 
 import { getMainThreadTasks } from './main-thread-tasks.js';
@@ -45,15 +60,29 @@ function round(ms) {
   return Math.round(ms * 10) / 10;
 }
 
-function dominantUrl(task) {
+function nodeUrl(node) {
+  const url = node.attributableURLs.at(-1);
+  if (url) return url;
+  if (node.event.name === 'ParseHTML') {
+    const beginData = node.event.args && node.event.args.beginData;
+    return beginData && beginData.url;
+  }
+}
+
+// One subtree walk computing both attributions for a blocking task:
+// the dominant URL (most self-time) and the self-time per task kind.
+function analyzeTask(task) {
   const selfTimeByUrl = new Map();
+  const selfTimeByKind = new Map();
   const stack = [task];
   while (stack.length > 0) {
     const node = stack.pop();
-    const url = node.attributableURLs.at(-1);
+    const url = nodeUrl(node);
     if (url) {
       selfTimeByUrl.set(url, (selfTimeByUrl.get(url) || 0) + node.selfTime);
     }
+    const kind = node.group.id;
+    selfTimeByKind.set(kind, (selfTimeByKind.get(kind) || 0) + node.selfTime);
     stack.push(...node.children);
   }
   let bestUrl;
@@ -64,23 +93,34 @@ function dominantUrl(task) {
       bestTime = time;
     }
   }
-  return bestUrl || UNKNOWN;
+  return { url: bestUrl || UNKNOWN, selfTimeByKind };
 }
 
 function newWindow() {
-  return { totalBlockingTime: 0, tasks: 0, byUrl: new Map() };
+  return {
+    totalBlockingTime: 0,
+    tasks: 0,
+    byUrl: new Map(),
+    byKind: new Map()
+  };
 }
 
-function addToWindow(window, url, blocking) {
+function addToWindow(window, task, blocking, analysis) {
   window.totalBlockingTime += blocking;
   window.tasks += 1;
-  let entry = window.byUrl.get(url);
+  let entry = window.byUrl.get(analysis.url);
   if (!entry) {
-    entry = { url, value: 0, tasks: 0 };
-    window.byUrl.set(url, entry);
+    entry = { url: analysis.url, value: 0, tasks: 0 };
+    window.byUrl.set(analysis.url, entry);
   }
   entry.value += blocking;
   entry.tasks += 1;
+  // Scale each kind's subtree self-time to the task's blocking share,
+  // so the kinds sum to totalBlockingTime instead of raw durations.
+  for (const [kind, selfTime] of analysis.selfTimeByKind) {
+    const share = (selfTime / task.duration) * blocking;
+    window.byKind.set(kind, (window.byKind.get(kind) || 0) + share);
+  }
 }
 
 function finishWindow(window) {
@@ -92,10 +132,18 @@ function finishWindow(window) {
     }
   }
   urls.sort((a, b) => b.value - a.value);
+  const kinds = {};
+  for (const [kind, value] of [...window.byKind.entries()].toSorted(
+    (a, b) => b[1] - a[1]
+  )) {
+    const rounded = round(value);
+    if (rounded > 0) kinds[kind] = rounded;
+  }
   return {
     totalBlockingTime: round(window.totalBlockingTime),
     tasks: window.tasks,
-    urls
+    urls,
+    kinds
   };
 }
 
@@ -121,15 +169,15 @@ export function computeBlockingTime(trace) {
     if (task.duration <= BLOCKING_THRESHOLD_MS) continue;
 
     const blocking = task.duration - BLOCKING_THRESHOLD_MS;
-    const url = dominantUrl(task);
-    addToWindow(total, url, blocking);
+    const analysis = analyzeTask(task);
+    addToWindow(total, task, blocking, analysis);
 
     if (
       lcpEvent &&
       task.event.ts >= timestamps.navigationStart &&
       task.event.ts < lcpEvent.ts
     ) {
-      addToWindow(beforeLcp, url, blocking);
+      addToWindow(beforeLcp, task, blocking, analysis);
     }
   }
 

--- a/test/unittests/traceAnalysisTest.js
+++ b/test/unittests/traceAnalysisTest.js
@@ -10,7 +10,7 @@ const FRAME = 'FRAME0';
 // resolve pid/tid/frame, a navigationStart, three top-level tasks
 // longer than 50 ms (one attributed via a nested child, one after the
 // LCP candidate, one with no attributable URL) and one short task.
-function syntheticTrace({ withLcp = true } = {}) {
+function syntheticTrace({ withLcp = true, withParseHtml = false } = {}) {
   const traceEvents = [
     {
       name: 'TracingStartedInBrowser',
@@ -104,6 +104,20 @@ function syntheticTrace({ withLcp = true } = {}) {
       args: { frame: FRAME, data: {} }
     });
   }
+  if (withParseHtml) {
+    // ParseHTML carries no attributable URL, only the document URL in
+    // args.beginData.url.
+    traceEvents.push({
+      name: 'ParseHTML',
+      cat: 'devtools.timeline',
+      ph: 'X',
+      pid: PID,
+      tid: TID,
+      ts: 1_800_000,
+      dur: 70_000,
+      args: { beginData: { url: 'https://en.first.example/page' } }
+    });
+  }
   return { traceEvents };
 }
 
@@ -119,13 +133,37 @@ test('blocking time is attributed to the dominant URL in the task subtree', t =>
   ]);
 });
 
+test('blocking time is split by kind of work, scaled to the blocking share', t => {
+  const result = computeBlockingTime(syntheticTrace());
+
+  // The 200 ms RunTask (150 ms blocking) is 150 ms script self-time
+  // and 50 ms wrapper self-time: 150/200 and 50/200 of its blocking.
+  t.deepEqual(result.kinds, {
+    scriptEvaluation: 192.5,
+    styleLayout: 40,
+    other: 37.5
+  });
+});
+
+test('HTML parsing is attributed to the document and split out as a kind', t => {
+  const result = computeBlockingTime(syntheticTrace({ withParseHtml: true }));
+
+  t.is(result.totalBlockingTime, 290);
+  t.deepEqual(
+    result.urls.find(u => u.url === 'https://en.first.example/page'),
+    { url: 'https://en.first.example/page', value: 20, tasks: 1 }
+  );
+  t.is(result.kinds.parseHTML, 20);
+});
+
 test('blocking time before LCP only counts tasks in the navigationStart to LCP window', t => {
   const result = computeBlockingTime(syntheticTrace());
 
   t.deepEqual(result.beforeLargestContentfulPaint, {
     totalBlockingTime: 150,
     tasks: 1,
-    urls: [{ url: 'https://sub.first.example/app.js', value: 150, tasks: 1 }]
+    urls: [{ url: 'https://sub.first.example/app.js', value: 150, tasks: 1 }],
+    kinds: { scriptEvaluation: 112.5, other: 37.5 }
   });
 });
 

--- a/types/chrome/trace/blocking-time.d.ts
+++ b/types/chrome/trace/blocking-time.d.ts
@@ -2,5 +2,6 @@ export function computeBlockingTime(trace: any): {
     totalBlockingTime: number;
     tasks: any;
     urls: any[];
+    kinds: {};
 };
 //# sourceMappingURL=blocking-time.d.ts.map

--- a/types/chrome/trace/blocking-time.d.ts.map
+++ b/types/chrome/trace/blocking-time.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"blocking-time.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/blocking-time.js"],"names":[],"mappings":"AAqGA;;;;EAuCC"}
+{"version":3,"file":"blocking-time.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/blocking-time.js"],"names":[],"mappings":"AAgJA;;;;;EAuCC"}


### PR DESCRIPTION
The per-script blocking attribution answered "which script blocked" but a page blocked by parsing its own large HTML or by style/layout showed up as an anonymous 'unknown' row — and the fix for parse or layout blocking is completely different from the fix for script blocking. Each blocking task's subtree is now also split by task kind into cpu.blocking.kinds, and blocking ParseHTML tasks are attributed to the document URL, so that class of blocking gets a name instead of disappearing. The fallback lives in blocking-time.js only, keeping the main-thread task walker byte-equivalent for cpu.urls consumers.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I812e10a1369a127d1f22308cd7a6b57e0114c9f0