### PR TITLE
Ship the remaining LoAF per-script fields

### DIFF
--- a/browserscripts/pageinfo/loaf.js
+++ b/browserscripts/pageinfo/loaf.js
@@ -39,6 +39,11 @@
         // every script that ran in it.
         s.startTime = script.startTime;
         s.duration = script.duration;
+        // executionStart - startTime is queue/compile delay before the
+        // script ran; pauseDuration separates "computed the whole time"
+        // from "sat in a sync pause" (alert, sync XHR).
+        s.executionStart = script.executionStart;
+        s.pauseDuration = script.pauseDuration;
         s.forcedStyleAndLayoutDuration = script.forcedStyleAndLayoutDuration;
         s.invoker = script.invoker;
         s.invokerType = script.invokerType;


### PR DESCRIPTION
executionStart reveals queue/compile delay before a script ran (executionStart - startTime), and pauseDuration separates a script that computed the whole time from one that sat in a synchronous pause like alert or sync XHR. With these the LoAF data carries every per-script field the API exposes, so per-script diagnosis downstream never has to wait for another engine release. Additive fields only.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I5100834932fc443b9be7544ca80f44fcf0be2c6a