### PR TITLE
Classify document-loading and V8 housekeeping out of 'other'

### DIFF
--- a/lib/chrome/trace/task-groups.js
+++ b/lib/chrome/trace/task-groups.js
@@ -43,7 +43,26 @@ export const taskGroups = {
       'ResourceReceiveResponse',
       'ResourceReceivedData',
       'ResourceReceivedResponse',
-      'ResourceFinish'
+      'ResourceFinish',
+      'ResourceChangePriority',
+      // Document/navigation body loading internals (sampled from real
+      // Wikipedia traces, July 2026) — the main-thread side of
+      // streaming the document into the parser. Same rationale as the
+      // resource lifecycle events above.
+      'DocumentLoader::DocumentLoader',
+      'DocumentLoader::HandleData',
+      'DocumentLoader::CommitData',
+      'DocumentLoader::BodyDataReceivedImpl',
+      'DocumentLoader::BodyLoadingFinished',
+      'DocumentLoader::FinishedLoading',
+      'NavigationBodyLoader::OnReadable',
+      'NavigationBodyLoader::ReadFromDataPipe',
+      'URLLoader::Context::OnReceivedResponse',
+      'URLLoader::Context::OnCompletedRequest',
+      'URLLoader::Context::Cancel',
+      'ThrottlingURLLoader::OnReceiveResponse',
+      'ResourceRequestSender::OnReceivedResponse',
+      'ResourceRequestSender::OnRequestComplete'
     ]
   },
   styleLayout: {
@@ -129,7 +148,14 @@ export const taskGroups = {
       'v8.callFunction',
       'v8.callModuleMethod',
       'XHRLoad',
-      'XHRReadyStateChange'
+      'XHRReadyStateChange',
+      // V8 housekeeping that only runs because JS is executing —
+      // interrupt handling, stack guards, constructor instantiation.
+      'v8.newInstance',
+      'V8.InvokeApiInterruptCallbacks',
+      'V8.HandleInterrupts',
+      'V8.BytecodeBudgetInterrupt',
+      'V8.StackGuard'
     ]
   },
   garbageCollection: {

--- a/types/chrome/trace/task-groups.d.ts.map
+++ b/types/chrome/trace/task-groups.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"task-groups.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/task-groups.js"],"names":[],"mappings":"AAsLA;;;;;;GAMG;AACH,8CAMC;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AApBD,iCAAkC"}
+{"version":3,"file":"task-groups.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/task-groups.js"],"names":[],"mappings":"AAgNA;;;;;;GAMG;AACH,8CAMC;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AApBD,iCAAkC"}


### PR DESCRIPTION
Almost a fifth of cpu.categories landed in 'other', which reads as mystery time. Measuring real Wikipedia traces showed 90% of it is Chrome's task-scheduling overhead (RunTask self time) and most of the rest is document body-loading and V8 interrupt events the classifier didn't know. Those now go to parseHTML and scriptEvaluation respectively, so what remains in 'other' really is scheduling overhead and consumers can label it as such.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Iff3c9ea38bbce022b6b71d9eb67eb8421986828a