### PR TITLE
Break orchestrator function totals down by callee

### DIFF
--- a/lib/chrome/trace/function-costs.js
+++ b/lib/chrome/trace/function-costs.js
@@ -36,16 +36,22 @@
  * the bundle map so the reported url matches cpu.urls / moduleCosts.
  *
  * Returns [{ functionName, url?, line?, column?, module?, selfTime,
- * totalTime }, …] in ms rounded to one decimal, sorted by selfTime
- * desc, noise-filtered to self time ≥ 1 ms and capped at 50 rows.
- * Empty array when the trace carries no profiler data (the category
- * is only enabled on profile runs).
+ * totalTime, callees? }, …] in ms rounded to one decimal, sorted by
+ * selfTime desc, noise-filtered to self time ≥ 1 ms and capped at 50
+ * rows. `callees` (top 5 ≥ 1 ms, [{ functionName, url?, module?,
+ * value }]) breaks a function's non-self time down by what it called,
+ * so orchestrators (loaders, dispatchers) whose total dwarfs their
+ * self time show what they actually ran. Empty array when the trace
+ * carries no profiler data (the category is only enabled on profile
+ * runs).
  */
 
 import { findMainFrameIds } from './tracing-processor.js';
 
 const REPORT_LIMIT_US = 1000;
 const MAX_FUNCTIONS = 50;
+const CALLEE_LIMIT_US = 1000;
+const MAX_CALLEES = 5;
 // V8 truncates callFrame.url in the trace (observed at 1024 chars),
 // so long bundle URLs (MediaWiki load.php easily exceeds it) won't
 // exact-match the coverage-path bundle map or the rest of the result.
@@ -139,15 +145,35 @@ export function computeFunctionCosts(trace, bundles) {
   }
 
   const functions = new Map();
+  const nodesByKey = new Map();
+  const childNodes = new Map();
   for (const node of nodes.values()) {
+    if (node.parent !== undefined) {
+      let siblings = childNodes.get(node.parent);
+      if (!siblings) {
+        siblings = [];
+        childNodes.set(node.parent, siblings);
+      }
+      siblings.push(node);
+    }
     const callFrame = node.callFrame;
     if (isMetaFrame(callFrame)) continue;
     const key = functionKey(callFrame);
     if (!functions.has(key)) {
       functions.set(key, { callFrame, selfUs: 0, totalUs: 0 });
     }
+    let keyNodes = nodesByKey.get(key);
+    if (!keyNodes) {
+      keyNodes = [];
+      nodesByKey.set(key, keyNodes);
+    }
+    keyNodes.push(node);
   }
 
