### PR TITLE
Split style invalidations at first paint/lcp

### DIFF
--- a/lib/chrome/trace/style-invalidations.js
+++ b/lib/chrome/trace/style-invalidations.js
@@ -26,6 +26,16 @@
  * they cause is already in cpu.categories.styleLayout and the
  * recalculateStyle summaries.
  *
+ * When the trace carries a firstContentfulPaint event, every reason,
+ * trigger and source also gets an afterFirstPaint count and the
+ * result gets styleRecalcsAfterFirstPaint /
+ * layoutInvalidationsAfterFirstPaint totals. Invalidations before
+ * first paint are mostly the page being built (nodes added to the
+ * document and its layout); the ones after it are churn on a page the
+ * user is already looking at — the actionable half. Without the FCP
+ * event the fields are absent, so consumers can fall back to guessing
+ * from the reason categories.
+ *
  * When the optional `bundles` map (url → location resolver from the
  * coverage path) is passed, source frames inside concatenated
  * bundles resolve to the owning module — thousands of invalidations
@@ -44,9 +54,12 @@ const MAX_REASONS = 10;
 const MAX_TRIGGERS = 15;
 const MAX_SOURCES = 10;
 
-function increment(map, key) {
+function increment(map, key, afterFirstPaint) {
   if (!key) return;
-  map.set(key, (map.get(key) || 0) + 1);
+  const entry = map.get(key) || { count: 0, after: 0 };
+  entry.count++;
+  if (afterFirstPaint) entry.after++;
+  map.set(key, entry);
 }
 
 // Source identity for an invalidation: the innermost stack frame
@@ -54,7 +67,7 @@ function increment(map, key) {
 // a known concatenated bundle (trace stack-frame positions are
 // 1-based, matching the resolvers). Without bundles the identity is
 // just the URL — the pre-existing behaviour.
-function sourceEntryFor(sources, data, bundles) {
+function sourceEntryFor(sources, data, bundles, afterFirstPaint) {
   for (const frame of data.stackTrace || []) {
     if (!frame.url) continue;
     let module_;
@@ -67,18 +80,19 @@ function sourceEntryFor(sources, data, bundles) {
     const key = module_ ? `${frame.url}|${module_.name}` : frame.url;
     let entry = sources.get(key);
     if (!entry) {
-      entry = { url: frame.url, count: 0 };
+      entry = { url: frame.url, count: 0, after: 0 };
       if (module_) entry.module = module_.name;
       sources.set(key, entry);
     }
     entry.count++;
+    if (afterFirstPaint) entry.after++;
     return;
   }
 }
 
 function topEntries(map, limit, publish) {
   return [...map.entries()]
-    .toSorted((a, b) => b[1] - a[1])
+    .toSorted((a, b) => b[1].count - a[1].count)
     .slice(0, limit)
     .map(entry => publish(entry));
 }
@@ -90,38 +104,55 @@ export function computeStyleInvalidations(trace, bundles) {
   const sources = new Map();
   let styleRecalcs = 0;
   let layoutInvalidations = 0;
+  let styleRecalcsAfter = 0;
+  let layoutInvalidationsAfter = 0;
   let sawInvalidations = false;
+
+  // Same event getRenderBlocking uses to window the recalculate-style
+  // work — one boundary, so "after first paint" means the same thing
+  // in both places.
+  const fcpEvent = trace.traceEvents.find(
+    task => task.name === 'firstContentfulPaint'
+  );
+  const fcpTs = fcpEvent ? fcpEvent.ts : undefined;
 
   for (const event of trace.traceEvents) {
     const data = (event.args && event.args.data) || {};
+    const afterFirstPaint = fcpTs !== undefined && event.ts > fcpTs;
     switch (event.name) {
       case 'StyleRecalcInvalidationTracking': {
         sawInvalidations = true;
         styleRecalcs++;
-        increment(recalcReasons, data.reason);
-        sourceEntryFor(sources, data, bundles);
+        if (afterFirstPaint) styleRecalcsAfter++;
+        increment(recalcReasons, data.reason, afterFirstPaint);
+        sourceEntryFor(sources, data, bundles, afterFirstPaint);
         break;
       }
       case 'LayoutInvalidationTracking': {
         sawInvalidations = true;
         layoutInvalidations++;
-        increment(layoutReasons, data.reason);
-        sourceEntryFor(sources, data, bundles);
+        if (afterFirstPaint) layoutInvalidationsAfter++;
+        increment(layoutReasons, data.reason, afterFirstPaint);
+        sourceEntryFor(sources, data, bundles, afterFirstPaint);
         break;
       }
       case 'ScheduleStyleInvalidationTracking': {
         sawInvalidations = true;
         if (data.changedClass) {
-          increment(triggers, `class|${data.changedClass}`);
+          increment(triggers, `class|${data.changedClass}`, afterFirstPaint);
         }
         if (data.changedAttribute) {
-          increment(triggers, `attribute|${data.changedAttribute}`);
+          increment(
+            triggers,
+            `attribute|${data.changedAttribute}`,
+            afterFirstPaint
+          );
         }
         if (data.changedId) {
-          increment(triggers, `id|${data.changedId}`);
+          increment(triggers, `id|${data.changedId}`, afterFirstPaint);
         }
         if (data.changedPseudo) {
-          increment(triggers, `pseudo|${data.changedPseudo}`);
+          increment(triggers, `pseudo|${data.changedPseudo}`, afterFirstPaint);
         }
         break;
       }
@@ -132,31 +163,41 @@ export function computeStyleInvalidations(trace, bundles) {
   }
   if (!sawInvalidations) return;
 
-  return {
+  // The afterFirstPaint fields only exist when the trace had the FCP
+  // event — an absent field means "unknown", never "zero".
+  const withAfter = (published, entry) => {
+    if (fcpTs !== undefined) published.afterFirstPaint = entry.after;
+    return published;
+  };
+
+  const result = {
     styleRecalcs,
     layoutInvalidations,
-    recalcReasons: topEntries(
-      recalcReasons,
-      MAX_REASONS,
-      ([reason, count]) => ({
-        reason,
-        count
-      })
+    recalcReasons: topEntries(recalcReasons, MAX_REASONS, ([reason, entry]) =>
+      withAfter({ reason, count: entry.count }, entry)
     ),
-    layoutReasons: topEntries(
-      layoutReasons,
-      MAX_REASONS,
-      ([reason, count]) => ({
-        reason,
-        count
-      })
+    layoutReasons: topEntries(layoutReasons, MAX_REASONS, ([reason, entry]) =>
+      withAfter({ reason, count: entry.count }, entry)
     ),
-    triggers: topEntries(triggers, MAX_TRIGGERS, ([key, count]) => {
+    triggers: topEntries(triggers, MAX_TRIGGERS, ([key, entry]) => {
       const [kind, ...name] = key.split('|');
-      return { kind, name: name.join('|'), count };
+      return withAfter(
+        { kind, name: name.join('|'), count: entry.count },
+        entry
+      );
     }),
     sources: [...sources.values()]
       .toSorted((a, b) => b.count - a.count)
       .slice(0, MAX_SOURCES)
+      .map(entry => {
+        const published = { url: entry.url, count: entry.count };
+        if (entry.module) published.module = entry.module;
+        return withAfter(published, entry);
+      })
   };
+  if (fcpTs !== undefined) {
+    result.styleRecalcsAfterFirstPaint = styleRecalcsAfter;
+    result.layoutInvalidationsAfterFirstPaint = layoutInvalidationsAfter;
+  }
+  return result;
 }

--- a/lib/chrome/trace/style-invalidations.js
+++ b/lib/chrome/trace/style-invalidations.js
@@ -29,12 +29,18 @@
  * When the trace carries a firstContentfulPaint event, every reason,
  * trigger and source also gets an afterFirstPaint count and the
  * result gets styleRecalcsAfterFirstPaint /
- * layoutInvalidationsAfterFirstPaint totals. Invalidations before
- * first paint are mostly the page being built (nodes added to the
- * document and its layout); the ones after it are churn on a page the
- * user is already looking at — the actionable half. Without the FCP
- * event the fields are absent, so consumers can fall back to guessing
- * from the reason categories.
+ * layoutInvalidationsAfterFirstPaint totals; with a
+ * largestContentfulPaint::Candidate event the same happens for
+ * afterLargestContentfulPaint (final candidate, mirroring how
+ * getRenderBlocking windows the recalculate-style work to both
+ * paints). Invalidations before first paint are mostly the page being
+ * built; between the paints they are what delayed the largest paint;
+ * after it they are churn on a page the user is already looking at.
+ * Absent fields mean the paint event was missing from the trace —
+ * consumers can fall back to guessing from the reason categories, and
+ * should mind that LCP can land before FCP in real traces (the counts
+ * stay truthful per boundary, an "in between" window is then simply
+ * not derivable by subtraction).
  *
  * When the optional `bundles` map (url → location resolver from the
  * coverage path) is passed, source frames inside concatenated
@@ -54,11 +60,12 @@ const MAX_REASONS = 10;
 const MAX_TRIGGERS = 15;
 const MAX_SOURCES = 10;
 
-function increment(map, key, afterFirstPaint) {
+function increment(map, key, afterFirstPaint, afterLargestPaint) {
   if (!key) return;
-  const entry = map.get(key) || { count: 0, after: 0 };
+  const entry = map.get(key) || { count: 0, after: 0, afterLcp: 0 };
   entry.count++;
   if (afterFirstPaint) entry.after++;
+  if (afterLargestPaint) entry.afterLcp++;
   map.set(key, entry);
 }
 
@@ -67,7 +74,13 @@ function increment(map, key, afterFirstPaint) {
 // a known concatenated bundle (trace stack-frame positions are
 // 1-based, matching the resolvers). Without bundles the identity is
 // just the URL — the pre-existing behaviour.
-function sourceEntryFor(sources, data, bundles, afterFirstPaint) {
+function sourceEntryFor(
+  sources,
+  data,
+  bundles,
+  afterFirstPaint,
+  afterLargestPaint
+) {
   for (const frame of data.stackTrace || []) {
     if (!frame.url) continue;
     let module_;
@@ -80,12 +93,13 @@ function sourceEntryFor(sources, data, bundles, afterFirstPaint) {
     const key = module_ ? `${frame.url}|${module_.name}` : frame.url;
     let entry = sources.get(key);
     if (!entry) {
-      entry = { url: frame.url, count: 0, after: 0 };
+      entry = { url: frame.url, count: 0, after: 0, afterLcp: 0 };
       if (module_) entry.module = module_.name;
       sources.set(key, entry);
     }
     entry.count++;
     if (afterFirstPaint) entry.after++;
+    if (afterLargestPaint) entry.afterLcp++;
     return;
   }
 }
@@ -106,53 +120,106 @@ export function computeStyleInvalidations(trace, bundles) {
   let layoutInvalidations = 0;
   let styleRecalcsAfter = 0;
   let layoutInvalidationsAfter = 0;
+  let styleRecalcsAfterLcp = 0;
+  let layoutInvalidationsAfterLcp = 0;
   let sawInvalidations = false;
 
-  // Same event getRenderBlocking uses to window the recalculate-style
-  // work — one boundary, so "after first paint" means the same thing
-  // in both places.
+  // Same events getRenderBlocking uses to window the recalculate-style
+  // work — one boundary per paint, so "after first paint" and "after
+  // the largest paint" mean the same thing in both places. LCP is the
+  // final candidate, like getLargestContentfulPaintEvent picks it.
   const fcpEvent = trace.traceEvents.find(
     task => task.name === 'firstContentfulPaint'
   );
   const fcpTs = fcpEvent ? fcpEvent.ts : undefined;
+  let lcpTs;
+  for (const task of trace.traceEvents) {
+    if (
+      task.name === 'largestContentfulPaint::Candidate' &&
+      (lcpTs === undefined || task.ts > lcpTs)
+    ) {
+      lcpTs = task.ts;
+    }
+  }
 
   for (const event of trace.traceEvents) {
     const data = (event.args && event.args.data) || {};
     const afterFirstPaint = fcpTs !== undefined && event.ts > fcpTs;
+    const afterLargestPaint = lcpTs !== undefined && event.ts > lcpTs;
     switch (event.name) {
       case 'StyleRecalcInvalidationTracking': {
         sawInvalidations = true;
         styleRecalcs++;
         if (afterFirstPaint) styleRecalcsAfter++;
-        increment(recalcReasons, data.reason, afterFirstPaint);
-        sourceEntryFor(sources, data, bundles, afterFirstPaint);
+        if (afterLargestPaint) styleRecalcsAfterLcp++;
+        increment(
+          recalcReasons,
+          data.reason,
+          afterFirstPaint,
+          afterLargestPaint
+        );
+        sourceEntryFor(
+          sources,
+          data,
+          bundles,
+          afterFirstPaint,
+          afterLargestPaint
+        );
         break;
       }
       case 'LayoutInvalidationTracking': {
         sawInvalidations = true;
         layoutInvalidations++;
         if (afterFirstPaint) layoutInvalidationsAfter++;
-        increment(layoutReasons, data.reason, afterFirstPaint);
-        sourceEntryFor(sources, data, bundles, afterFirstPaint);
+        if (afterLargestPaint) layoutInvalidationsAfterLcp++;
+        increment(
+          layoutReasons,
+          data.reason,
+          afterFirstPaint,
+          afterLargestPaint
+        );
+        sourceEntryFor(
+          sources,
+          data,
+          bundles,
+          afterFirstPaint,
+          afterLargestPaint
+        );
         break;
       }
       case 'ScheduleStyleInvalidationTracking': {
         sawInvalidations = true;
         if (data.changedClass) {
-          increment(triggers, `class|${data.changedClass}`, afterFirstPaint);
+          increment(
+            triggers,
+            `class|${data.changedClass}`,
+            afterFirstPaint,
+            afterLargestPaint
+          );
         }
         if (data.changedAttribute) {
           increment(
             triggers,
             `attribute|${data.changedAttribute}`,
-            afterFirstPaint
+            afterFirstPaint,
+            afterLargestPaint
           );
         }
         if (data.changedId) {
-          increment(triggers, `id|${data.changedId}`, afterFirstPaint);
+          increment(
+            triggers,
+            `id|${data.changedId}`,
+            afterFirstPaint,
+            afterLargestPaint
+          );
         }
         if (data.changedPseudo) {
-          increment(triggers, `pseudo|${data.changedPseudo}`, afterFirstPaint);
+          increment(
+            triggers,
+            `pseudo|${data.changedPseudo}`,
+            afterFirstPaint,
+            afterLargestPaint
+          );
         }
         break;
       }
@@ -163,10 +230,13 @@ export function computeStyleInvalidations(trace, bundles) {
   }
   if (!sawInvalidations) return;
 
-  // The afterFirstPaint fields only exist when the trace had the FCP
+  // The after fields only exist when the trace had the matching paint
   // event — an absent field means "unknown", never "zero".
   const withAfter = (published, entry) => {
     if (fcpTs !== undefined) published.afterFirstPaint = entry.after;
+    if (lcpTs !== undefined) {
+      published.afterLargestContentfulPaint = entry.afterLcp;
+    }
     return published;
   };
 
@@ -198,6 +268,11 @@ export function computeStyleInvalidations(trace, bundles) {
   if (fcpTs !== undefined) {
     result.styleRecalcsAfterFirstPaint = styleRecalcsAfter;
     result.layoutInvalidationsAfterFirstPaint = layoutInvalidationsAfter;
+  }
+  if (lcpTs !== undefined) {
+    result.styleRecalcsAfterLargestContentfulPaint = styleRecalcsAfterLcp;
+    result.layoutInvalidationsAfterLargestContentfulPaint =
+      layoutInvalidationsAfterLcp;
   }
   return result;
 }

--- a/test/unittests/styleInvalidationsTest.js
+++ b/test/unittests/styleInvalidationsTest.js
@@ -95,3 +95,69 @@ test('returns undefined when the trace has no invalidation events', t => {
     undefined
   );
 });
+
+const beforePaint = data => ({ name: data.name, ts: 100, args: { data } });
+const afterPaint = data => ({ name: data.name, ts: 900, args: { data } });
+
+test('splits counts on first paint when the trace has the FCP event', t => {
+  const result = computeStyleInvalidations({
+    traceEvents: [
+      { name: 'firstContentfulPaint', ts: 500 },
+      beforePaint({
+        name: 'LayoutInvalidationTracking',
+        reason: 'Added to layout'
+      }),
+      beforePaint({
+        name: 'StyleRecalcInvalidationTracking',
+        reason: 'Node was inserted into tree'
+      }),
+      afterPaint({
+        name: 'StyleRecalcInvalidationTracking',
+        reason: 'Style rule change',
+        stackTrace: [{ url: SCRIPT_URL }]
+      }),
+      afterPaint({
+        name: 'StyleRecalcInvalidationTracking',
+        reason: 'Style rule change'
+      }),
+      afterPaint({
+        name: 'ScheduleStyleInvalidationTracking',
+        changedClass: 'menu-open'
+      })
+    ]
+  });
+
+  t.is(result.styleRecalcs, 3);
+  t.is(result.styleRecalcsAfterFirstPaint, 2);
+  t.is(result.layoutInvalidations, 1);
+  t.is(result.layoutInvalidationsAfterFirstPaint, 0);
+  t.deepEqual(result.recalcReasons, [
+    { reason: 'Style rule change', count: 2, afterFirstPaint: 2 },
+    { reason: 'Node was inserted into tree', count: 1, afterFirstPaint: 0 }
+  ]);
+  t.deepEqual(result.layoutReasons, [
+    { reason: 'Added to layout', count: 1, afterFirstPaint: 0 }
+  ]);
+  t.deepEqual(result.triggers, [
+    { kind: 'class', name: 'menu-open', count: 1, afterFirstPaint: 1 }
+  ]);
+  t.deepEqual(result.sources, [
+    { url: SCRIPT_URL, count: 1, afterFirstPaint: 1 }
+  ]);
+});
+
+test('leaves the afterFirstPaint fields out without an FCP event', t => {
+  const result = computeStyleInvalidations({
+    traceEvents: [
+      {
+        name: 'StyleRecalcInvalidationTracking',
+        ts: 1,
+        args: { data: { reason: 'Style rule change' } }
+      }
+    ]
+  });
+  t.is(result.styleRecalcsAfterFirstPaint, undefined);
+  t.deepEqual(result.recalcReasons, [
+    { reason: 'Style rule change', count: 1 }
+  ]);
+});

--- a/test/unittests/styleInvalidationsTest.js
+++ b/test/unittests/styleInvalidationsTest.js
@@ -161,3 +161,48 @@ test('leaves the afterFirstPaint fields out without an FCP event', t => {
     { reason: 'Style rule change', count: 1 }
   ]);
 });
+
+const eventAt = (ts, data) => ({ name: data.name, ts, args: { data } });
+
+test('adds the largest-paint window when the trace has LCP candidates', t => {
+  const result = computeStyleInvalidations({
+    traceEvents: [
+      { name: 'firstContentfulPaint', ts: 500 },
+      // The final candidate wins, like getLargestContentfulPaintEvent.
+      { name: 'largestContentfulPaint::Candidate', ts: 600 },
+      { name: 'largestContentfulPaint::Candidate', ts: 1000 },
+      eventAt(100, {
+        name: 'StyleRecalcInvalidationTracking',
+        reason: 'Node was inserted into tree'
+      }),
+      // Between the paints: after FCP, not after LCP — the bucket that
+      // delayed the largest paint.
+      eventAt(800, {
+        name: 'StyleRecalcInvalidationTracking',
+        reason: 'Style rule change'
+      }),
+      eventAt(1200, {
+        name: 'StyleRecalcInvalidationTracking',
+        reason: 'Style rule change'
+      })
+    ]
+  });
+
+  t.is(result.styleRecalcs, 3);
+  t.is(result.styleRecalcsAfterFirstPaint, 2);
+  t.is(result.styleRecalcsAfterLargestContentfulPaint, 1);
+  t.deepEqual(result.recalcReasons, [
+    {
+      reason: 'Style rule change',
+      count: 2,
+      afterFirstPaint: 2,
+      afterLargestContentfulPaint: 1
+    },
+    {
+      reason: 'Node was inserted into tree',
+      count: 1,
+      afterFirstPaint: 0,
+      afterLargestContentfulPaint: 0
+    }
+  ]);
+});


### PR DESCRIPTION
The invalidation counts lump the page being built together with churn on a page the user is already looking at, so consumers guess from reason categories — and guess wrong: post-paint "Added to layout" events hide inside the construction-dominated totals.

Stamp every reason, trigger and source with an afterFirstPaint count and add styleRecalcsAfterFirstPaint/layoutInvalidationsAfterFirstPaint totals, using the same trace FCP event getRenderBlocking windows with so the boundary means one thing. The fields only exist when the trace carried the FCP event — absent means unknown, never zero — keeping the output backward compatible.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I4f20f7ba702cbfcd9e5ef2ec9679e968724bbe0b