### PR TITLE
Surface CSS selector matching cost from the profile run

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -180,8 +180,12 @@ async function run(urls, options) {
           options.chrome.timeline = true;
           options.cpu = true;
           options.chrome.enableTraceScreenshots = true;
+          // v8.cpu_profiler feeds cpu.functionCosts; blink.debug
+          // emits SelectorStats for cpu.selectorStats. Both add
+          // overhead, which is fine here — this run is not measured.
           options.chrome.traceCategory = [
-            'disabled-by-default-v8.cpu_profiler'
+            'disabled-by-default-v8.cpu_profiler',
+            'disabled-by-default-blink.debug'
           ];
           options.chrome.coverage = true;
         }

--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -7,7 +7,8 @@ import {
   computeBlockingTime,
   computeDomainBreakdown,
   computeFrameStability,
-  computeStyleInvalidations
+  computeStyleInvalidations,
+  computeSelectorStats
 } from './trace/index.js';
 import { labelForUrl } from './mediawikiResourceLoader.js';
 const log = getLogger('browsertime.chrome.cpu');
@@ -147,6 +148,14 @@ export async function parseCPUTrace(tracelog, url) {
     } catch (error) {
       log.debug('computeStyleInvalidations failed: %s', error.message);
     }
+    // Only produces output when the SelectorStats trace category is
+    // on (--enableProfileRun); undefined omits the key.
+    let selectorStats;
+    try {
+      selectorStats = computeSelectorStats(tracelog);
+    } catch (error) {
+      log.debug('computeSelectorStats failed: %s', error.message);
+    }
 
     addResourceLoaderLabels(cleanedUrls);
     addResourceLoaderLabels(scriptCosts);
