### PR TITLE
Fall back to no crop when no viewport can be found

### DIFF
--- a/visualmetrics/visualmetrics-portable.py
+++ b/visualmetrics/visualmetrics-portable.py
@@ -670,6 +670,9 @@ def find_video_viewport(
                         "Could not calculate a viewport after %s tries.",
                         viewport_retries,
                     )
+                    # Fall back to no crop instead of cropping every frame
+                    # to the last known-too-small candidate.
+                    viewport = None
                     break
                 logging.info("Failed to find a good viewport. Retrying...")
 


### PR DESCRIPTION
When every viewport-detection retry produced a too-small candidate, the loop exited holding the last bad candidate and every frame was cropped to a sliver, silently producing garbage visual metrics. Logging said a viewport could not be calculated but the caller was never told; now the video is analysed uncropped instead.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ia219019a45c0603f1b25b566173b9aee6f0bef84