### PR TITLE
Fix broken proxy support for Edge

### DIFF
--- a/lib/edge/webdriver/builder.js
+++ b/lib/edge/webdriver/builder.js
@@ -2,9 +2,9 @@ import { Options, ServiceBuilder } from 'selenium-webdriver/edge.js';
 import { getLogger } from '@sitespeed.io/log';
 import { logging } from 'selenium-webdriver';
 import { setupChromiumOptions } from '../../chrome/webdriver/setupChromiumOptions.js';
-const log = getLogger('browsertime.edge');
-const { pac, manual } = 'selenium-webdriver/proxy.js';
+import { pac, manual } from 'selenium-webdriver/proxy.js';
 import { pick, isEmpty, getProperty } from '../../support/util.js';
+const log = getLogger('browsertime.edge');
 
 export async function configureBuilder(builder, baseDir, options) {
   const edgeConfig = options.edge || {};


### PR DESCRIPTION
The proxy helpers were destructured from the string 'selenium-webdriver/proxy.js' instead of imported from it, so any Edge run using --proxy.* crashed with "pac is not a function".

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ib964de21724a63db26852b9d7cd89c326fcb1959