### PR TITLE
Stop --android from swallowing the next argument

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -826,6 +826,14 @@ export function parseCommandLine() {
       describe:
         'Short key to use Android. Defaults to use com.android.chrome unless --browser is specified.'
     })
+    // parseCommandLine rewrites --android to --android.enabled before
+    // yargs runs. Without this declaration yargs treats it as a string
+    // option and swallows the following argument (typically an URL).
+    .option('android.enabled', {
+      type: 'boolean',
+      default: false,
+      hidden: true
+    })
     .option('android.rooted', {
       type: 'boolean',
       alias: 'androidRooted',


### PR DESCRIPTION
--android is rewritten to --android.enabled before yargs parses, but that key was never declared as an option, so yargs treated it as a string and consumed the following token. browsertime --android url dropped the URL (with two URLs the first was silently never tested), and --android false enabled android because the string is truthy. Declaring the rewritten key as a boolean restores all of those.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
Change-Id: I6d890e09cd5ed8507a581ad918fd395554d5b326