### PR TITLE
Decode why animations could not be composited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+* `cpu.nonCompositedAnimations` entries now include `failureReasons` — the `compositeFailed` bitmask decoded to human-readable strings via Blink's FailureReason enum (Chrome only). Chrome often omits `unsupportedProperties`, leaving consumers with "an animation failed" and a bare number; the decoded reasons say why, and the why decides the action ("animation has no visible change" is benign, "unsupported CSS property" is a fix).
 * Per-function JS cost from the V8 sampling profiler (Chrome only): runs with the `disabled-by-default-v8.cpu_profiler` trace category (which `--enableProfileRun` already enables) now get `cpu.functionCosts` — the top functions by main-thread self time with total time and source position — so consumers can show *which function* is slow instead of stopping at "this script used 300 ms". Functions inside concatenated bundles (MediaWiki ResourceLoader) are attributed to the owning module, e.g. `scrollToActiveSection` → `skins.vector.js`.
 
 ### Added

--- a/lib/chrome/trace/non-composited-animations.js
+++ b/lib/chrome/trace/non-composited-animations.js
@@ -10,19 +10,63 @@
  *
  * Chrome marks these in the trace via `Animation` events whose
  * `args.data.compositeFailed` bitmask is non-zero, plus a list of
- * `unsupportedProperties` strings. We surface the raw values; the
- * consumer can map the bitmask to human reasons (see Lighthouse's
- * non-composited-animations audit for the canonical mapping).
+ * `unsupportedProperties` strings. Chrome often omits the property
+ * list (the bitmask is the only signal), so the bitmask is decoded
+ * into `failureReasons` strings here — otherwise consumers show "an
+ * animation failed" with no way to say why.
  *
- * Returns: [{ name, id, compositeFailed, unsupportedProperties,
- *             startTime }, …]
+ * The bit meanings come from Blink's CompositorAnimations
+ * FailureReason enum (compositor_animations.h, kFailureReasonCount
+ * = 21 as of Chrome ~M140): bit values are stable and never reused,
+ * so decoding old traces is safe. Bits 8/11/14 are retired in
+ * current Blink but kept here for traces from older Chrome versions.
+ * Unknown future bits decode to 'unknown reason (bit N)' instead of
+ * being dropped.
+ *
+ * Returns: [{ name, id, compositeFailed, failureReasons,
+ *             unsupportedProperties, startTime }, …]
  *   name            — args.data.nodeName when present (rare)
  *   id              — args.data.id (compositor-internal)
  *   compositeFailed — bitmask of failure reasons
+ *   failureReasons  — the bitmask decoded to human-readable strings
  *   unsupportedProperties — array of property names that blocked
  *                           composite (e.g. ['top','box-shadow'])
  *   startTime       — event ts in microseconds (raw trace timestamp)
  */
+
+// Blink FailureReason bit → human-readable string, in bit order.
+const FAILURE_REASONS = [
+  'accelerated animations disabled', // 1 << 0
+  'effect suppressed by DevTools', // 1 << 1
+  'invalid animation or effect', // 1 << 2
+  'effect has unsupported timing parameters', // 1 << 3
+  "effect has composite mode other than 'replace'", // 1 << 4
+  'target has invalid compositing state', // 1 << 5
+  'target has another incompatible animation', // 1 << 6
+  'target has CSS offset', // 1 << 7
+  'target has multiple transform properties', // 1 << 8 (retired)
+  'animation affects non-CSS properties', // 1 << 9
+  'transform-related property cannot be accelerated on target', // 1 << 10
+  'transform-related property depends on box size', // 1 << 11 (retired)
+  'filter-related property may move pixels', // 1 << 12
+  'unsupported CSS property', // 1 << 13
+  'multiple transform animations on same target', // 1 << 14 (retired)
+  'mixed keyframe value types', // 1 << 15
+  'scroll timeline source has invalid compositing state', // 1 << 16
+  'animation has no visible change', // 1 << 17
+  'animation affects an !important property', // 1 << 18
+  'SVG target has independent transform property', // 1 << 19
+  "effect has iteration composite mode other than 'replace'" // 1 << 20
+];
+
+function decodeFailureReasons(bitmask) {
+  const reasons = [];
+  for (let bit = 0; bitmask >> bit > 0; bit++) {
+    if (((bitmask >> bit) & 1) === 0) continue;
+    reasons.push(FAILURE_REASONS[bit] || `unknown reason (bit ${bit})`);
+  }
+  return reasons;
+}
 
 export function computeNonCompositedAnimations(trace) {
   const seen = new Set();
@@ -46,6 +90,7 @@ export function computeNonCompositedAnimations(trace) {
       name: data.nodeName || '',
       id: data.id || '',
       compositeFailed: failed,
+      failureReasons: decodeFailureReasons(failed),
       unsupportedProperties: unsupported,
       startTime: event.ts
     });