+  // Per-node inclusive time (its subtree's samples) — the cost of the
+  // call-tree edge from its parent, which is what the callee
+  // breakdown aggregates.
+  const nodeTotals = new Map();
   for (const [index, nodeId] of samples.entries()) {
     const delta = timeDeltas[index];
     // The first delta rebases against the profile start and can be
@@ -161,10 +187,68 @@ export function computeFunctionCosts(trace, bundles) {
     for (const key of keysForNode(nodeId)) {
       functions.get(key).totalUs += delta;
     }
+    for (
+      let ancestor = node;
+      ancestor;
+      ancestor =
+        ancestor.parent === undefined ? undefined : nodes.get(ancestor.parent)
+    ) {
+      nodeTotals.set(ancestor.id, (nodeTotals.get(ancestor.id) || 0) + delta);
+    }
+  }
+
+  // Where a function's non-self time went: for every call-tree node of
+  // the function, each child's inclusive time is credited to the
+  // child's function identity. Answers "what did this orchestrator
+  // run" for loader/dispatcher rows whose total dwarfs their self
+  // time. Direct recursion shows the inner occurrence as a callee of
+  // itself, same as DevTools' top-down tree.
+  function calleesFor(key) {
+    const byCallee = new Map();
+    for (const node of nodesByKey.get(key) || []) {
+      for (const child of childNodes.get(node.id) || []) {
+        if (isMetaFrame(child.callFrame)) continue;
+        const childUs = nodeTotals.get(child.id);
+        if (!childUs) continue;
+        const childKey = functionKey(child.callFrame);
+        let entry = byCallee.get(childKey);
+        if (!entry) {
+          entry = { callFrame: child.callFrame, us: 0 };
+          byCallee.set(childKey, entry);
+        }
+        entry.us += childUs;
+      }
+    }
+    const callees = [];
+    for (const { callFrame, us } of [...byCallee.values()].toSorted(
+      (a, b) => b.us - a.us
+    )) {
+      if (us < CALLEE_LIMIT_US || callees.length >= MAX_CALLEES) break;
+      const callee = {
+        functionName: callFrame.functionName || '(anonymous)',
+        value: round(us / 1000)
+      };
+      const url = callFrame.url || scriptUrls.get(callFrame.scriptId) || '';
+      const bundle = findBundle(bundles, url);
+      if (bundle) {
+        callee.url = bundle.url;
+      } else if (url) {
+        callee.url = url;
+      }
+      if (bundle && callFrame.lineNumber !== undefined) {
+        const module_ = bundle.resolver.resolve(
+          callFrame.lineNumber + 1,
+          callFrame.columnNumber === undefined ? 1 : callFrame.columnNumber + 1
+        );
+        if (module_) callee.module = module_.name;
+      }
+      callees.push(callee);
+    }
+    return callees;
   }
 
   const costs = [];
-  for (const { callFrame, selfUs, totalUs } of functions.values()) {
+  for (const [key, { callFrame, selfUs, totalUs }] of functions.entries()) {
     if (selfUs < REPORT_LIMIT_US) continue;
     const url = callFrame.url || scriptUrls.get(callFrame.scriptId) || '';
     const cost = {
@@ -187,6 +271,8 @@ export function computeFunctionCosts(trace, bundles) {
         if (module_) cost.module = module_.name;
       }
     }
+    const callees = calleesFor(key);
+    if (callees.length > 0) cost.callees = callees;
     costs.push(cost);
   }
 

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -465,6 +465,12 @@ export class Chromium {
             if (label) {
               functionCost.label = label;
             }
+            for (const callee of functionCost.callees || []) {
+              const calleeLabel = labelForUrl(callee.url);
+              if (calleeLabel) {
+                callee.label = calleeLabel;
+              }
+            }
           }
           cpu.functionCosts = functionCosts;
         }

--- a/test/unittests/functionCostsTest.js
+++ b/test/unittests/functionCostsTest.js
@@ -163,6 +163,41 @@ test('aggregates self and total time per function across chunks', t => {
   t.is(inner.column, 5);
 });
 
+test('breaks an orchestrator total down by callee', t => {
+  const costs = computeFunctionCosts(syntheticTrace());
+
+  // outer's non-self time all went to inner (4.7 ms inclusive);
+  // inner called nothing so it gets no callees key.
+  const outer = costs.find(c => c.functionName === 'outer');
+  t.deepEqual(outer.callees, [
+    { functionName: 'inner', url: PLAIN_URL, value: 4.7 }
+  ]);
+  t.false('callees' in costs.find(c => c.functionName === 'inner'));
+});
+
+test('resolves callees inside bundles to their module', t => {
+  const bundles = new Map([
+    [BUNDLE_URL, resourceLoaderLocationResolver(bundleSource)]
+  ]);
+  const trace = syntheticTrace();
+  // Point inner at the bundle (module.two on 0-based line 2) so the
+  // callee resolution path is exercised.
+  for (const event of trace.traceEvents) {
+    for (const node of event.args?.data?.cpuProfile?.nodes || []) {
+      if (node.callFrame.functionName === 'inner') {
+        node.callFrame.url = BUNDLE_URL;
+        node.callFrame.lineNumber = 2;
+        node.callFrame.columnNumber = 0;
+      }
+    }
+  }
+  const costs = computeFunctionCosts(trace, bundles);
+  const outer = costs.find(c => c.functionName === 'outer');
+  t.deepEqual(outer.callees, [
+    { functionName: 'inner', url: BUNDLE_URL, module: 'module.two', value: 4.7 }
+  ]);
+});
+
 test('resolves bundle frames to the owning module', t => {
   const bundles = new Map([
     [BUNDLE_URL, resourceLoaderLocationResolver(bundleSource)]

--- a/types/chrome/trace/function-costs.d.ts.map
+++ b/types/chrome/trace/function-costs.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"function-costs.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/function-costs.js"],"names":[],"mappings":"AAmFA;;;;IA+GC"}
+{"version":3,"file":"function-costs.d.ts","sourceRoot":"","sources":["../../../lib/chrome/trace/function-costs.js"],"names":[],"mappings":"AAyFA;;;;IA+LC"}


### PR DESCRIPTION
The slowest-functions table could show that MediaWiki's runScript had a small self time but a huge total, and nothing more — the reader couldn't tell where the total went. Each cpu.functionCosts row now carries the top callees its non-self time was spent in, derived from the sampled call tree's edges, with the same module attribution as the main rows. Because mw.loader wraps every module file in a named closure, an orchestrator's callees read as the module files it executed (runScript → jquery, ext.wikimediaEvents, …), which is the answer the total alone couldn't give.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I1ef213cbb34ad36dd30c42b1675b67f6f9db7264