### PR TITLE
Resolve LoAF script URLs to ResourceLoader module labels

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -395,6 +395,20 @@ export class Chromium {
     // this hack fixes that
     if (result.browserScripts && result.browserScripts.pageinfo) {
       result.browserScripts.pageinfo.longTask = this.longTaskInfo;
+
+      // Resolve LoAF script URLs to ResourceLoader module labels the
+      // same way cpu.urls gets them — several frames all blaming one
+      // giant load.php URL say nothing without the module name.
+      if (Array.isArray(result.browserScripts.pageinfo.loaf)) {
+        for (const frame of result.browserScripts.pageinfo.loaf) {
+          for (const script of frame.scripts || []) {
+            const label = labelForUrl(script.sourceURL);
+            if (label) {
+              script.label = label;
+            }
+          }
+        }
+      }
     }
 
     if (this.chrome.collectNetLog && this.chrome.android) {


### PR DESCRIPTION
On MediaWiki sites several frames can all blame the same giant load.php URL, which makes the culprit list unactionable — three identical rows with different numbers. The scripts now get the same label treatment as cpu.urls (load.php[startup] and friends), applied Node-side after each URL. Additive field only.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I5d11ea7936d9b61699539b0fe00b01fda200eb71