--- a/test/unittests/nonCompositedAnimationsTest.js
+++ b/test/unittests/nonCompositedAnimationsTest.js
@@ -1,0 +1,38 @@
+import test from 'ava';
+import { computeNonCompositedAnimations } from '../../lib/chrome/trace/non-composited-animations.js';
+
+function animationEvent(id, ts, data) {
+  return { name: 'Animation', ts, args: { data: { id, ...data } } };
+}
+
+test('decodes the compositeFailed bitmask into failure reasons', t => {
+  const trace = {
+    traceEvents: [
+      animationEvent('a', 1, {
+        compositeFailed: (1 << 13) | (1 << 17),
+        unsupportedProperties: ['top']
+      }),
+      // Same animation id at a later phase — deduped.
+      animationEvent('a', 2, { compositeFailed: 1 << 13 }),
+      // A bit Blink hasn't defined yet must not be dropped silently.
+      animationEvent('b', 3, { compositeFailed: 1 << 21 })
+    ]
+  };
+
+  const result = computeNonCompositedAnimations(trace);
+
+  t.is(result.length, 2);
+  t.deepEqual(result[0].failureReasons, [
+    'unsupported CSS property',
+    'animation has no visible change'
+  ]);
+  t.deepEqual(result[0].unsupportedProperties, ['top']);
+  t.deepEqual(result[1].failureReasons, ['unknown reason (bit 21)']);
+});
+
+test('animations without failures are not reported', t => {
+  const trace = {
+    traceEvents: [animationEvent('a', 1, { compositeFailed: 0 })]
+  };
+  t.deepEqual(computeNonCompositedAnimations(trace), []);
+});

--- a/types/chrome/trace/blocking-time.d.ts.map
+++ b/types/chrome/trace/blocking-time.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"blocking-time.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/blocking-time.js"],"names":[],"mappings":"AAgJA;;;;;EAuCC"}
+{"version":3,"file":"blocking-time.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/blocking-time.js"],"names":[],"mappings":"AAqJA;;;;;EAuCC"}

--- a/types/chrome/trace/non-composited-animations.d.ts
+++ b/types/chrome/trace/non-composited-animations.d.ts
@@ -1,32 +1,8 @@
-/**
- * Non-composited animations — animations that triggered Layout or
- * Paint instead of running entirely on the compositor thread.
- *
- * Compositor-only animations (transform, opacity) hand off to the
- * GPU and don't block the main thread. Anything that touches
- * `top` / `left` / `width` / `box-shadow` / non-transformable
- * filters / etc. forces a per-frame layout or paint, which means
- * jank on busy main threads.
- *
- * Chrome marks these in the trace via `Animation` events whose
- * `args.data.compositeFailed` bitmask is non-zero, plus a list of
- * `unsupportedProperties` strings. We surface the raw values; the
- * consumer can map the bitmask to human reasons (see Lighthouse's
- * non-composited-animations audit for the canonical mapping).
- *
- * Returns: [{ name, id, compositeFailed, unsupportedProperties,
- *             startTime }, …]
- *   name            — args.data.nodeName when present (rare)
- *   id              — args.data.id (compositor-internal)
- *   compositeFailed — bitmask of failure reasons
- *   unsupportedProperties — array of property names that blocked
- *                           composite (e.g. ['top','box-shadow'])
- *   startTime       — event ts in microseconds (raw trace timestamp)
- */
 export function computeNonCompositedAnimations(trace: any): {
     name: any;
     id: any;
     compositeFailed: any;
+    failureReasons: string[];
     unsupportedProperties: any;
     startTime: any;
 }[];

--- a/types/chrome/trace/non-composited-animations.d.ts.map
+++ b/types/chrome/trace/non-composited-animations.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"non-composited-animations.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/non-composited-animations.js"],"names":[],"mappings":"AAAA;;;;;;;;;;;;;;;;;;;;;;;;GAwBG;AAEH;;;;;;IA4BC"}
+{"version":3,"file":"non-composited-animations.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/non-composited-animations.js"],"names":[],"mappings":"AAsEA;;;;;;;IA6BC"}


### PR DESCRIPTION
cpu.nonCompositedAnimations reported a raw compositeFailed bitmask, and Chrome often omits the unsupportedProperties list — so consumers could only say "an animation failed" with no way to tell a harmless case from a real problem. The bitmask is now decoded into failureReasons strings using Blink's FailureReason enum, whose bit values are never reused, so old traces decode safely and unknown future bits surface as unknown instead of disappearing. On Wikipedia the flagged animations decode to "animation has no visible change" — benign — which is exactly the distinction the raw number couldn't express.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ic1e405105610767cfb5c5483f5042fe25055d8df