### PR TITLE
Precompute filmstrip frame diffs in visual metrics

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -212,8 +212,9 @@ export class Collector {
           this._logVisualMetrics(data);
         }
         for (let key of Object.keys(data.visualMetrics)) {
-          // Skip VisualProgress/ContentfulProgress etc
-          if (!key.includes('Progress')) {
+          // Skip VisualProgress/ContentfulProgress etc, and FrameDiffs —
+          // an array of per-frame objects, nothing to summarize.
+          if (!key.includes('Progress') && key !== 'FrameDiffs') {
             const d = { visualMetrics: {} };
             d['visualMetrics'][key] = data.visualMetrics[key];
             statistics.addDeep(d);

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -732,6 +732,13 @@ export function parseCommandLine() {
       describe: 'Create filmstrip screenshots.',
       group: 'video'
     })
+    .option('videoParams.filmstripDiff', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Also write a diff image per filmstrip frame (the frame dimmed with every pixel changed since the previous frame painted red) plus changed-pixel counts. Lets report UIs show exact frame diffs without pixel access, for example when a report is opened from file://.',
+      group: 'video'
+    })
     .option('videoParams.nice', {
       default: 0,
       describe:

--- a/lib/video/postprocessing/visualmetrics/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/visualMetrics.js
@@ -111,6 +111,9 @@ export async function run(
     } else if (thumbsize !== 400) {
       scriptArguments.push('--thumbsize', thumbsize);
     }
+    if (getProperty(options, 'videoParams.filmstripDiff', false)) {
+      scriptArguments.push('--framediff');
+    }
   }
 
   const visualMetricsLogFile = path.join(

--- a/visualmetrics/visualmetrics-portable.py
+++ b/visualmetrics/visualmetrics-portable.py
@@ -1189,6 +1189,60 @@ def save_screenshot(directory, dest, quality):
 ##########################################################################
 
 
+def create_frame_diffs(directory):
+    """Write a diff image next to every filmstrip frame and return the
+    changed-pixel counts.
+
+    For each adjacent pair of kept frames, diff_<ms>.png shows the
+    current frame dimmed toward white with every changed pixel painted
+    red — precomputed here because the report's lightbox cannot read
+    pixels when opened from file:// (tainted canvas), and this is where
+    the frames and Pillow already are. The per-pixel threshold (sum of
+    channel deltas > 30) matches the report's canvas fallback, so both
+    paths show the same picture. PNG on purpose: mostly-white plus
+    sparse red compresses better than JPEG and keeps the marks crisp.
+
+    Runs before convert_to_jpeg (which only globs ms_*.png) while the
+    frames are still lossless PNG.
+    """
+    diffs = []
+    try:
+        import numpy as np
+        from PIL import Image
+
+        files = sorted(glob.glob(str(Path(directory) / "ms_*.png")))
+        for previous_file, current_file in zip(files, files[1:]):
+            with Image.open(previous_file) as previous_image, Image.open(
+                current_file
+            ) as current_image:
+                previous = np.array(previous_image.convert("RGB"), dtype=int)
+                current = np.array(current_image.convert("RGB"), dtype=int)
+            if previous.shape != current.shape:
+                continue
+            delta = np.abs(previous - current).sum(axis=2)
+            changed = delta > 30
+            out = 255 - (255 - current) * 0.2
+            out[changed] = [224, 28, 60]
+            stem = Path(current_file).stem
+            diff_name = "diff_" + stem[3:] + ".png"
+            Image.fromarray(out.astype(np.uint8)).save(
+                str(Path(directory) / diff_name)
+            )
+            changed_pixels = int(changed.sum())
+            diffs.append(
+                {
+                    "time": int(stem[3:]),
+                    "changedPixels": changed_pixels,
+                    "changedShare": round(
+                        changed_pixels / changed.size * 100, 2
+                    ),
+                }
+            )
+    except BaseException:
+        logging.exception("Error creating frame diffs")
+    return diffs
+
+
 def convert_to_jpeg(directory, quality):
     logging.debug("Converting video frames to JPEG")
     directory = str(Path(directory).resolve())
@@ -1927,6 +1981,16 @@ def main():
         "the first rendered frame (useful for Opera mini).",
     )
     parser.add_argument(
+        "--framediff",
+        action="store_true",
+        default=False,
+        help="Write a diff image next to every filmstrip frame (the "
+        "frame dimmed with every pixel changed since the previous frame "
+        "painted red) and report the changed-pixel counts as a Frame "
+        "Diffs metric. Lets report UIs show exact diffs without pixel "
+        "access.",
+    )
+    parser.add_argument(
         "-k",
         "--perceptual",
         action="store_true",
@@ -2056,6 +2120,11 @@ def main():
                 options.herodata,
                 key_colors,
             )
+
+            if options.framediff and options.dir is not None and metrics is not None:
+                framediffs = create_frame_diffs(directory)
+                if framediffs:
+                    metrics.append({"name": "Frame Diffs", "value": framediffs})
 
             if options.screenshot is not None:
                 quality = 30


### PR DESCRIPTION
Report UIs cannot read frame pixels when a result is opened from file:// — the canvas is tainted and fetch is blocked — so an exact "what changed in this frame" view was impossible exactly where people debug local results. Visual metrics already walks every adjacent frame pair with Pillow in hand, so the diff belongs here.

With videoParams.filmstripDiff, write diff_<ms>.png next to each filmstrip frame — the frame dimmed with every changed pixel painted red, the same per-pixel threshold report UIs use at runtime so both paths show the same picture — and report the counts as a Frame Diffs metric. Off by default: it is one extra image per frame per run, stored wherever results are stored. PNG on purpose — mostly white plus sparse red compresses far below the frame JPEGs.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I469edacc66efa9386d20867d9d8cf08953337115