### PR TITLE
ix Firefox --block and --appendToUserAgent being ignored

### DIFF
--- a/lib/firefox/webdriver/firefox.js
+++ b/lib/firefox/webdriver/firefox.js
@@ -119,23 +119,24 @@ export class Firefox {
 
     if (this.options.requestheader) {
       await this.browsertimeBidi.setRequestHeaders(this.options.requestheader);
-      if (this.options.block) {
-        await this.browsertimeBidi.blockUrls(this.options.block);
-      }
+    }
 
-      if (
-        this.firefoxConfig.appendToUserAgent ||
-        this.options.appendToUserAgent
-      ) {
-        const currentUserAgent = await runner.runScript(
-          'return navigator.userAgent;',
-          'GET_USER_AGENT'
-        );
-        let script = `Services.prefs.setStringPref('general.useragent.override', '${currentUserAgent} ${
-          this.firefoxConfig.appendToUserAgent || this.options.appendToUserAgent
-        }');`;
-        return runner.runPrivilegedScript(script, 'SET_USER_AGENT');
-      }
+    if (this.options.block) {
+      await this.browsertimeBidi.blockUrls(this.options.block);
+    }
+
+    if (
+      this.firefoxConfig.appendToUserAgent ||
+      this.options.appendToUserAgent
+    ) {
+      const currentUserAgent = await runner.runScript(
+        'return navigator.userAgent;',
+        'GET_USER_AGENT'
+      );
+      let script = `Services.prefs.setStringPref('general.useragent.override', '${currentUserAgent} ${
+        this.firefoxConfig.appendToUserAgent || this.options.appendToUserAgent
+      }');`;
+      return runner.runPrivilegedScript(script, 'SET_USER_AGENT');
     }
   }
 


### PR DESCRIPTION
Both options only took effect when --requestheader was also set: the BiDi header work in #2108 accidentally moved the previously independent blocks inside the requestheader branch. Chrome handles the same options independently, so Firefox runs silently blocked nothing.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I49ce3ee89010a998681b264ef39eafca1480f217