### PR TITLE
Attribute setTimeout/setInterval pressure to the installing script

### DIFF
--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -8,7 +8,8 @@ import {
   computeDomainBreakdown,
   computeFrameStability,
   computeStyleInvalidations,
-  computeSelectorStats
+  computeSelectorStats,
+  computeTimerCosts
 } from './trace/index.js';
 import { labelForUrl } from './mediawikiResourceLoader.js';
 const log = getLogger('browsertime.chrome.cpu');
@@ -156,6 +157,12 @@ export async function parseCPUTrace(tracelog, url) {
     } catch (error) {
       log.debug('computeSelectorStats failed: %s', error.message);
     }
+    let timers;
+    try {
+      timers = computeTimerCosts(tracelog);
+    } catch (error) {
+      log.debug('computeTimerCosts failed: %s', error.message);
+    }
 
     addResourceLoaderLabels(cleanedUrls);
     addResourceLoaderLabels(scriptCosts);
@@ -173,6 +180,9 @@ export async function parseCPUTrace(tracelog, url) {
     if (styleInvalidations) {
       addResourceLoaderLabels(styleInvalidations.sources);
     }
+    if (timers) {
+      addResourceLoaderLabels(timers.byUrl);
+    }
 
     log.debug('Chrome trace log finished parsed and sorted.');
     return {
@@ -186,7 +196,8 @@ export async function parseCPUTrace(tracelog, url) {
       ...(domains ? { domains } : {}),
       ...(frames ? { frames } : {}),
       ...(styleInvalidations ? { styleInvalidations } : {}),
-      ...(selectorStats ? { selectorStats } : {})
+      ...(selectorStats ? { selectorStats } : {}),
+      ...(timers ? { timers } : {})
     };
   } catch (error) {
     log.error(

--- a/lib/chrome/trace/index.js
+++ b/lib/chrome/trace/index.js
@@ -19,6 +19,7 @@ export { computeFrameStability } from './frame-stability.js';
 export { computeFunctionCosts } from './function-costs.js';
 export { computeStyleInvalidations } from './style-invalidations.js';
 export { computeSelectorStats } from './selector-stats.js';
+export { computeTimerCosts } from './timer-costs.js';
 export { computeBlockingTime } from './blocking-time.js';
 export { computeDomainBreakdown } from './domain-breakdown.js';
 

--- a/lib/chrome/trace/timer-costs.js
+++ b/lib/chrome/trace/timer-costs.js
@@ -1,0 +1,121 @@
+/**
+ * Timer pressure per script — how much setTimeout/setInterval churn
+ * a page runs, from trace events already collected with
+ * --chrome.timeline.
+ *
+ * Two sides are joined per URL:
+ *  - TimerInstall events (instant): who schedules timers, how many,
+ *    how many with timeout 0 (the "yield" pattern that turns into
+ *    main-thread machine-gunning) and how many recurring
+ *    (setInterval / singleShot: false). Attribution from the
+ *    innermost stack frame with a URL.
+ *  - TimerFire tasks from the main-thread task tree: what running
+ *    those timers actually cost. main-thread-tasks.js already chains
+ *    TimerFire back to the installing script's URLs, so the cost
+ *    lands on the script that scheduled the timer even when the
+ *    callback is anonymous.
+ *
+ * Polling loops show up as a high install/fire count with recurring
+ * installs on one URL; oversliced work shows up as hundreds of
+ * timeout-0 installs. Fire time is inclusive task duration — what
+ * the main thread was occupied with when the timer ran.
+ *
+ * Returns undefined when the trace has no timer events. Otherwise:
+ *   { installs, fires, fireTime, timeoutZeroInstalls,
+ *     recurringInstalls,
+ *     byUrl: [{ url, installs, fires, fireTime,
+ *               timeoutZeroInstalls, recurringInstalls }, …] }
+ * fireTime in ms with one decimal; byUrl sorted by fireTime desc,
+ * capped at 10 entries with sub-0.1 ms/zero-install rows dropped.
+ */
+
+import { compute } from './main-thread-tasks.js';
+
+const MAX_URLS = 10;
+const UNKNOWN = 'unknown';
+
+function round(ms) {
+  return Math.round(ms * 10) / 10;
+}
+
+function installUrl(data) {
+  for (const frame of data.stackTrace || []) {
+    if (frame.url) return frame.url;
+  }
+  return UNKNOWN;
+}
+
+export function computeTimerCosts(trace) {
+  const byUrl = new Map();
+  let installs = 0;
+  let fires = 0;
+  let fireTimeMs = 0;
+  let timeoutZeroInstalls = 0;
+  let recurringInstalls = 0;
+
+  function entryFor(url) {
+    let entry = byUrl.get(url);
+    if (!entry) {
+      entry = {
+        url,
+        installs: 0,
+        fires: 0,
+        fireTimeMs: 0,
+        timeoutZeroInstalls: 0,
+        recurringInstalls: 0
+      };
+      byUrl.set(url, entry);
+    }
+    return entry;
+  }
+
+  for (const event of trace.traceEvents) {
+    if (event.name !== 'TimerInstall') continue;
+    const data = (event.args && event.args.data) || {};
+    const entry = entryFor(installUrl(data));
+    installs++;
+    entry.installs++;
+    if ((data.timeout || 0) === 0) {
+      timeoutZeroInstalls++;
+      entry.timeoutZeroInstalls++;
+    }
+    if (data.singleShot === false) {
+      recurringInstalls++;
+      entry.recurringInstalls++;
+    }
+  }
+
+  const tasks = compute(trace);
+  for (const task of tasks) {
+    if (task.event.name !== 'TimerFire') continue;
+    const entry = entryFor(task.attributableURLs.at(-1) || UNKNOWN);
+    fires++;
+    fireTimeMs += task.duration;
+    entry.fires++;
+    entry.fireTimeMs += task.duration;
+  }
+
+  if (installs === 0 && fires === 0) return;
+
+  const urls = [...byUrl.values()]
+    .filter(entry => entry.fireTimeMs >= 0.1 || entry.installs > 0)
+    .toSorted((a, b) => b.fireTimeMs - a.fireTimeMs || b.installs - a.installs)
+    .slice(0, MAX_URLS)
+    .map(entry => ({
+      url: entry.url,
+      installs: entry.installs,
+      fires: entry.fires,
+      fireTime: round(entry.fireTimeMs),
+      timeoutZeroInstalls: entry.timeoutZeroInstalls,
+      recurringInstalls: entry.recurringInstalls
+    }));
+
+  return {
+    installs,
+    fires,
+    fireTime: round(fireTimeMs),
+    timeoutZeroInstalls,
+    recurringInstalls,
+    byUrl: urls
+  };
+}

--- a/test/unittests/timerCostsTest.js
+++ b/test/unittests/timerCostsTest.js
@@ -1,0 +1,112 @@
+import test from 'ava';
+import { computeTimerCosts } from '../../lib/chrome/trace/timer-costs.js';
+
+const PID = 1;
+const TID = 2;
+const FRAME = 'FRAME0';
+const SCRIPT_URL = 'https://en.example.org/w/app.js';
+
+// Same minimal-but-valid skeleton as moduleCostsTest: enough metadata
+// for trace-of-tab, one script task that installs a timer (instant
+// event inside it), and a later TimerFire task that main-thread-tasks
+// attributes back to the installing script.
+function syntheticTrace() {
+  return {
+    traceEvents: [
+      {
+        name: 'TracingStartedInBrowser',
+        cat: 'disabled-by-default-devtools.timeline',
+        ph: 'I',
+        pid: 100,
+        tid: 100,
+        ts: 900_000,
+        args: { data: { frames: [{ frame: FRAME, processId: PID }] } }
+      },
+      {
+        name: 'thread_name',
+        cat: '__metadata',
+        ph: 'M',
+        pid: PID,
+        tid: TID,
+        ts: 0,
+        args: { name: 'CrRendererMain' }
+      },
+      {
+        name: 'navigationStart',
+        cat: 'blink.user_timing',
+        ph: 'R',
+        pid: PID,
+        tid: TID,
+        ts: 1_000_000,
+        args: {
+          frame: FRAME,
+          data: { documentLoaderURL: 'https://en.example.org/wiki/Page' }
+        }
+      },
+      {
+        name: 'EvaluateScript',
+        cat: 'devtools.timeline',
+        ph: 'X',
+        pid: PID,
+        tid: TID,
+        ts: 1_050_000,
+        dur: 30_000,
+        args: { data: { url: SCRIPT_URL } }
+      },
+      {
+        name: 'TimerInstall',
+        cat: 'devtools.timeline',
+        ph: 'I',
+        pid: PID,
+        tid: TID,
+        ts: 1_060_000,
+        args: {
+          data: {
+            timerId: 7,
+            timeout: 0,
+            singleShot: false,
+            stackTrace: [{ url: SCRIPT_URL, lineNumber: 1, columnNumber: 1 }]
+          }
+        }
+      },
+      {
+        name: 'TimerFire',
+        cat: 'devtools.timeline',
+        ph: 'X',
+        pid: PID,
+        tid: TID,
+        ts: 1_200_000,
+        dur: 25_000,
+        args: { data: { timerId: 7 } }
+      }
+    ]
+  };
+}
+
+test('joins timer installs with the cost of firing them', t => {
+  const result = computeTimerCosts(syntheticTrace());
+
+  t.is(result.installs, 1);
+  t.is(result.fires, 1);
+  t.is(result.fireTime, 25);
+  t.is(result.timeoutZeroInstalls, 1);
+  t.is(result.recurringInstalls, 1);
+  t.deepEqual(result.byUrl, [
+    {
+      url: SCRIPT_URL,
+      installs: 1,
+      fires: 1,
+      fireTime: 25,
+      timeoutZeroInstalls: 1,
+      recurringInstalls: 1
+    }
+  ]);
+});
+
+test('returns undefined when the trace has no timer events', t => {
+  const trace = syntheticTrace();
+  trace.traceEvents = trace.traceEvents.filter(
+    e => e.name !== 'TimerInstall' && e.name !== 'TimerFire'
+  );
+  t.is(computeTimerCosts(trace), undefined);
+});


### PR DESCRIPTION
Timer callbacks are usually anonymous, so timer-heavy pages showed the cost under setTimeout with no owner. cpu.timers joins TimerInstall events with the cost of the TimerFire tasks — already chained back to the installer by the task tree — per script: installs, fires, main-thread fire time, plus timeout-0 and recurring counts that expose oversliced work and polling loops.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I3d7d5765137615952dcfaed25a241f802c698ef5