### PR TITLE
Restore soft handling of page-complete-check timeouts

### DIFF
--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -1,5 +1,5 @@
 import { getLogger } from '@sitespeed.io/log';
-import { Condition } from 'selenium-webdriver';
+import { Condition, error as webdriverError } from 'selenium-webdriver';
 import { isAndroidConfigured } from '../android/index.js';
 import { UrlLoadError, BrowserError, TimeoutError } from '../support/errors.js';
 import { createWebDriver } from './webdriver/index.js';
@@ -41,7 +41,7 @@ async function timeout(promise, ms, errorMessage) {
     timerId = setTimeout(() => {
       if (!finished) {
         // Reject with a TimeoutError if the input promise has not yet settled.
-        reject(new Error(errorMessage));
+        reject(new TimeoutError(errorMessage));
       }
     }, ms);
   });
@@ -195,7 +195,10 @@ export class SeleniumRunner {
         `Running page complete check ${pageCompleteCheck} took too long`
       );
     } catch (error) {
-      if (error instanceof TimeoutError) {
+      if (
+        error instanceof TimeoutError ||
+        error instanceof webdriverError.TimeoutError
+      ) {
         log.info(
           `The page did not finished loading in ${pageCompleteCheckTimeout} ms. You can adjust the timeout by setting the --maxLoadTime option (in ms).`
         );


### PR DESCRIPTION
A timeout in the page complete check is documented to log and continue measuring, but the tolerant branch checked for a TimeoutError class that stopped being thrown in #2005, so every timeout escalated to a failed URL after the full retry loop. The check also accepts selenium's own TimeoutError since driver.wait races the same deadline.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ie4ce8c7244fbff2c240b63f173bafbd77d8110ea