### PR TITLE
Support SPA navigations that make no requests

### DIFF
--- a/.github/workflows/linux-chrome.yml
+++ b/.github/workflows/linux-chrome.yml
@@ -187,6 +187,17 @@ jobs:
         jq -e '.[0].browserScripts[0].timings.softNavigations[0].name | endswith("/spa/page-2")' /tmp/soft-nav/browsertime.json
         jq -e '.log.pages[0]._softNavigation == true' /tmp/soft-nav/browsertime.har
         jq -e '.log.pages[0]._url | endswith("/spa/page-2")' /tmp/soft-nav/browsertime.har
+    - name: Test Chrome soft navigation without any request
+      run: |
+        ./bin/browsertime.js -b chrome -n 1 --xvfb --spa --resultDir /tmp/soft-nav-no-request test/data/commandscripts/softNavigationNoRequest.cjs
+        echo "--- soft navigation entry ---"
+        jq '.[0].browserScripts[0].timings.softNavigations[0]' /tmp/soft-nav-no-request/browsertime.json
+        echo "--- HAR page ---"
+        jq '.log.pages[0] | {title, _url, _softNavigation}' /tmp/soft-nav-no-request/browsertime.har
+        jq -e '.[0].browserScripts[0].timings.softNavigations | length > 0' /tmp/soft-nav-no-request/browsertime.json
+        jq -e '.[0].browserScripts[0].timings.softNavigations[0].name | endswith("/spa/page-3")' /tmp/soft-nav-no-request/browsertime.json
+        jq -e '.log.pages[0]._softNavigation == true' /tmp/soft-nav-no-request/browsertime.har
+        jq -e '.log.pages[0]._url | endswith("/spa/page-3")' /tmp/soft-nav-no-request/browsertime.har
   video:
     runs-on: ubuntu-22.04
     steps:

--- a/lib/chrome/har.js
+++ b/lib/chrome/har.js
@@ -3,6 +3,7 @@ import { harFromMessages } from 'chrome-har';
 import { logging } from 'selenium-webdriver';
 const log = getLogger('browsertime.chrome');
 import { addBrowser, cleanSensitiveHeaders } from '../support/har/index.js';
