### PR TITLE
Parse the style invalidation tracking already in every trace

### DIFF
--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -6,7 +6,8 @@ import {
   computeNonCompositedAnimations,
   computeBlockingTime,
   computeDomainBreakdown,
-  computeFrameStability
+  computeFrameStability,
+  computeStyleInvalidations
 } from './trace/index.js';
 import { labelForUrl } from './mediawikiResourceLoader.js';
 const log = getLogger('browsertime.chrome.cpu');
@@ -140,6 +141,12 @@ export async function parseCPUTrace(tracelog, url) {
     } catch (error) {
       log.debug('computeFrameStability failed: %s', error.message);
     }
+    let styleInvalidations;
+    try {
+      styleInvalidations = computeStyleInvalidations(tracelog);
+    } catch (error) {
+      log.debug('computeStyleInvalidations failed: %s', error.message);
+    }
 
     addResourceLoaderLabels(cleanedUrls);
     addResourceLoaderLabels(scriptCosts);
@@ -154,6 +161,9 @@ export async function parseCPUTrace(tracelog, url) {
         addResourceLoaderLabels(blocking.beforeLargestContentfulPaint.urls);
       }
     }
+    if (styleInvalidations) {
+      addResourceLoaderLabels(styleInvalidations.sources);
+    }
 
     log.debug('Chrome trace log finished parsed and sorted.');
     return {
@@ -165,7 +175,8 @@ export async function parseCPUTrace(tracelog, url) {
       nonCompositedAnimations,
       ...(blocking ? { blocking } : {}),
       ...(domains ? { domains } : {}),
-      ...(frames ? { frames } : {})
+      ...(frames ? { frames } : {}),
+      ...(styleInvalidations ? { styleInvalidations } : {})
     };
   } catch (error) {
     log.error(

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -17,6 +17,7 @@ export { computeForcedReflows } from './forced-reflows.js';
 export { computeNonCompositedAnimations } from './non-composited-animations.js';
 export { computeFrameStability } from './frame-stability.js';
 export { computeFunctionCosts } from './function-costs.js';
+export { computeStyleInvalidations } from './style-invalidations.js';
 export { computeBlockingTime } from './blocking-time.js';
 export { computeDomainBreakdown } from './domain-breakdown.js';
 

--- a/lib/chrome/trace/style-invalidations.js
+++ b/lib/chrome/trace/style-invalidations.js
@@ -1,0 +1,137 @@
+/**
+ * Style/layout invalidation attribution, from the
+ * devtools.timeline.invalidationTracking events browsertime has
+ * always collected with --chrome.timeline but never parsed. The
+ * recalculate-style and layout totals say HOW MUCH invalidation work
+ * happened; these events say WHY and WHO:
+ *
+ *  - StyleRecalcInvalidationTracking: one event per invalidated node
+ *    with the reason ("Style rule change", "Node was inserted into
+ *    tree", "Affected by :has()", …) and often the JS stack that
+ *    caused it.
+ *  - ScheduleStyleInvalidationTracking: the DOM change that scheduled
+ *    an invalidation — which class/attribute/id/pseudo changed on
+ *    which node.
+ *  - LayoutInvalidationTracking: one event per node whose layout was
+ *    invalidated, with reason and often a stack.
+ *
+ * Aggregated three ways: reason counts (what kind of churn),
+ * trigger counts (which class/attribute names keep changing) and
+ * source counts (which script did it, from the innermost stack frame
+ * with a URL). One noisy script toggling a class on N nodes shows up
+ * as N invalidations from that URL with that class as the trigger —
+ * exactly the row a developer can act on.
+ *
+ * Counts, not milliseconds: the events are instant markers, the time
+ * they cause is already in cpu.categories.styleLayout and the
+ * recalculateStyle summaries.
+ *
+ * Returns undefined when the trace has no invalidation events.
+ * Otherwise:
+ *   { styleRecalcs, layoutInvalidations,
+ *     recalcReasons: [{ reason, count }, …],
+ *     layoutReasons: [{ reason, count }, …],
+ *     triggers:      [{ kind, name, count }, …],
+ *     sources:       [{ url, count }, …] }
+ */
+
+const MAX_REASONS = 10;
+const MAX_TRIGGERS = 15;
+const MAX_SOURCES = 10;
+
+function increment(map, key) {
+  if (!key) return;
+  map.set(key, (map.get(key) || 0) + 1);
+}
+
+function sourceUrl(data) {
+  for (const frame of data.stackTrace || []) {
+    if (frame.url) return frame.url;
+  }
+}
+
+function topEntries(map, limit, publish) {
+  return [...map.entries()]
+    .toSorted((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(entry => publish(entry));
+}
+
+export function computeStyleInvalidations(trace) {
+  const recalcReasons = new Map();
+  const layoutReasons = new Map();
+  const triggers = new Map();
+  const sources = new Map();
+  let styleRecalcs = 0;
+  let layoutInvalidations = 0;
+  let sawInvalidations = false;
+
+  for (const event of trace.traceEvents) {
+    const data = (event.args && event.args.data) || {};
+    switch (event.name) {
+      case 'StyleRecalcInvalidationTracking': {
+        sawInvalidations = true;
+        styleRecalcs++;
+        increment(recalcReasons, data.reason);
+        increment(sources, sourceUrl(data));
+        break;
+      }
+      case 'LayoutInvalidationTracking': {
+        sawInvalidations = true;
+        layoutInvalidations++;
+        increment(layoutReasons, data.reason);
+        increment(sources, sourceUrl(data));
+        break;
+      }
+      case 'ScheduleStyleInvalidationTracking': {
+        sawInvalidations = true;
+        if (data.changedClass) {
+          increment(triggers, `class|${data.changedClass}`);
+        }
+        if (data.changedAttribute) {
+          increment(triggers, `attribute|${data.changedAttribute}`);
+        }
+        if (data.changedId) {
+          increment(triggers, `id|${data.changedId}`);
+        }
+        if (data.changedPseudo) {
+          increment(triggers, `pseudo|${data.changedPseudo}`);
+        }
+        break;
+      }
+      default: {
+        continue;
+      }
+    }
+  }
+  if (!sawInvalidations) return;
+
+  return {
+    styleRecalcs,
+    layoutInvalidations,
+    recalcReasons: topEntries(
+      recalcReasons,
+      MAX_REASONS,
+      ([reason, count]) => ({
+        reason,
+        count
+      })
+    ),
+    layoutReasons: topEntries(
+      layoutReasons,
+      MAX_REASONS,
+      ([reason, count]) => ({
+        reason,
+        count
+      })
+    ),
+    triggers: topEntries(triggers, MAX_TRIGGERS, ([key, count]) => {
+      const [kind, ...name] = key.split('|');
+      return { kind, name: name.join('|'), count };
+    }),
+    sources: topEntries(sources, MAX_SOURCES, ([url, count]) => ({
+      url,
+      count
+    }))
+  };
+}

--- a/test/unittests/styleInvalidationsTest.js
+++ b/test/unittests/styleInvalidationsTest.js
@@ -1,0 +1,59 @@
+import test from 'ava';
+import { computeStyleInvalidations } from '../../lib/chrome/trace/style-invalidations.js';
+
+const SCRIPT_URL = 'https://en.example.org/w/script.js';
+
+function invalidationEvent(name, data) {
+  return { name, ts: 1, args: { data } };
+}
+
+test('aggregates invalidations by reason, trigger and source', t => {
+  const result = computeStyleInvalidations({
+    traceEvents: [
+      invalidationEvent('StyleRecalcInvalidationTracking', {
+        reason: 'Style rule change',
+        stackTrace: [{ url: SCRIPT_URL, lineNumber: 1, columnNumber: 1 }]
+      }),
+      invalidationEvent('StyleRecalcInvalidationTracking', {
+        reason: 'Style rule change'
+      }),
+      invalidationEvent('StyleRecalcInvalidationTracking', {
+        reason: 'Affected by :has()'
+      }),
+      invalidationEvent('LayoutInvalidationTracking', {
+        reason: 'Removed from layout',
+        // The innermost frame with a URL wins.
+        stackTrace: [{ functionName: 'inner' }, { url: SCRIPT_URL }]
+      }),
+      invalidationEvent('ScheduleStyleInvalidationTracking', {
+        changedClass: 'collapsed',
+        changedAttribute: 'aria-expanded'
+      }),
+      invalidationEvent('ScheduleStyleInvalidationTracking', {
+        changedClass: 'collapsed'
+      })
+    ]
+  });
+
+  t.is(result.styleRecalcs, 3);
+  t.is(result.layoutInvalidations, 1);
+  t.deepEqual(result.recalcReasons, [
+    { reason: 'Style rule change', count: 2 },
+    { reason: 'Affected by :has()', count: 1 }
+  ]);
+  t.deepEqual(result.layoutReasons, [
+    { reason: 'Removed from layout', count: 1 }
+  ]);
+  t.deepEqual(result.triggers, [
+    { kind: 'class', name: 'collapsed', count: 2 },
+    { kind: 'attribute', name: 'aria-expanded', count: 1 }
+  ]);
+  t.deepEqual(result.sources, [{ url: SCRIPT_URL, count: 2 }]);
+});
+
+test('returns undefined when the trace has no invalidation events', t => {
+  t.is(
+    computeStyleInvalidations({ traceEvents: [{ name: 'Layout' }] }),
+    undefined
+  );
+});


### PR DESCRIPTION
The invalidation-tracking trace category has been collected with --chrome.timeline for years without being parsed, so the recalculate-style totals could say how much invalidation work happened but never why. cpu.styleInvalidations now aggregates those events by reason, by trigger (which class or attribute keeps changing) and by source script, turning "style is expensive" into "this script toggles this attribute hundreds of times per load".

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I5fcde67f541b76745d2df3b13d0f7e65859af688