### PR TITLE
List the individual timers behind the per-script totals

### DIFF
--- a/lib/chrome/parseCpuTrace.js
+++ b/lib/chrome/parseCpuTrace.js
@@ -182,6 +182,7 @@ export async function parseCPUTrace(tracelog, url) {
     }
     if (timers) {
       addResourceLoaderLabels(timers.byUrl);
+      addResourceLoaderLabels(timers.sites);
     }
 
     log.debug('Chrome trace log finished parsed and sorted.');

--- a/lib/chrome/trace/timer-costs.js
+++ b/lib/chrome/trace/timer-costs.js
@@ -24,29 +24,40 @@
  *   { installs, fires, fireTime, timeoutZeroInstalls,
  *     recurringInstalls,
  *     byUrl: [{ url, installs, fires, fireTime,
- *               timeoutZeroInstalls, recurringInstalls }, …] }
+ *               timeoutZeroInstalls, recurringInstalls }, …],
+ *     sites: [{ url, line?, column?, functionName?, timeout,
+ *               recurring, installs, fires, fireTime }, …] }
  * fireTime in ms with one decimal; byUrl sorted by fireTime desc,
  * capped at 10 entries with sub-0.1 ms/zero-install rows dropped.
+ * `sites` lists the individual timers grouped by install site
+ * (installer source position + timeout + kind) — the closest thing
+ * to a timer's identity the trace offers — top 10 by fire time.
+ * Positions are 1-based (trace stack-frame convention).
  */
 
 import { compute } from './main-thread-tasks.js';
 
 const MAX_URLS = 10;
+const MAX_SITES = 10;
 const UNKNOWN = 'unknown';
 
 function round(ms) {
   return Math.round(ms * 10) / 10;
 }
 
-function installUrl(data) {
+function installFrame(data) {
   for (const frame of data.stackTrace || []) {
-    if (frame.url) return frame.url;
+    if (frame.url) return frame;
   }
-  return UNKNOWN;
 }
 
 export function computeTimerCosts(trace) {
   const byUrl = new Map();
+  // Individual timers grouped by install site (installer source
+  // position + timeout + kind): a polling loop reinstalling from the
+  // same line collapses into one row with its install/fire counts.
+  const bySite = new Map();
+  const siteForTimerId = new Map();
   let installs = 0;
   let fires = 0;
   let fireTimeMs = 0;
@@ -72,17 +83,43 @@ export function computeTimerCosts(trace) {
   for (const event of trace.traceEvents) {
     if (event.name !== 'TimerInstall') continue;
     const data = (event.args && event.args.data) || {};
-    const entry = entryFor(installUrl(data));
+    const frame = installFrame(data);
+    const entry = entryFor(frame ? frame.url : UNKNOWN);
     installs++;
     entry.installs++;
-    if ((data.timeout || 0) === 0) {
+    const timeout = data.timeout || 0;
+    if (timeout === 0) {
       timeoutZeroInstalls++;
       entry.timeoutZeroInstalls++;
     }
-    if (data.singleShot === false) {
+    const recurring = data.singleShot === false;
+    if (recurring) {
       recurringInstalls++;
       entry.recurringInstalls++;
     }
+
+    const siteKey = frame
+      ? `${frame.url}|${frame.lineNumber}|${frame.columnNumber}|${timeout}|${recurring}`
+      : `${UNKNOWN}|${timeout}|${recurring}`;
+    let site = bySite.get(siteKey);
+    if (!site) {
+      site = {
+        url: frame ? frame.url : UNKNOWN,
+        timeout,
+        recurring,
+        installs: 0,
+        fires: 0,
+        fireTimeMs: 0
+      };
+      if (frame) {
+        site.line = frame.lineNumber;
+        site.column = frame.columnNumber;
+        if (frame.functionName) site.functionName = frame.functionName;
+      }
+      bySite.set(siteKey, site);
+    }
+    site.installs++;
+    if (data.timerId !== undefined) siteForTimerId.set(data.timerId, site);
   }
 
   const tasks = compute(trace);
@@ -93,6 +130,12 @@ export function computeTimerCosts(trace) {
     fireTimeMs += task.duration;
     entry.fires++;
     entry.fireTimeMs += task.duration;
+    const fireData = (task.event.args && task.event.args.data) || {};
+    const site = siteForTimerId.get(fireData.timerId);
+    if (site) {
+      site.fires++;
+      site.fireTimeMs += task.duration;
+    }
   }
 
   if (installs === 0 && fires === 0) return;
@@ -110,12 +153,31 @@ export function computeTimerCosts(trace) {
       recurringInstalls: entry.recurringInstalls
     }));
 
+  const sites = [...bySite.values()]
+    .toSorted((a, b) => b.fireTimeMs - a.fireTimeMs || b.installs - a.installs)
+    .slice(0, MAX_SITES)
+    .map(site => {
+      const published = {
+        url: site.url,
+        timeout: site.timeout,
+        recurring: site.recurring,
+        installs: site.installs,
+        fires: site.fires,
+        fireTime: round(site.fireTimeMs)
+      };
+      if (site.line !== undefined) published.line = site.line;
+      if (site.column !== undefined) published.column = site.column;
+      if (site.functionName) published.functionName = site.functionName;
+      return published;
+    });
+
   return {
     installs,
     fires,
     fireTime: round(fireTimeMs),
     timeoutZeroInstalls,
     recurringInstalls,
-    byUrl: urls
+    byUrl: urls,
+    sites
   };
 }

--- a/test/unittests/timerCostsTest.js
+++ b/test/unittests/timerCostsTest.js
@@ -101,6 +101,19 @@ test('joins timer installs with the cost of firing them', t => {
       recurringInstalls: 1
     }
   ]);
+  // The individual timer, identified by its install site.
+  t.deepEqual(result.sites, [
+    {
+      url: SCRIPT_URL,
+      timeout: 0,
+      recurring: true,
+      installs: 1,
+      fires: 1,
+      fireTime: 25,
+      line: 1,
+      column: 1
+    }
+  ]);
 });
 
 test('returns undefined when the trace has no timer events', t => {


### PR DESCRIPTION
The timer pressure summary said a script installed 47 timers costing 70 ms but not which timers — and timer callbacks are usually anonymous, so the reader had nowhere to go next. cpu.timers now includes the timers themselves, grouped by install site (installer source position, timeout and kind), so a polling loop reinstalling from the same line reads as one offender with its install count, fire count and fire time instead of disappearing into an aggregate.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I6f5aa53c2e862b9a2bb2995d51ef382ea4f60830