### PR TITLE
Report INP as the p98 interaction like web-vitals

### DIFF
--- a/browserscripts/pageinfo/interactionToNextPaintInfo.js
+++ b/browserscripts/pageinfo/interactionToNextPaintInfo.js
@@ -105,6 +105,7 @@
   const MAX_INTERACTIONS_TO_CONSIDER = 10;
   const longestInteractionList = [];
   const longestInteractionMap = {};
+  const seenInteractionIds = new Set();
   for (let entry of entries) {
     // web-vitals only counts entries the browser tagged as part of a
     // discrete interaction; bare events like a `pointerover` fired by
@@ -113,6 +114,7 @@
     // INP whenever the cursor happens to be over content as it paints.
     // See https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/interactions.ts
     if (!entry.interactionId) continue;
+    seenInteractionIds.add(entry.interactionId);
     var minLongestInteraction =
       longestInteractionList[longestInteractionList.length - 1];
     var existingInteraction = longestInteractionMap[entry.interactionId];
@@ -147,7 +149,18 @@
     }
   }
 
-  const inp = longestInteractionList[longestInteractionList.length - 1];
+  // The list is sorted longest first and web-vitals reports the p98
+  // interaction, index floor(interactionCount / 50), so with fewer
+  // than 50 interactions INP is the longest one.
+  const interactionCount =
+    performance.interactionCount || seenInteractionIds.size;
+  const inp =
+    longestInteractionList[
+      Math.min(
+        longestInteractionList.length - 1,
+        Math.floor(interactionCount / 50)
+      )
+    ];
   if (inp) {
     const cleanedEntries = [];
 

--- a/browserscripts/timings/interactionToNextPaint.js
+++ b/browserscripts/timings/interactionToNextPaint.js
@@ -8,6 +8,7 @@
   const MAX_INTERACTIONS_TO_CONSIDER = 10;
   const longestInteractionList = [];
   const longestInteractionMap = {};
+  const seenInteractionIds = new Set();
   for (let entry of entries) {
     // web-vitals only counts entries the browser tagged as part of a
     // discrete interaction; bare events like a `pointerover` fired by
@@ -16,6 +17,7 @@
     // INP whenever the cursor happens to be over content as it paints.
     // See https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/interactions.ts
     if (!entry.interactionId) continue;
+    seenInteractionIds.add(entry.interactionId);
     var minLongestInteraction =
       longestInteractionList[longestInteractionList.length - 1];
     var existingInteraction = longestInteractionMap[entry.interactionId];
@@ -50,7 +52,18 @@
     }
   }
 
-  const inp = longestInteractionList[longestInteractionList.length - 1];
+  // The list is sorted longest first and web-vitals reports the p98
+  // interaction, index floor(interactionCount / 50), so with fewer
+  // than 50 interactions INP is the longest one.
+  const interactionCount =
+    performance.interactionCount || seenInteractionIds.size;
+  const inp =
+    longestInteractionList[
+      Math.min(
+        longestInteractionList.length - 1,
+        Math.floor(interactionCount / 50)
+      )
+    ];
   if (inp) {
     return inp.latency;
   } else {

--- a/browserscripts/timings/softNavigations.js
+++ b/browserscripts/timings/softNavigations.js
@@ -64,7 +64,11 @@
         longestList.splice(MAX_INTERACTIONS).forEach(function (i) { delete longestMap[i.id]; });
       }
     }
-    var inpEntry = longestList[longestList.length - 1];
+    // The list is sorted longest first and web-vitals reports the p98
+    // interaction, index floor(interactionCount / 50), so with fewer
+    // than 50 interactions INP is the longest one.
+    var interactionCount = new Set(events.map(function (e) { return e.interactionId; })).size;
+    var inpEntry = longestList[Math.min(longestList.length - 1, Math.floor(interactionCount / 50))];
     inp = inpEntry ? inpEntry.latency : 0;
   }
 


### PR DESCRIPTION
With more than one interaction in a measurement, INP was reported as the fastest of the kept interactions instead of the slowest, because the selection took the wrong end of the sorted candidate list. A journey with clicks of 500 ms and 150 ms reported 150. Runs with a single interaction were unaffected, which is why tests never caught it.

This aligns the selection with the web-vitals estimator: the p98 candidate, which is the longest interaction until a page has seen 50 of them. The same wrong selection existed in the INP extras script and in the per-soft-navigation INP, so all three are fixed together.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I4a37494e4afc048a31fd4fdc08414e1d2b477338