### PR TITLE
Ship frame startTime and firstUIEventTimestamp in the LoAF pageinfo data

### DIFF
--- a/browserscripts/pageinfo/loaf.js
+++ b/browserscripts/pageinfo/loaf.js
@@ -17,6 +17,11 @@
     // re-package
     for (let entry of longestBlockingLoAFs) {
       const info = {};
+      // startTime places the frame on the page timeline (before or
+      // after FCP/LCP/load); firstUIEventTimestamp > 0 means an input
+      // was waiting while this frame blocked — the INP connection.
+      info.startTime = entry.startTime;
+      info.firstUIEventTimestamp = entry.firstUIEventTimestamp;
       info.blockingDuration = entry.blockingDuration;
       info.duration = entry.duration;
       info.styleAndLayoutStart = entry.styleAndLayoutStart;


### PR DESCRIPTION
The frames are sorted by blocking time, so without a timestamp there is no way to tell render-critical pre-LCP work from harmless post-load churn — the single biggest triage question. firstUIEventTimestamp also says whether an input was waiting during the frame, which is the INP connection the docs currently only assert in prose. Additive fields only.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I0c27f60b409f5e9b83a5c2f00bf881a781c8a2d8