### PR TITLE
Keep video and result pairing intact when visual metrics fail

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -337,7 +337,7 @@ export class Measure {
     // Remove the last result
     this.result.pop();
 
-    await this.measureVideo.stop();
+    await this.measureVideo.stopAsError();
 
     if (this.options.tcpdump) {
       await this.tcpDump.stop();

--- a/lib/core/engine/command/measure/video.js
+++ b/lib/core/engine/command/measure/video.js
@@ -62,6 +62,15 @@ export class MeasureVideo {
     }
   }
 
+  // Stop recording without queueing the video for visual metrics analysis.
+  // The measurement's result has been thrown away, so queueing the video
+  // would pair it with the next measured page's result.
+  async stopAsError() {
+    if (this.recordVideo && !this.options.videoParams.debug) {
+      await this.video.stop();
+    }
+  }
+
   getRecordingMetadata() {
     if (
       this.recordVideo &&

--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -371,14 +371,15 @@ export class Iteration {
           if (options.safari?.ios) {
             syncVisualMetricsToFCP(result[index_]);
           }
-
-          index_++;
         } catch (error) {
           // If one of the Visual Metrics runs fail, try the next one
           log.error('Visual Metrics failed to analyse the video', error);
           if (result[index_]) {
+            result[index_].error = result[index_].error || [];
             result[index_].error.push(error.message);
           }
+        } finally {
+          index_++;
         }
       }
     }


### PR DESCRIPTION
When one video failed analysis the index was not advanced, so every later page in the iteration got visual metrics from the wrong video, and pushing to a missing error array turned a single failed video into a failed iteration. measure.stopAsError also queued its video for analysis after removing the result, misaligning all later pages the same way.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ife2e2e34042b0d0fc0c8e3f011d3dd91a1799946