@@ -176,7 +185,8 @@ export async function parseCPUTrace(tracelog, url) {
       ...(blocking ? { blocking } : {}),
       ...(domains ? { domains } : {}),
       ...(frames ? { frames } : {}),
-      ...(styleInvalidations ? { styleInvalidations } : {})
+      ...(styleInvalidations ? { styleInvalidations } : {}),
+      ...(selectorStats ? { selectorStats } : {})
     };
   } catch (error) {
     log.error(

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -18,6 +18,7 @@ export { computeNonCompositedAnimations } from './non-composited-animations.js';
 export { computeFrameStability } from './frame-stability.js';
 export { computeFunctionCosts } from './function-costs.js';
 export { computeStyleInvalidations } from './style-invalidations.js';
+export { computeSelectorStats } from './selector-stats.js';
 export { computeBlockingTime } from './blocking-time.js';
 export { computeDomainBreakdown } from './domain-breakdown.js';
 

--- a/lib/chrome/trace/selector-stats.js
+++ b/lib/chrome/trace/selector-stats.js
@@ -1,0 +1,110 @@
+/**
+ * CSS selector matching cost, from Chrome's SelectorStats trace
+ * events (the disabled-by-default-blink.debug category, enabled on
+ * --enableProfileRun). For every style recalculation Chrome reports
+ * per-selector elapsed time, match attempts and match count — the
+ * same data DevTools' "CSS selector stats" checkbox shows. Style &
+ * layout often dominates main-thread blocking, and this is the only
+ * signal that says WHICH selectors the recalc time goes to.
+ *
+ * Selectors are aggregated across all recalcs in the trace. Two
+ * rankings matter and both are kept: elapsed time (what costs now)
+ * and match attempts with zero matches (pure waste — selectors
+ * evaluated against the whole document for rules that never apply,
+ * e.g. a lightbox selector on pages where the lightbox never opens).
+ *
+ * `styleSheetId` is Chrome's session-internal stylesheet handle —
+ * kept so consumers that also collect CSS coverage over CDP can join
+ * back to a stylesheet URL, but it is not stable across runs.
+ * 'ua-style-sheet' marks Chrome's own user-agent rules; those are
+ * not the page's to fix and are excluded from the reported lists
+ * (their time still counts in the totals).
+ *
+ * Returns undefined when the trace has no SelectorStats events (the
+ * category is only on for profile runs). Otherwise:
+ *   { totalElapsed, totalMatchAttempts, totalMatchCount,
+ *     selectors:      [{ selector, styleSheetId?, elapsed,
+ *                        matchAttempts, matchCount }, …],
+ *     wastedSelectors: [{ … same shape, matchCount always 0 }, …] }
+ * elapsed in ms with two decimals (individual selectors are sub-ms),
+ * both lists capped at 25 entries; selectors sorted by elapsed desc,
+ * wastedSelectors by matchAttempts desc.
+ */
+
+const MAX_SELECTORS = 25;
+const UA_STYLE_SHEET = 'ua-style-sheet';
+
+function round2(ms) {
+  return Math.round(ms * 100) / 100;
+}
+
+export function computeSelectorStats(trace) {
+  const bySelector = new Map();
+  let sawSelectorStats = false;
+  let totalElapsedUs = 0;
+  let totalMatchAttempts = 0;
+  let totalMatchCount = 0;
+
+  for (const event of trace.traceEvents) {
+    if (event.name !== 'SelectorStats') continue;
+    sawSelectorStats = true;
+    const timings =
+      (event.args &&
+        event.args.selector_stats &&
+        event.args.selector_stats.selector_timings) ||
+      [];
+    for (const timing of timings) {
+      const elapsedUs = timing['elapsed (us)'] || 0;
+      totalElapsedUs += elapsedUs;
+      totalMatchAttempts += timing.match_attempts || 0;
+      totalMatchCount += timing.match_count || 0;
+      if (timing.style_sheet_id === UA_STYLE_SHEET) continue;
+      const key = `${timing.selector}|${timing.style_sheet_id || ''}`;
+      let entry = bySelector.get(key);
+      if (!entry) {
+        entry = {
+          selector: timing.selector,
+          styleSheetId: timing.style_sheet_id,
+          elapsedUs: 0,
+          matchAttempts: 0,
+          matchCount: 0
+        };
+        bySelector.set(key, entry);
+      }
+      entry.elapsedUs += elapsedUs;
+      entry.matchAttempts += timing.match_attempts || 0;
+      entry.matchCount += timing.match_count || 0;
+    }
+  }
+  if (!sawSelectorStats) return;
+
+  function publish(entry) {
+    const result = {
+      selector: entry.selector,
+      elapsed: round2(entry.elapsedUs / 1000),
+      matchAttempts: entry.matchAttempts,
+      matchCount: entry.matchCount
+    };
+    if (entry.styleSheetId) result.styleSheetId = entry.styleSheetId;
+    return result;
+  }
+
+  const all = [...bySelector.values()];
+  const selectors = all
+    .toSorted((a, b) => b.elapsedUs - a.elapsedUs)
+    .slice(0, MAX_SELECTORS)
+    .map(entry => publish(entry));
+  const wastedSelectors = all
+    .filter(entry => entry.matchCount === 0)
+    .toSorted((a, b) => b.matchAttempts - a.matchAttempts)
+    .slice(0, MAX_SELECTORS)
+    .map(entry => publish(entry));
+
+  return {
+    totalElapsed: round2(totalElapsedUs / 1000),
+    totalMatchAttempts,
+    totalMatchCount,
+    selectors,
+    wastedSelectors
+  };
+}

--- a/test/unittests/selectorStatsTest.js
+++ b/test/unittests/selectorStatsTest.js
@@ -1,0 +1,69 @@
+import test from 'ava';
+import { computeSelectorStats } from '../../lib/chrome/trace/selector-stats.js';
+
+function selectorStatsEvent(timings) {
+  return {
+    name: 'SelectorStats',
+    ts: 1,
+    args: { selector_stats: { selector_timings: timings } }
+  };
+}
+
+function timing(selector, elapsedUs, attempts, matches, styleSheetId) {
+  return {
+    selector,
+    'elapsed (us)': elapsedUs,
+    match_attempts: attempts,
+    match_count: matches,
+    style_sheet_id: styleSheetId
+  };
+}
+
+test('aggregates selector timings across recalcs', t => {
+  const result = computeSelectorStats({
+    traceEvents: [
+      selectorStatsEvent([
+        timing('.slow > *', 900, 500, 0, 'sheet-1'),
+        timing('.hit', 100, 50, 10, 'sheet-1')
+      ]),
+      selectorStatsEvent([timing('.slow > *', 600, 300, 0, 'sheet-1')])
+    ]
+  });
+
+  t.is(result.totalElapsed, 1.6);
+  t.is(result.totalMatchAttempts, 850);
+  t.is(result.totalMatchCount, 10);
+  t.deepEqual(result.selectors[0], {
+    selector: '.slow > *',
+    elapsed: 1.5,
+    matchAttempts: 800,
+    matchCount: 0,
+    styleSheetId: 'sheet-1'
+  });
+  t.deepEqual(
+    result.wastedSelectors.map(s => s.selector),
+    ['.slow > *']
+  );
+});
+
+test('user-agent stylesheet selectors count in totals but are not listed', t => {
+  const result = computeSelectorStats({
+    traceEvents: [
+      selectorStatsEvent([
+        timing('svg:not(:root)', 500, 100, 0, 'ua-style-sheet'),
+        timing('.page', 100, 10, 5, 'sheet-1')
+      ])
+    ]
+  });
+
+  t.is(result.totalElapsed, 0.6);
+  t.deepEqual(
+    result.selectors.map(s => s.selector),
+    ['.page']
+  );
+  t.deepEqual(result.wastedSelectors, []);
+});
+
+test('returns undefined when the trace has no SelectorStats events', t => {
+  t.is(computeSelectorStats({ traceEvents: [{ name: 'Layout' }] }), undefined);
+});


### PR DESCRIPTION
Style and layout often dominates main-thread blocking but nothing said which selectors the recalc time went to. The profile run now also enables Chrome's SelectorStats category and the trace parser aggregates it into cpu.selectorStats: the slowest selectors by elapsed matching time, and the wasteful ones that rack up tens of thousands of match attempts without ever matching — pure removable cost. The extra category only runs on the profile run so measured runs stay unaffected.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ia849a4498e1fe85981b180148b6f01a536d8cc9d