### PR TITLE
Keep full request header values that contain a colon

### DIFF
--- a/lib/chrome/chromeDevtoolsProtocol.js
+++ b/lib/chrome/chromeDevtoolsProtocol.js
@@ -168,8 +168,9 @@ export class ChromeDevtoolsProtocol {
     const headers = {};
     for (let header of headersArray) {
       if (header.indexOf && header.includes(':')) {
-        const parts = header.split(':');
-        headers[parts[0]] = parts[1];
+        headers[header.slice(0, header.indexOf(':'))] = header.slice(
+          header.indexOf(':') + 1
+        );
       } else {
         log.error(
           'Request headers need to be of the format key:value not ' + header

--- a/lib/firefox/firefoxBidi.js
+++ b/lib/firefox/firefoxBidi.js
@@ -153,12 +153,11 @@ export class FirefoxBidi {
     const headers = [];
     for (let header of headersArray) {
       if (header.indexOf && header.includes(':')) {
-        const parts = header.split(':');
         headers.push({
-          name: parts[0],
+          name: header.slice(0, header.indexOf(':')),
           value: {
             type: 'string',
-            value: parts[1]
+            value: header.slice(header.indexOf(':') + 1)
           }
         });
       } else {


### PR DESCRIPTION
Header strings were split on every colon and only the second part kept, so values like Referer URLs or tokens with colons were silently truncated at the first colon, in both the Chrome CDP and Firefox BiDi paths.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I78f47df4d7c83932e495299f1433b0efcfe283bd