### PR TITLE
Add a LoAF summary with totals over every long animation frame

### DIFF
--- a/browserscripts/pageinfo/loafSummary.js
+++ b/browserscripts/pageinfo/loafSummary.js
@@ -1,0 +1,24 @@
+(function () {
+  // The loaf script ships only the 10 frames with the most blocking
+  // time, so its numbers understate busy pages. These totals are
+  // computed over every long animation frame before the cut.
+  if (
+    PerformanceObserver.supportedEntryTypes.includes('long-animation-frame')
+  ) {
+    const observer = new PerformanceObserver(list => {});
+    observer.observe({type: 'long-animation-frame', buffered: true});
+    const entries = observer.takeRecords();
+
+    let totalBlockingDuration = 0;
+    let totalDuration = 0;
+    for (let entry of entries) {
+      totalBlockingDuration += entry.blockingDuration;
+      totalDuration += entry.duration;
+    }
+    return {
+      totalFrames: entries.length,
+      totalBlockingDuration,
+      totalDuration
+    };
+  }
+})();


### PR DESCRIPTION
The loaf pageinfo script deliberately ships only the 10 frames with the most blocking, so any total computed from it understates busy pages and users compare a lower bound against TBT without knowing it. The new pageinfo.loafSummary key carries frame count, total blocking and total duration over all frames, computed before the cut. A sibling key keeps the existing loaf array untouched.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I0b9788a79d8b637d3e500c00151d5fc2d26ac93d