### PR TITLE
Resolve invalidation sources to their ResourceLoader module

### DIFF
--- a/lib/chrome/trace/style-invalidations.js
+++ b/lib/chrome/trace/style-invalidations.js
@@ -26,13 +26,18 @@
  * they cause is already in cpu.categories.styleLayout and the
  * recalculateStyle summaries.
  *
+ * When the optional `bundles` map (url → location resolver from the
+ * coverage path) is passed, source frames inside concatenated
+ * bundles resolve to the owning module — thousands of invalidations
+ * from one giant load.php URL split into per-module rows.
+ *
  * Returns undefined when the trace has no invalidation events.
  * Otherwise:
  *   { styleRecalcs, layoutInvalidations,
  *     recalcReasons: [{ reason, count }, …],
  *     layoutReasons: [{ reason, count }, …],
  *     triggers:      [{ kind, name, count }, …],
- *     sources:       [{ url, count }, …] }
+ *     sources:       [{ url, module?, count }, …] }
  */
 
 const MAX_REASONS = 10;
@@ -44,9 +49,30 @@ function increment(map, key) {
   map.set(key, (map.get(key) || 0) + 1);
 }
 
-function sourceUrl(data) {
+// Source identity for an invalidation: the innermost stack frame
+// with a URL, resolved to the owning module when the frame lands in
+// a known concatenated bundle (trace stack-frame positions are
+// 1-based, matching the resolvers). Without bundles the identity is
+// just the URL — the pre-existing behaviour.
+function sourceEntryFor(sources, data, bundles) {
   for (const frame of data.stackTrace || []) {
-    if (frame.url) return frame.url;
+    if (!frame.url) continue;
+    let module_;
+    if (bundles && frame.lineNumber !== undefined) {
+      const resolver = bundles.get(frame.url);
+      if (resolver) {
+        module_ = resolver.resolve(frame.lineNumber, frame.columnNumber);
+      }
+    }
+    const key = module_ ? `${frame.url}|${module_.name}` : frame.url;
+    let entry = sources.get(key);
+    if (!entry) {
+      entry = { url: frame.url, count: 0 };
+      if (module_) entry.module = module_.name;
+      sources.set(key, entry);
+    }
+    entry.count++;
+    return;
   }
 }
 
@@ -57,7 +83,7 @@ function topEntries(map, limit, publish) {
     .map(entry => publish(entry));
 }
 
-export function computeStyleInvalidations(trace) {
+export function computeStyleInvalidations(trace, bundles) {
   const recalcReasons = new Map();
   const layoutReasons = new Map();
   const triggers = new Map();
@@ -73,14 +99,14 @@ export function computeStyleInvalidations(trace) {
         sawInvalidations = true;
         styleRecalcs++;
         increment(recalcReasons, data.reason);
-        increment(sources, sourceUrl(data));
+        sourceEntryFor(sources, data, bundles);
         break;
       }
       case 'LayoutInvalidationTracking': {
         sawInvalidations = true;
         layoutInvalidations++;
         increment(layoutReasons, data.reason);
-        increment(sources, sourceUrl(data));
+        sourceEntryFor(sources, data, bundles);
         break;
       }
       case 'ScheduleStyleInvalidationTracking': {
@@ -129,9 +155,8 @@ export function computeStyleInvalidations(trace) {
       const [kind, ...name] = key.split('|');
       return { kind, name: name.join('|'), count };
     }),
-    sources: topEntries(sources, MAX_SOURCES, ([url, count]) => ({
-      url,
-      count
-    }))
+    sources: [...sources.values()]
+      .toSorted((a, b) => b.count - a.count)
+      .slice(0, MAX_SOURCES)
   };
 }

--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -9,6 +9,7 @@ import { longTaskMetrics } from '../longTaskMetrics.js';
 import { parseCPUTrace } from '../parseCpuTrace.js';
 import { computeModuleCosts } from '../trace/module-costs.js';
 import { computeFunctionCosts } from '../trace/function-costs.js';
+import { computeStyleInvalidations } from '../trace/style-invalidations.js';
 import { labelForUrl } from '../mediawikiResourceLoader.js';
 import { getHar } from '../har.js';
 import { getEmptyHAR, mergeHars } from '../../support/har/index.js';
@@ -476,6 +477,37 @@ export class Chromium {
         }
       } catch (error) {
         log.debug('computeFunctionCosts failed: %s', error.message);
+      }
+      // Invalidation sources resolve to modules the same way —
+      // thousands of invalidations from one giant load.php URL say
+      // nothing, the per-module split says whose code churns the
+      // DOM. Recomputing with the bundles replaces the unresolved
+      // sources parseCpuTrace produced.
+      if (
+        cpu.styleInvalidations &&
+        this.resourceLoaderBundles &&
+        this.resourceLoaderBundles.size > 0
+      ) {
+        try {
+          const enriched = computeStyleInvalidations(
+            trace,
+            this.resourceLoaderBundles
+          );
+          if (enriched) {
+            for (const source of enriched.sources) {
+              const label = labelForUrl(source.url);
+              if (label) {
+                source.label = label;
+              }
+            }
+            cpu.styleInvalidations = enriched;
+          }
+        } catch (error) {
+          log.debug(
+            'computeStyleInvalidations with bundles failed: %s',
+            error.message
+          );
+        }
       }
       // Timer install sites inside concatenated bundles resolve to
       // the owning module — "load.php[scripts]:418" says nothing,

