### PR TITLE
Ship per-script startTime and duration in the LoAF pageinfo data

### DIFF
--- a/browserscripts/pageinfo/loaf.js
+++ b/browserscripts/pageinfo/loaf.js
@@ -29,6 +29,11 @@
       info.scripts = [];
       for (let script of entry.scripts) {
         const s = {};
+        // startTime + duration make per-script attribution possible:
+        // without them a frame's blocking can only be credited to
+        // every script that ran in it.
+        s.startTime = script.startTime;
+        s.duration = script.duration;
         s.forcedStyleAndLayoutDuration = script.forcedStyleAndLayoutDuration;
         s.invoker = script.invoker;
         s.invokerType = script.invokerType;


### PR DESCRIPTION
Without them a frame's blocking time can only be credited to every script that ran in the frame, so downstream tools (the sitespeed.io report) show competing heuristics instead of an answer to "which script do I fix". With start and duration per script, blocking can be attributed proportionally to actual run time. Additive fields only.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I42dd752ecc6c55f81f9703389eff20293a37a8b6