### PR TITLE
Stop dropping the built-in Chrome disable-features list

### DIFF
--- a/lib/chrome/webdriver/setupChromiumOptions.js
+++ b/lib/chrome/webdriver/setupChromiumOptions.js
@@ -24,6 +24,7 @@ const CHROME_FEATURES_THAT_WE_ENABLE = ['SoftNavigationHeuristics'];
 const CHROME_FEATURES_THAT_WE_DISABLES = [
   'AutofillServerCommunication',
   'CalculateNativeWinOcclusion',
+  'ChromeWhatsNewUI',
   'HeavyAdPrivacyMitigations',
   'InterestFeedContentSuggestions',
   'MediaRouter',
@@ -229,25 +230,22 @@ export function setupChromiumOptions(
   if (browserOptions.args) {
     const chromeCommandLineArguments = toArray(browserOptions.args);
     for (const argument of chromeCommandLineArguments) {
-      if (
-        argument.includes('disable-features') &&
-        !argument.includes('ChromeWhatsNewUI')
-      ) {
-        addArgs(`${argument},ChromeWhatsNewUI`);
-        log.debug('Set Chrome args %j', `${argument},ChromeWhatsNewUI`);
-      } else if (
-        argument.includes('enable-features') &&
-        !argument.includes('SoftNavigationHeuristics')
-      ) {
-        addArgs(`${argument},SoftNavigationHeuristics`);
-        log.debug('Set Chrome args %j', `${argument},SoftNavigationHeuristics`);
+      // Chrome is last-wins for duplicated switches, so a user supplied
+      // disable-features/enable-features argument would silently replace
+      // the built-in lists added above. Merge them instead.
+      if (argument.includes('disable-features')) {
+        const merged = `${argument},${CHROME_FEATURES_THAT_WE_DISABLES.join(',')}`;
+        addArgs(merged);
+        log.debug('Set Chrome args %j', merged);
+      } else if (argument.includes('enable-features')) {
+        const merged = `${argument},${CHROME_FEATURES_THAT_WE_ENABLE.join(',')}`;
+        addArgs(merged);
+        log.debug('Set Chrome args %j', merged);
       } else {
         addArgs(argument);
         log.debug('Set Chrome args %j', argument);
       }
     }
-  } else {
-    addArgs('--disable-features=ChromeWhatsNewUI');
   }
 
   if (browserOptions.binaryPath) {


### PR DESCRIPTION
Chrome resolves duplicated command line switches last-wins, so the extra --disable-features=ChromeWhatsNewUI added after the built-in list silently replaced it: default runs kept Translate, OptimizationHints, MediaRouter and the rest of the phone-home features enabled. User supplied disable-features/enable-features arguments replaced the built-in lists the same way.

ChromeWhatsNewUI now lives in the built-in list, and user supplied feature arguments are merged with the built-in lists instead of racing them.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: Ib6b915b1d55e3c6c3fa74c9eef53b6df62ccfa78