### PR TITLE
Fix network idle detection for pages without requests

### DIFF
--- a/lib/chrome/networkManager.js
+++ b/lib/chrome/networkManager.js
@@ -14,52 +14,64 @@ export class NetworkManager {
 
     this.cdp = cdpClient.getRawClient();
     this.inflight = 0;
-    this.lastRequestTimestamp;
-    this.lastResponseTimestamp;
+    this.lastRequestTimestamp = Date.now();
+    this.lastResponseTimestamp = Date.now();
 
-    this.cdp.Network.requestWillBeSent(() => {
-      this.inflight++;
-      this.lastRequestTimestamp = Date.now();
-    });
+    // Each registration returns an unsubscribe function. Keep them so
+    // the listeners can be removed when the wait is over: a new
+    // NetworkManager is created per waitForNetworkIdle call and the CDP
+    // client lives for the whole browser session.
+    this.unsubscribers = [
+      this.cdp.Network.requestWillBeSent(() => {
+        this.inflight++;
+        this.lastRequestTimestamp = Date.now();
+      }),
 
-    this.cdp.Network.loadingFinished(() => {
-      this.inflight--;
-      this.lastResponseTimestamp = Date.now();
-    });
+      this.cdp.Network.loadingFinished(() => {
+        this.inflight--;
+        this.lastResponseTimestamp = Date.now();
+      }),
 
-    this.cdp.Network.loadingFailed(() => {
-      this.inflight--;
-      this.lastResponseTimestamp = Date.now();
-    });
+      this.cdp.Network.loadingFailed(() => {
+        this.inflight--;
+        this.lastResponseTimestamp = Date.now();
+      })
+    ];
   }
 
   async waitForNetworkIdle() {
     const startTime = Date.now();
 
-    while (true) {
-      const now = Date.now();
-      const sinceLastResponseRequest =
-        now - Math.max(this.lastResponseTimestamp, this.lastRequestTimestamp);
-      const sinceStart = now - startTime;
+    try {
+      while (true) {
+        const now = Date.now();
+        const sinceLastResponseRequest =
+          now - Math.max(this.lastResponseTimestamp, this.lastRequestTimestamp);
+        const sinceStart = now - startTime;
 
-      if (sinceLastResponseRequest >= this.idleTime) {
-        if (this.inflight > 0) {
-          log.info(
-            'Idle time without any request/responses. Inflight requests:' +
-              this.inflight
-          );
+        if (sinceLastResponseRequest >= this.idleTime) {
+          if (this.inflight > 0) {
+            log.info(
+              'Idle time without any request/responses. Inflight requests:' +
+                this.inflight
+            );
+          }
+          break;
         }
-        break;
-      }
 
-      if (sinceStart >= this.maxTimeout) {
-        log.info(
-          'Timeout waiting for network.  Inflight requests:' + this.inflight
-        );
-        break;
-      }
+        if (sinceStart >= this.maxTimeout) {
+          log.info(
+            'Timeout waiting for network.  Inflight requests:' + this.inflight
+          );
+          break;
+        }
 
-      await new Promise(r => setTimeout(r, 200));
+        await new Promise(r => setTimeout(r, 200));
+      }
+    } finally {
+      for (const unsubscribe of this.unsubscribers) {
+        unsubscribe();
+      }
     }
   }
 }


### PR DESCRIPTION
The last request/response timestamps started as undefined, making the idle comparison NaN, so a navigation with no network activity (fully cached page or SPA route) waited out the whole max timeout instead of the idle time. The CDP listeners are now also removed when the wait finishes: a new manager is created per call and the listeners piled up on the client for the rest of the browser session.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: If2c89462f3f5cda36b8f2450039c96dfd3c2628e