--- a/test/unittests/styleInvalidationsTest.js
+++ b/test/unittests/styleInvalidationsTest.js
@@ -1,7 +1,15 @@
 import test from 'ava';
 import { computeStyleInvalidations } from '../../lib/chrome/trace/style-invalidations.js';
+import { resourceLoaderLocationResolver } from '../../lib/chrome/mediawikiResourceLoader.js';
 
 const SCRIPT_URL = 'https://en.example.org/w/script.js';
+const BUNDLE_URL = 'https://en.example.org/w/load.php?modules=a|b';
+
+// line 1: preamble, line 2: module.one, line 3: module.two
+const bundleSource =
+  '/* preamble */\n' +
+  'mw.loader.impl(function(){return["module.one@abc12",function(){}];});\n' +
+  'mw.loader.impl(function(){return["module.two@def34",function(){}];});';
 
 function invalidationEvent(name, data) {
   return { name, ts: 1, args: { data } };
@@ -49,6 +57,36 @@ test('aggregates invalidations by reason, trigger and source', t => {
     { kind: 'attribute', name: 'aria-expanded', count: 1 }
   ]);
   t.deepEqual(result.sources, [{ url: SCRIPT_URL, count: 2 }]);
+});
+
+test('resolves invalidation sources to modules when bundles are known', t => {
+  const bundles = new Map([
+    [BUNDLE_URL, resourceLoaderLocationResolver(bundleSource)]
+  ]);
+  const result = computeStyleInvalidations(
+    {
+      traceEvents: [
+        invalidationEvent('StyleRecalcInvalidationTracking', {
+          reason: 'Style rule change',
+          stackTrace: [{ url: BUNDLE_URL, lineNumber: 2, columnNumber: 1 }]
+        }),
+        invalidationEvent('LayoutInvalidationTracking', {
+          reason: 'Removed from layout',
+          stackTrace: [{ url: BUNDLE_URL, lineNumber: 2, columnNumber: 5 }]
+        }),
+        invalidationEvent('StyleRecalcInvalidationTracking', {
+          reason: 'Style rule change',
+          stackTrace: [{ url: BUNDLE_URL, lineNumber: 3, columnNumber: 1 }]
+        })
+      ]
+    },
+    bundles
+  );
+
+  t.deepEqual(result.sources, [
+    { url: BUNDLE_URL, module: 'module.one', count: 2 },
+    { url: BUNDLE_URL, module: 'module.two', count: 1 }
+  ]);
 });
 
 test('returns undefined when the trace has no invalidation events', t => {


### PR DESCRIPTION
The invalidation source list attributed DOM churn to URLs, which on bundled sites collapses into one giant load.php row — 1,680 invalidations from "the big bundle" names no owner. Sources are now aggregated per module when the coverage bundle resolvers are available, using the same position join as timer install sites, so the row splits into the modules whose code actually invalidates style and layout.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ieec4807d1d7a37c9e96dc297f543ebf174b8666f