### PR TITLE
Actually remove the recorded video from Android devices

### DIFF
--- a/lib/android/index.js
+++ b/lib/android/index.js
@@ -282,7 +282,7 @@ export class Android {
   }
 
   async removeVideo() {
-    return this.removeFileOnSdCard(`${this.sdcard}/browsertime.mp4`);
+    return this.removeFileOnSdCard('browsertime.mp4');
   }
 
   async pidof(packageName) {


### PR DESCRIPTION
removeVideo passed a full sdcard path to a helper that prepends the sdcard path itself, so the rm targeted a doubled path and cleanup silently failed on every run.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I6ebcacb3e90c95b6746084de2693da3cf1135150