### PR TITLE
Collect the browser's CPU Performance API device rating

### DIFF
--- a/browserscripts/browser/cpuPerformance.js
+++ b/browserscripts/browser/cpuPerformance.js
@@ -1,0 +1,7 @@
+(function() {
+  // The CPU Performance API (https://wicg.github.io/cpu-performance/) reports
+  // the browser's own device rating: 1 to 4, or 0 when it cannot classify the
+  // device. Chromium exposes it from Chrome 152; other browsers return
+  // undefined so the metric is simply absent there.
+  return 'cpuPerformance' in navigator ? navigator.cpuPerformance : undefined;
+})();


### PR DESCRIPTION
Chrome 152 ships navigator.cpuPerformance, the browser's own coarse device rating (1 to 4, or 0 when unknown). It is a useful piece of test-environment context: the same page measured on a fast laptop and a slow CI runner is not really the same test, and recording the device tier alongside the existing synthetic CPU benchmark helps explain cross-machine differences in the results.

Collected as a browser script so it rides along automatically wherever browserScripts.browser is read. Browsers without the API return undefined, so the field is simply absent rather than zero, and nothing downstream has to change to stay correct.

Co-Authored-By: Claude Opus 4.8 (1M context) noreply@anthropic.com
Change-Id: I37e3a965cb45a73b5bd4c82e03d706321a04d57f