### PR TITLE
Resolve timer install sites to their ResourceLoader module

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -477,6 +477,26 @@ export class Chromium {
       } catch (error) {
         log.debug('computeFunctionCosts failed: %s', error.message);
       }
+      // Timer install sites inside concatenated bundles resolve to
+      // the owning module — "load.php[scripts]:418" says nothing,
+      // the module name says whose timer it is. Trace stack-frame
+      // positions are 1-based, matching the resolvers.
+      if (
+        cpu.timers &&
+        cpu.timers.sites &&
+        this.resourceLoaderBundles &&
+        this.resourceLoaderBundles.size > 0
+      ) {
+        for (const site of cpu.timers.sites) {
+          if (site.line === undefined) continue;
+          const resolver = this.resourceLoaderBundles.get(site.url);
+          if (!resolver) continue;
+          const module_ = resolver.resolve(site.line, site.column);
+          if (module_) {
+            site.module = module_.name;
+          }
+        }
+      }
       this.resourceLoaderBundles = undefined;
       result.cpu = cpu;
 


### PR DESCRIPTION
The new timer list identifies each timer by its install position, but on bundled sites a position like load.php[scripts]:418 says nothing about whose code it is. Install sites inside concatenated bundles are now resolved to the owning module via the coverage-path resolvers, the same join module and function costs use — on Wikipedia the timeout-0 offender turns out to be jquery's deferred machinery, an answer the line number alone could never give.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I25d76517408ac4b4c3206293ced65603a56d4f85