### PR TITLE
Label every multi-module load.php batch with its first module

### DIFF
--- a/lib/chrome/mediawikiResourceLoader.js
+++ b/lib/chrome/mediawikiResourceLoader.js
@@ -96,11 +96,13 @@ export function labelForUrl(url) {
     return 'load.php[startup]';
   }
   const kind = only === 'styles' ? 'styles' : 'scripts';
-  if (modules.length === 1) {
+  // Every multi-module batch carries its (alphabetically) first module
+  // name. Real pages lazy-load several general batches (no `only=`)
+  // over time, so a bare load.php[scripts] label collides as soon as
+  // there is more than one — and the single-module case already names
+  // general batches like raw ones.
+  if (modules.length > 0) {
     return `load.php[${kind}:${modules[0]}]`;
-  }
-  if (modules.length > 1 && only === 'scripts') {
-    return `load.php[scripts:${modules[0]}]`;
   }
   return `load.php[${kind}]`;
 }

--- a/test/unittests/mediawikiResourceLoaderTest.js
+++ b/test/unittests/mediawikiResourceLoaderTest.js
@@ -128,12 +128,12 @@ test('labels the startup request', t => {
   );
 });
 
-test('labels the top-queue styles batch', t => {
+test('labels the top-queue styles batch with its first module', t => {
   t.is(
     labelForUrl(
       `${loadPhp}?lang=en&modules=ext.cite.styles%7Cskins.vector.styles&only=styles&skin=vector-2022`
     ),
-    'load.php[styles]'
+    'load.php[styles:ext.cite.styles]'
   );
 });
 
@@ -144,12 +144,12 @@ test('labels a single-module styles request with the module name', t => {
   );
 });
 
-test('labels the big general bundle', t => {
+test('labels the big general bundle with its first module', t => {
   t.is(
     labelForUrl(
       `${loadPhp}?lang=en&modules=ext.centralNotice.startUp%2CchoiceData%7Cext.echo.centralauth%7Cmediawiki.page.ready&skin=vector-2022&version=1u4qz`
     ),
-    'load.php[scripts]'
+    'load.php[scripts:ext.centralNotice.choiceData]'
   );
 });
 
@@ -164,16 +164,18 @@ test('version, lang and skin parameters never affect the label', t => {
   t.is(before, 'load.php[scripts:jquery]');
 });
 
-test('raw script batches are disambiguated from the general bundle', t => {
-  const base = labelForUrl(
-    `${loadPhp}?lang=en&modules=jquery%7Cmediawiki.base&only=scripts`
+// Pages lazy-load several general batches (no `only=`) over time, so
+// a shared bare label would collide as soon as there is more than one.
+test('several general batches get distinct labels', t => {
+  const bigBundle = labelForUrl(
+    `${loadPhp}?lang=en&modules=ext.centralNotice.display%2CgeoIP%7Cmediawiki.page.ready&skin=vector-2022`
   );
-  const general = labelForUrl(
-    `${loadPhp}?lang=en&modules=jquery%7Cmediawiki.base&skin=vector-2022`
+  const lazyBatch = labelForUrl(
+    `${loadPhp}?lang=en&modules=ext.cite.referencePreviews%7Cext.math.popup%7Cext.popups.main&skin=vector-2022`
   );
-  t.is(base, 'load.php[scripts:jquery]');
-  t.is(general, 'load.php[scripts]');
-  t.not(base, general);
+  t.is(bigBundle, 'load.php[scripts:ext.centralNotice.display]');
+  t.is(lazyBatch, 'load.php[scripts:ext.cite.referencePreviews]');
+  t.not(bigBundle, lazyBatch);
 });
 
 test('expands packed module lists when picking the first sorted name', t => {


### PR DESCRIPTION
labelForUrl assumed a page has one general bundle (no only= parameter) and gave it the bare load.php[scripts] label. Real pages lazy-load several general batches over time, so the bare label collides as soon as there is more than one — on en.wikipedia.org the page bundle and the popups batch became indistinguishable rows in every per-script view. Single-module general batches were already labeled with their module name, so this also removes an inconsistency. Changing the label format now is safe: 28.1 is unreleased, so no time series depend on the bare batch label yet.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I8d4d30a7242b1914b88b6817de27a3892c1ae38d