### PR TITLE
Stop saving every screenshot twice when jimp is missing

### DIFF
--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -40,6 +40,7 @@ export class ScreenshotManager {
       this.savedScreenshots.push(
         pathAndName.replace(this.storageManager.directory + '/', '')
       );
+      return;
     }
     if (this.config.type === 'png') {
       const pathAndName = await savePng(


### PR DESCRIPTION
The no-jimp branch fell through into the png/jpg branch, writing the same screenshot again and listing it twice in the result JSON on any install without the optional jimp dependency.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I3b4bcfb23d7ecfcffaf538520b9f4dea0a339bee