### PR TITLE
Wait for delegate post work before finishing the iteration

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -163,7 +163,7 @@ export class Iteration {
 
       await this._processVisualMetrics(videos, result, options);
 
-      this._collectResults(
+      await this._collectResults(
         result,
         screenshotManager,
         engineDelegate,
@@ -384,7 +384,7 @@ export class Iteration {
     }
   }
 
-  _collectResults(
+  async _collectResults(
     result,
     screenshotManager,
     engineDelegate,
@@ -396,7 +396,11 @@ export class Iteration {
     result.screenshots = screenshotManager.getSaved();
 
     if (engineDelegate.postWork) {
-      engineDelegate.postWork(index, result);
+      // Firefox's postWork renames moz logs and rewrites the gecko
+      // profile on disk. Without the await the iteration returns while
+      // those writes are in flight and a failure becomes an unhandled
+      // promise rejection.
+      await engineDelegate.postWork(index, result);
     }
 
     if (isAndroidConfigured(options)) {


### PR DESCRIPTION
Firefox's postWork renames moz logs and rewrites the gecko profile with visual metrics, but it was fired without await, so the iteration could hand over results while those writes were still in flight and any failure became an unhandled promise rejection that kills the process on modern Node.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I9d27785ce229d937545dd4d4d91bf31399f7d29e