+import { localTime } from '../support/util.js';
 const { Type } = logging;
 
 export async function getHar(
@@ -34,6 +35,7 @@ export async function getHar(
   // location.href. Without the fallback, chrome-har silently emits zero
   // pages for that measurement and downstream consumers (sitespeed.io's
   // per-iteration page indexing) drift out of alignment.
+  let softNavigationUrl;
   try {
     const softNavEntries = await runner.runScript(
       `const supported = PerformanceObserver.supportedEntryTypes;
@@ -47,6 +49,7 @@ export async function getHar(
     );
     if (softNavEntries && softNavEntries.length > 0) {
       const entry = softNavEntries[0];
+      softNavigationUrl = entry.url;
       messages.push({
         method: 'SoftNavigation.detected',
         params: { url: entry.url, startTime: entry.startTime }
@@ -57,6 +60,7 @@ export async function getHar(
         'GET_URL_FOR_HAR_FALLBACK'
       );
       if (fallbackUrl) {
+        softNavigationUrl = fallbackUrl;
         messages.push({
           method: 'SoftNavigation.detected',
           params: { url: fallbackUrl, startTime: 0 }
@@ -78,6 +82,20 @@ export async function getHar(
   await runner.getLogs(Type.PERFORMANCE);
 
   const har = harFromMessages(messages);
+
+  // chrome-har drops pages without any entries, so a soft navigation
+  // that made zero requests (a route rendered entirely from memory)
+  // would leave this measurement without a HAR page and break the
+  // per-iteration page indexing downstream. Recreate the page.
+  if (har.log.pages.length === 0 && softNavigationUrl) {
+    har.log.pages.push({
+      id: 'page_1',
+      startedDateTime: localTime(),
+      title: softNavigationUrl,
+      pageTimings: {},
+      _softNavigation: true
+    });
+  }
 
   if (cleanHeaders === true) {
     for (const entry of har.log.entries ?? []) {

--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -261,7 +261,9 @@ export class Measure {
       // Make sure that the resource timing is empty
       await this.browser
         .getDriver()
-        .executeScript('window.performance.clearResourceTimings();');
+        .executeScript(
+          'window.performance.clearResourceTimings(); delete window.__bt_spaQuietSince;'
+        );
     }
 
     // Record current soft navigation count so browser scripts

--- a/lib/core/pageCompleteChecks/spaInactivity.js
+++ b/lib/core/pageCompleteChecks/spaInactivity.js
@@ -1,6 +1,5 @@
 export const spaInactivity = `
 return (function(waitTime) {
-  const timing = window.performance.timing;
   const p = window.performance;
   const resourceTimings = p.getEntriesByType('resource');
   if (resourceTimings.length > 0) {
@@ -9,9 +8,23 @@ return (function(waitTime) {
     if (stop) {
       // empty resource timings for the next run
       p.clearResourceTimings();
+      delete window.__bt_spaQuietSince;
       return true;
     }
+    return false;
   }
-  else return false;
+  // Some SPA navigations render entirely from memory and never make a
+  // request. With no resource entries to watch, treat the navigation as
+  // done after the same quiet time, counted from the first time this
+  // check runs for the navigation.
+  if (window.__bt_spaQuietSince === undefined) {
+    window.__bt_spaQuietSince = p.now();
+    return false;
+  }
+  if (p.now() - window.__bt_spaQuietSince > waitTime) {
+    delete window.__bt_spaQuietSince;
+    return true;
+  }
+  return false;
 })(arguments[arguments.length - 1]);
 `;

--- a/test/data/commandscripts/softNavigationNoRequest.cjs
+++ b/test/data/commandscripts/softNavigationNoRequest.cjs
@@ -1,0 +1,7 @@
+module.exports = async function (context, commands) {
+  await commands.navigate('http://127.0.0.1:3000/spa/');
+  await commands.measure.start('soft-nav-no-request');
+  await commands.mouse.singleClick.bySelector('#goto-page-3');
+  await commands.wait.byTime(2000);
+  return commands.measure.stop();
+};

--- a/test/data/html/spa/index.html
+++ b/test/data/html/spa/index.html
@@ -10,6 +10,7 @@
       button. Combined with the user click and the new content painted into
       the page, Chrome treats the transition as a soft navigation.</p>
     <button id="goto-page-2">Go to page 2</button>
+    <button id="goto-page-3">Go to page 3 (no request)</button>
     <script>
       document.getElementById('goto-page-2').addEventListener('click', function () {
         history.pushState({}, '', '/spa/page-2');
@@ -23,6 +24,19 @@
         content.textContent = 'Welcome to page 2 — fresh content rendered after the soft navigation.';
         document.body.appendChild(content);
         document.getElementById('title').textContent = 'Page 2';
+      });
+      // A soft navigation rendered entirely from memory: no fetch, no
+      // resource entries. Used to test that Browsertime can measure SPA
+      // navigations that make zero requests.
+      document.getElementById('goto-page-3').addEventListener('click', function () {
+        history.pushState({}, '', '/spa/page-3');
+        var content = document.createElement('div');
+        content.id = 'page-3-content';
+        content.style.fontSize = '32px';
+        content.style.padding = '40px';
+        content.textContent = 'Welcome to page 3, rendered without any network request.';
+        document.body.appendChild(content);
+        document.getElementById('title').textContent = 'Page 3';
       });
     </script>
   </body>


### PR DESCRIPTION
Some SPA route changes render entirely from memory. The SPA page-complete check watched resource timings and never finished without one, and chrome-har drops HAR pages that have no entries, so such navigations burned the whole timeout and lost their HAR page. The check now treats quiet time without any request as done, and the HAR page is recreated from the detected soft navigation. Adds a no-request page to the SPA test app and a CI step covering it. Closes #2001.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I0bf51d8df3e339354f2561a18dd1fd564801b79a