### PR TITLE
Reset trace state when an iteration fails

### DIFF
--- a/lib/chrome/webdriver/chromium.js
+++ b/lib/chrome/webdriver/chromium.js
@@ -191,6 +191,8 @@ export class Chromium {
       await this.coverage.start();
     }
 
+    this.testStartTime = Date.now();
+
     if (
       this.collectTracingEvents &&
       !this.isTracing &&
@@ -199,8 +201,6 @@ export class Chromium {
       this.isTracing = true;
       return this.cdpClient.startTrace();
     }
-
-    this.testStartTime = Date.now();
   }
 
   /**
@@ -693,6 +693,11 @@ export class Chromium {
    * THis method is called if a runs fail
    */
   failing(url) {
+    // The CDP client is recreated for the next iteration, so a run that
+    // failed between starting and stopping the trace must not leave the
+    // flag set: beforeEachURL would skip starting a new trace and
+    // stopTrace would then fail every remaining iteration.
+    this.isTracing = false;
     if (this.skipHar) {
       return;
     }


### PR DESCRIPTION
With --chrome.timeline, a page load that failed between starting and stopping the trace left the isTracing flag set. Since the CDP client is recreated per iteration, the next iteration skipped starting a new trace and then failed trying to stop one that was never started, so a single transient timeout turned every remaining iteration into a failure.

The failure hook now clears the flag. The test start time is also set before the tracing block, which used to return early and leave it undefined, breaking the USB power measurement window when tracing was on.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I87b25ef27707b68eb2d073a33f5cfe6ffa03d4a7